### PR TITLE
New MissionConditionLocation

### DIFF
--- a/libMBIN/Source/Models/Structs/GcMissionConditionLocation.cs
+++ b/libMBIN/Source/Models/Structs/GcMissionConditionLocation.cs
@@ -6,7 +6,7 @@
         public string[] MissionPlayerLocationValues()
         {
             return new[] { "OnPlanet", "OnPlanetInVehicle", "InShipLanded" , "InShipInPlanetOrbit" , "InShipInSpace",
-             "InSpaceStation", "InFreighter", "Underground", "InBuilding", "Frigate", "Frigate_Damaged", "FreighterConstructionArea", "FriendsPlanetBase"};
+             "InSpaceStation", "InFreighter", "Underground", "InBuilding", "Frigate", "Frigate_Damaged", "FreighterConstructionArea", "FriendsPlanetBase", "OutsideBuilding"};
         }
     }
 }

--- a/libMBIN/Source/Models/Structs/GcMissionConditionLocation.cs
+++ b/libMBIN/Source/Models/Structs/GcMissionConditionLocation.cs
@@ -6,7 +6,7 @@
         public string[] MissionPlayerLocationValues()
         {
             return new[] { "OnPlanet", "OnPlanetInVehicle", "InShipLanded" , "InShipInPlanetOrbit" , "InShipInSpace",
-             "InSpaceStation", "InFreighter", "Underground", "InBuilding", "Frigate", "Frigate_Damaged", "FreighterConstructionArea", "FriendsPlanetBase", "OutsideBuilding"};
+             "InSpaceStation", "InFreighter", "Underground", "InBuilding", "Frigate", "Frigate_Damaged", "FreighterConstructionArea", "FriendsPlanetBase", "OnPlanetSurface"};
         }
     }
 }


### PR DESCRIPTION
`METADATA\SIMULATION\MISSIONS\MISSIONTABLE.MBIN` fails to decompile as `WEAPGUY7` contains a new value.

```xml
<Property name="Stage" value="GcMissionSequenceWaitForConditions.xml">
  <Property name="Message" value="UI_WEAPGUY7_MSG2" />
  <Property name="ConditionTest" value="GcMissionConditionTest.xml">
	<Property name="ConditionTest" value="AllTrue" />
  </Property>
  <Property name="Conditions">
	<Property value="GcMissionConditionIsCurrentMission.xml" />
	<Property value="GcMissionConditionLocation.xml">
	  <Property name="MissionPlayerLocation" value="OutsideBuilding" />
	</Property>
  </Property>
  <Property name="DebugText" value="wait for outside" />
</Property>
```