### PR TITLE
Update GcScannerIcons.cs and added some new structs

### DIFF
--- a/libMBIN/Source/Models/Structs/GcLegacyItem.cs
+++ b/libMBIN/Source/Models/Structs/GcLegacyItem.cs
@@ -1,0 +1,15 @@
+﻿namespace libMBIN.Models.Structs
+{
+    [NMS(Size = 0x28)]
+    public class GcLegacyItem : NMSTemplate
+    {
+        [NMS(Size = 0x10)]
+        /* 0x00 */ public string ID;
+        [NMS(Size = 0x10)]
+        /* 0x10 */ public string ConvertID;
+        
+        /* 0x20 */ public float ConvertRatio;
+        [NMS(Size = 0x4, Ignore = true)]
+        /* 0x24 */ public byte[] EndPadding;
+    }
+}

--- a/libMBIN/Source/Models/Structs/GcLegacyItemTable.cs
+++ b/libMBIN/Source/Models/Structs/GcLegacyItemTable.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+
+namespace libMBIN.Models.Structs
+{
+    [NMS(Size = 0x10)]
+    public class GcLegacyItemTable : NMSTemplate
+    {
+		/* 0x00 */ public List<GcLegacyItem> Table;
+    }
+}

--- a/libMBIN/Source/Models/Structs/GcNGuiElementData.cs
+++ b/libMBIN/Source/Models/Structs/GcNGuiElementData.cs
@@ -1,6 +1,7 @@
 ﻿namespace libMBIN.Models.Structs
 {
-    public class GcNGuiElementData : NMSTemplate        // size: 0x50
+    [NMS(Size = 0x50)]
+    public class GcNGuiElementData : NMSTemplate
     {
         [NMS(Size = 0x10)]
         /* 0x00 */ public string ID;
@@ -10,7 +11,7 @@
         /* 0x20 */ public bool IsHidden;
 
         [NMS(Size = 0x3, Ignore = true)]
-        public byte[] Padding21;
+        /* 0x21 */ public byte[] Padding21;
 
         /* 0x24 */ public GcNGuiLayoutData Layout;
     }

--- a/libMBIN/Source/Models/Structs/GcPlayerEmote.cs
+++ b/libMBIN/Source/Models/Structs/GcPlayerEmote.cs
@@ -1,0 +1,28 @@
+﻿namespace libMBIN.Models.Structs
+{
+    [NMS(Size = 0x100)]
+    public class GcPlayerEmote : NMSTemplate
+    {
+        [NMS(Size = 0x20)]
+        /* 0x000 */ public string Title;
+        [NMS(Size = 0x20)]
+        /* 0x020 */ public string ChatText;
+        [NMS(Size = 0x10)]
+        /* 0x040 */ public string AnimationName;
+
+        /* 0x050 */ public TkTextureResource Icon;
+
+        [NMS(Size = 0x4, Ignore = true)]
+        /* 0x0D4 */ public byte[] PaddingD4;
+        
+        [NMS(Size = 0x10)]
+        /* 0x0D8 */ public string LinkedSpecialID;
+        [NMS(Size = 0x10)]
+        /* 0x0E8 */ public string LoopAnimUntilMov;
+
+        /* 0x0F8 */ public bool CloseMenuOnSelect;
+
+        [NMS(Size = 0x7, Ignore = true)]
+        /* 0x0F9 */ public byte[] Endpadding;
+    }
+}

--- a/libMBIN/Source/Models/Structs/GcPlayerEmoteList.cs
+++ b/libMBIN/Source/Models/Structs/GcPlayerEmoteList.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+
+namespace libMBIN.Models.Structs
+{
+    [NMS(Size = 0x10)]
+    public class GcPlayerEmoteList : NMSTemplate
+    {
+        /* 0x00 */ public List<GcPlayerEmote> Emotes;
+    }
+}

--- a/libMBIN/Source/Models/Structs/GcScannerIcons.cs
+++ b/libMBIN/Source/Models/Structs/GcScannerIcons.cs
@@ -1,6 +1,6 @@
-﻿namespace libMBIN.Models.Structs
+namespace libMBIN.Models.Structs
 {
-    public class GcScannerIcons : NMSTemplate       // size: 0x4A90
+    public class GcScannerIcons : NMSTemplate       // size: 0x5BF0
     {
         /* 0x0000 */ public TkTextureResource TaggedBuilding;
         /* 0x0084 */ public TkTextureResource Ship;
@@ -8,65 +8,80 @@
         /* 0x018C */ public TkTextureResource Freighter;
         /* 0x0210 */ public TkTextureResource FreighterBase;
         /* 0x0294 */ public TkTextureResource PlayerFreighter;
-        /* 0x0318 */ public TkTextureResource PlayerBase;
-        /* 0x039C */ public TkTextureResource Death;
-        /* 0x0420 */ public TkTextureResource Bounty1;
-        /* 0x04A4 */ public TkTextureResource Bounty2;
-        /* 0x0528 */ public TkTextureResource Bounty3;
-        /* 0x05AC */ public TkTextureResource Battle;
-        /* 0x0630 */ public TkTextureResource ShipSmall;
-        /* 0x06B4 */ public TkTextureResource DeathSmall;
-        /* 0x0738 */ public TkTextureResource BountySmall;
-        /* 0x07BC */ public TkTextureResource BattleSmall;
-        /* 0x0840 */ public TkTextureResource TimedEvent;
-        /* 0x08C4 */ public TkTextureResource Checkpoint;
-        /* 0x0948 */ public TkTextureResource CircleAnimation;
-        /* 0x09CC */ public TkTextureResource HexAnimation;
-        /* 0x0A50 */ public TkTextureResource ArrowSmall;
-        /* 0x0AD4 */ public TkTextureResource ArrowLarge;
+        /* 0x0318 */ public TkTextureResource DamagedFrigate;
+        /* 0x039C */ public TkTextureResource PurchasableFrigate;
+        /* 0x0420 */ public TkTextureResource Expedition;
+        /* 0x04A0 */ public TkTextureResource PlayerBase;
+        /* 0x0528 */ public TkTextureResource EditingBase;
+        /* 0x05AC */ public TkTextureResource Death;
+        /* 0x0630 */ public TkTextureResource Bounty1;
+        /* 0x06B4 */ public TkTextureResource Bounty2;
+        /* 0x0738 */ public TkTextureResource Bounty3;
+        /* 0x07BC */ public TkTextureResource Battle;
+        /* 0x0840 */ public TkTextureResource ShipSmall;
+        /* 0x08C4 */ public TkTextureResource DeathSmall;
+        /* 0x0948 */ public TkTextureResource BountySmall;
+        /* 0x09CC */ public TkTextureResource BattleSmall;
+        /* 0x0A50 */ public TkTextureResource TimedEvent;
+        /* 0x0AD4 */ public TkTextureResource Checkpoint;
+        /* 0x0B58 */ public TkTextureResource Garage;
+        /* 0x0BDC */ public TkTextureResource CircleAnimation;
+        /* 0x0C60 */ public TkTextureResource HexAnimation;
+        /* 0x0CE4 */ public TkTextureResource DiamondAnimation;
+        /* 0x0D68 */ public TkTextureResource ArrowSmall;
+        /* 0x0DEC */ public TkTextureResource ArrowLarge;
 
         [NMS(Size = 5)]
-        /* 0x0B58 */ public TkTextureResource[] GenericIcons;
+        /* 0x0E70 */ public TkTextureResource[] GenericIcons;
 
         [NMS(Size = 0x11)]
-        /* 0x0DEC */ public TkTextureResource[] BuildingIcons;
+        /* 0x1104 */ public TkTextureResource[] BuildingIcons;
 
         [NMS(Size = 0x11)]
-        /* 0x16B0 */ public TkTextureResource[] BuildingIconsLarge;
+        /* 0x19C8 */ public TkTextureResource[] BuildingIconsBinocs;
 
         [NMS(Size = 0x11)]
-        /* 0x1F74 */ public TkTextureResource[] BuildingIconsInactive;
+        /* 0x228C */ public TkTextureResource[] BuildingIconsHuge;
 
-        [NMS(Size = 0x11)]
-        /* 0x2838 */ public TkTextureResource[] BuildingIconsInactiveLarge;
+        [NMS(Size = 0x22)]
+        /* 0x2B50 */ public TkTextureResource[] ScannableIcons;
 
-        [NMS(Size = 0x11)]
-        /* 0x30FC */ public TkTextureResource[] BuildingIconsHuge;
+        [NMS(Size = 0x22)]
+        /* 0x3CD8 */ public TkTextureResource[] ScannableIconsBinocs;
 
-        [NMS(Size = 0x17)]
-        /* 0x39C0 */ public TkTextureResource[] ScannableIcons;
+        [NMS(Size = 0x22)]
+        /* 0x4E60 */ public Colour[] ScannableColours;
 
-        [NMS(Size = 0x4, Ignore = true)]
-        /* 0x459C */ public byte[] Padding459C;
+        /* 0x5080 */ public Colour BuildingColour;
+        /* 0x5090 */ public Colour GenericColour;
+        /* 0x50A0 */ public Colour RelicColour;
+        /* 0x50B0 */ public Colour SignalColour;
+        /* 0x50C0 */ public Colour UnknownColour;
 
-        [NMS(Size = 0x17)]
-        /* 0x45A0 */ public Colour[] ScannableColours;
+        /* 0x50D0 */ public TkTextureResource CreatureDiscovered;
+        /* 0x5154 */ public TkTextureResource CreatureUndiscovered;
+        /* 0x51D8 */ public TkTextureResource CreatureUnknown;
+        /* 0x525C */ public TkTextureResource MessageBeacon;
+        /* 0x52E0 */ public TkTextureResource MessageBeaconSmall;
+        /* 0x5364 */ public TkTextureResource BaseBuildingMarker;
+        
+        /* 0x53E8 */ public TkTextureResource PlanetNorthPole;
+        /* 0x546C */ public TkTextureResource PlanetSouthPole;
+        /* 0x54F0 */ public TkTextureResource MonumentMarker;
+        /* 0x5574 */ public TkTextureResource NetworkPlayerMarker;
+        /* 0x55F8 */ public TkTextureResource NetworkPlayerMarkerShip;
+        /* 0x567C */ public TkTextureResource NetworkPlayerMarkerVehicle;
+        
+        [NMS(Size = 0x4)]
+        /* 0x5700 */ public TkTextureResource[] NetworkFSPlayerMarkers;
+        [NMS(Size = 0x4)]
+        /* 0x5910 */ public Colour[] NetworkFSPlayerColours;
+        [NMS(Size = 0x4)]
+        /* 0x5950 */ public TkTextureResource[] NetworkPlayerFreighter;
+        
+        /* 0x5B60 */ public TkTextureResource PortalMarker;
 
-        /* 0x4710 */ public Colour BuildingColour;
-        /* 0x4720 */ public Colour GenericColour;
-        /* 0x4730 */ public Colour InactiveColour;
-        /* 0x4740 */ public Colour RelicColour;
-        /* 0x4750 */ public Colour SignalColour;
-        /* 0x4760 */ public Colour UnknownColour;
-
-        /* 0x4770 */ public TkTextureResource CreatureDiscovered;
-        /* 0x47F4 */ public TkTextureResource CreatureUndiscovered;
-        /* 0x4878 */ public TkTextureResource CreatureUnknown;
-        /* 0x48FC */ public TkTextureResource MessageBeacon;
-        /* 0x4980 */ public TkTextureResource MessageBeaconSmall;
-        /* 0x4A04 */ public TkTextureResource BaseBuildingMarker;
-
-        [NMS(Size = 8, Ignore = true)]
-        /* 0x4A88 */ public byte[] EndPadding;
+        [NMS(Size = 0xC, Ignore = true)]
+        /* 0x5BE4 */ public byte[] EndPadding;
     }
 }

--- a/libMBIN/Source/Models/Structs/TkNGuiGraphicStyleData.cs
+++ b/libMBIN/Source/Models/Structs/TkNGuiGraphicStyleData.cs
@@ -1,40 +1,46 @@
 ﻿namespace libMBIN.Models.Structs
 {
-    public class TkNGuiGraphicStyleData :NMSTemplate        // size: 0x80
+    [NMS(Size = 0x80)]
+    public class TkNGuiGraphicStyleData : NMSTemplate
     {
-        public float PaddingX;
-        public float PaddingY;
-        public float MarginX;
-        public float MarginY;
-        public Colour Colour;
-        public Colour IconColour;
-        public Colour StrokeColour;
-        public int Shape;
+        /* 0x00 */ public float PaddingX;
+        /* 0x04 */ public float PaddingY;
+        /* 0x08 */ public float MarginX;
+        /* 0x0C */ public float MarginY;
+        /* 0x10 */ public Colour Colour;
+        /* 0x20 */ public Colour IconColour;
+        /* 0x30 */ public Colour StrokeColour;
+        /* 0x40 */ public int Shape;
 
         public string[] ShapeValues()
-        { return new string[] { "Rectangle", "Ellipse" }; }
+        {
+            return new[] { "Rectangle", "Ellipse" };
+        }
 
 
-        public bool SolidColour;
-        public bool HasDropShadow;
-        public bool HasOuterGradient;
-        public bool HasInnerGradient;
-        public int Gradient;
+        /* 0x44 */ public bool SolidColour;
+        /* 0x45 */ public bool HasDropShadow;
+        /* 0x46 */ public bool HasOuterGradient;
+        /* 0x47 */ public bool HasInnerGradient;
+        /* 0x48 */ public int Gradient;
 
         public string[] GradientValues()
-        { return new string[] { "None", "Vertical", "Horizontal", "HorizontalBounce" }; }
+        {
+            return new[] { "None", "Vertical", "Horizontal", "HorizontalBounce" };
+        }
 
 
-        public float GradientStartOffset;
-        public float GradientEndOffset;
+        /* 0x4C */ public float GradientStartOffset;
+        /* 0x50 */ public float GradientEndOffset;
+        /* 0x54 */ public bool GradientOffsetPercent;
 
-        [NMS(Size = 0xC, Ignore = true)]
-        public byte[] Padding1;
+        [NMS(Size = 0xB, Ignore = true)]
+        /* 0x55 */ public byte[] Padding55;
 
-        public Colour GradientColour;
-        public float CornerRadius;
-        public float StrokeSize;
-        public int Image;
-        public int Icon;
+        /* 0x60 */ public Colour GradientColour;
+        /* 0x70 */ public float CornerRadius;
+        /* 0x74 */ public float StrokeSize;
+        /* 0x78 */ public int Image;
+        /* 0x7C */ public int Icon;
     }
 }

--- a/libMBIN/libMBIN-Shared.projitems
+++ b/libMBIN/libMBIN-Shared.projitems
@@ -24,6 +24,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Source\Models\NMSAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Source\Models\NMSTemplate.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Source\Models\Structs\Colour.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Source\Models\Structs\GcLegacyItem.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Source\Models\Structs\GcLegacyItemTable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Source\Models\Structs\GcPlayerEmote.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Source\Models\Structs\GcPlayerEmoteList.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Source\Models\Structs\TkAnimVectorBlendNodeData.cs" />

--- a/libMBIN/libMBIN-Shared.projitems
+++ b/libMBIN/libMBIN-Shared.projitems
@@ -24,6 +24,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Source\Models\NMSAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Source\Models\NMSTemplate.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Source\Models\Structs\Colour.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Source\Models\Structs\GcPlayerEmote.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Source\Models\Structs\GcPlayerEmoteList.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Source\Models\Structs\TkAnimVectorBlendNodeData.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Source\Models\Structs\TkAnimVectorBlendNode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Source\Models\Structs\TkAnim2dBlendNode.cs" />


### PR DESCRIPTION
Fixed GcScannerIcons and Adeded four new structs.

Files affected by these changes include:
METADATA\REALITY\TABLES\LEGACYITEMTABLE.MBIN
METADATA\UI\HUD\SCANNERICONS.MBIN
METADATA\UI\EMOTEMENU.MBIN

I have checked the files for weird values and compared them in hex after decompiling and recompiling, to make sure they compile correctly. 