### PR TITLE
Update GcDebugOptions.cs

### DIFF
--- a/libMBIN/Source/NMS/Globals/GcDebugOptions.cs
+++ b/libMBIN/Source/NMS/Globals/GcDebugOptions.cs
@@ -97,8 +97,8 @@ namespace libMBIN.NMS.Globals
         /* 0x400 */ public bool Unknown0x400;
         /* 0x401 */ public bool UseLegacyFreighters;
         /* 0x402 */ public bool SpawnPirates;
-        /* 0x403 */ public bool SpawnRobots;
-        /* 0x404 */ public bool SpawnShips;
+        /* 0x403 */ public bool SpawnPirates;
+        /* 0x404 */ public bool SpawnRobots;
         /* 0x405 */ public bool InstanceCollision;
         /* 0x406 */ public bool MPMissions;
         /* 0x407 */ public bool Unknown0x407;


### PR DESCRIPTION
NMS v2.11 (build 4165576)
SpawnRobots should be changed to SpawnPirates (line 77 in the EXML, 100 here)
SpawnShips should be changed to SpawnRobots (line 78 Iin the EXML, 101 here)

As for SpawnPirates line 76 (99 here) i've got no idea what it should be, but it shouldn't be SpawnPirates and haven't found where SpawnShips should be.