### PR TITLE
Alignment

### DIFF
--- a/libMBIN/Source/NMS/GameComponents/GcAnimFrameEvent.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcAnimFrameEvent.cs
@@ -3,7 +3,7 @@ using libMBIN.NMS.GameComponents;
 
 namespace libMBIN.NMS.GameComponents
 {
-	[NMS(Size = 0x18, GUID = 0x81EFA1D4D693E25A, NameHash = 0x6D7E63CBE4F67CF0)]
+    [NMS(Size = 0x18, Alignment = 0x8, GUID = 0x81EFA1D4D693E25A, NameHash = 0x6D7E63CBE4F67CF0)]
     public class GcAnimFrameEvent : NMSTemplate
     {
         [NMS(Size = 0x10)]

--- a/libMBIN/Source/NMS/GameComponents/GcAntagonistComponentData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcAntagonistComponentData.cs
@@ -5,7 +5,7 @@ using libMBIN.NMS.GameComponents;
 
 namespace libMBIN.NMS.GameComponents
 {
-	[NMS(Size = 0x148, GUID = 0x51B376CBC0E11C67, NameHash = 0xFAE78D5DE55087ED)]
+    [NMS(Size = 0x148, Alignment = 0x8, GUID = 0x51B376CBC0E11C67, NameHash = 0xFAE78D5DE55087ED)]
     public class GcAntagonistComponentData : NMSTemplate
     {
         /* 0x000 */ public GcAntagonistGroup Group;

--- a/libMBIN/Source/NMS/GameComponents/GcCameraShakeAction.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcCameraShakeAction.cs
@@ -3,7 +3,7 @@ using libMBIN.NMS.GameComponents;
 
 namespace libMBIN.NMS.GameComponents
 {
-	[NMS(Size = 0x18, GUID = 0xA5442BD7F600755C, NameHash = 0x8C20E93C658FEFB1)]
+    [NMS(Size = 0x18, Alignment = 0x8, GUID = 0xA5442BD7F600755C, NameHash = 0x8C20E93C658FEFB1)]
     public class GcCameraShakeAction : NMSTemplate
     {
         [NMS(Size = 0x10)]

--- a/libMBIN/Source/NMS/GameComponents/GcExpeditionHologramComponentData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcExpeditionHologramComponentData.cs
@@ -3,7 +3,7 @@ using libMBIN.NMS.GameComponents;
 
 namespace libMBIN.NMS.GameComponents
 {
-	[NMS(Size = 0x20, GUID = 0xCCFE6B3996CFA666, NameHash = 0xDCBE648F7DED1A9F)]
+    [NMS(Size = 0x20, Alignment = 0x10, GUID = 0xCCFE6B3996CFA666, NameHash = 0xDCBE648F7DED1A9F)]
     public class GcExpeditionHologramComponentData : NMSTemplate
     {
         public float HologramRotationSpeedDegPerSec;

--- a/libMBIN/Source/NMS/GameComponents/GcMissionConditionBaseQuery.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcMissionConditionBaseQuery.cs
@@ -3,7 +3,7 @@ using libMBIN.NMS.GameComponents;
 
 namespace libMBIN.NMS.GameComponents
 {
-	[NMS(Size = 0xA0, GUID = 0xC6DE822FF0BE7176, NameHash = 0xDAD32FDD35922F28)]
+    [NMS(Size = 0xA0, Alignment = 0x8, GUID = 0xC6DE822FF0BE7176, NameHash = 0xDAD32FDD35922F28)]
     public class GcMissionConditionBaseQuery : NMSTemplate
     {
         public GcBaseSearchFilter BaseSearchFilter;

--- a/libMBIN/Source/NMS/GameComponents/GcMissionConditionSystemPlanetTest.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcMissionConditionSystemPlanetTest.cs
@@ -5,7 +5,7 @@ using libMBIN.NMS.GameComponents;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(Size = 0x1, GUID = 0xFB24FC538BB5DD91, NameHash = 0xB22694B55382153C)]
+    [NMS(Size = 0x1, Alignment = 0x1, GUID = 0xFB24FC538BB5DD91, NameHash = 0xB22694B55382153C)]
     public class GcMissionConditionSystemPlanetTest : NMSTemplate
     {
         public bool RequiresExtremePlanet;

--- a/libMBIN/Source/NMS/GameComponents/GcMissionSequenceWaitForStatSeasonal.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcMissionSequenceWaitForStatSeasonal.cs
@@ -5,7 +5,7 @@ using libMBIN.NMS.GameComponents;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(Size = 0x128, GUID = 0x498C96F5B230C04E, NameHash = 0xCEBA3C32BCAF04F6)]
+    [NMS(Size = 0x128, Alignment = 0x8, GUID = 0x498C96F5B230C04E, NameHash = 0xCEBA3C32BCAF04F6)]
     public class GcMissionSequenceWaitForStatSeasonal : NMSTemplate
     {
         [NMS(Size = 0x80)]

--- a/libMBIN/Source/NMS/GameComponents/GcNPCInteractiveObjectComponentData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcNPCInteractiveObjectComponentData.cs
@@ -5,7 +5,7 @@ using libMBIN.NMS.GameComponents;
 
 namespace libMBIN.NMS.GameComponents
 {
-	[NMS(Size = 0x20, GUID = 0x4E4C352A22680927, NameHash = 0x6EB308F16DDC755C)]
+    [NMS(Size = 0x20, Alignment = 0x8, GUID = 0x4E4C352A22680927, NameHash = 0x6EB308F16DDC755C)]
     public class GcNPCInteractiveObjectComponentData : NMSTemplate
     {
         // 0x7 entries

--- a/libMBIN/Source/NMS/GameComponents/GcNPCPlacementComponentData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcNPCPlacementComponentData.cs
@@ -5,7 +5,7 @@ using libMBIN.NMS.GameComponents;
 
 namespace libMBIN.NMS.GameComponents
 {
-	[NMS(Size = 0x20, GUID = 0xB5451F053EE27AA, NameHash = 0x8047BE4D11BB54C8)]
+    [NMS(Size = 0x20, Alignment = 0x8, GUID = 0xB5451F053EE27AA, NameHash = 0x8047BE4D11BB54C8)]
     public class GcNPCPlacementComponentData : NMSTemplate
     {
         /* 0x00 */ public bool SearchPlacementFromMaster;

--- a/libMBIN/Source/NMS/GameComponents/GcOutpostComponentData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcOutpostComponentData.cs
@@ -5,7 +5,7 @@ using libMBIN.NMS.GameComponents;
 
 namespace libMBIN.NMS.GameComponents
 {
-	[NMS(Size = 0x68, GUID = 0x7B02CE1010B72306, NameHash = 0x184558FBF0A370E2)]
+    [NMS(Size = 0x68, Alignment = 0x8, GUID = 0x7B02CE1010B72306, NameHash = 0x184558FBF0A370E2)]
     public class GcOutpostComponentData : NMSTemplate
     {
         /* 0x00 */ public bool Anomaly;

--- a/libMBIN/Source/NMS/GameComponents/GcRewardAction.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcRewardAction.cs
@@ -3,7 +3,7 @@ using libMBIN.NMS.GameComponents;
 
 namespace libMBIN.NMS.GameComponents
 {
-	[NMS(Size = 0x10, GUID = 0xE99A21CC212AEF47, NameHash = 0x510AB74045DA8CCE)]
+    [NMS(Size = 0x10, Alignment = 0x8, GUID = 0xE99A21CC212AEF47, NameHash = 0x510AB74045DA8CCE)]
     public class GcRewardAction : NMSTemplate
     {
         [NMS(Size = 0x10)]

--- a/libMBIN/Source/NMS/GameComponents/GcRewardMissionMessageToMatchingSeeds.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcRewardMissionMessageToMatchingSeeds.cs
@@ -5,7 +5,7 @@ using libMBIN.NMS.GameComponents;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(Size = 0x18, GUID = 0x88ABA39C4A0CBA4A, NameHash = 0x9688A6EC7C08672F)]
+    [NMS(Size = 0x18, Alignment = 0x8, GUID = 0x88ABA39C4A0CBA4A, NameHash = 0x9688A6EC7C08672F)]
     public class GcRewardMissionMessageToMatchingSeeds : NMSTemplate
     {
         [NMS(Size = 0x10)]

--- a/libMBIN/Source/NMS/GameComponents/GcRewardMultiSpecificItems.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcRewardMultiSpecificItems.cs
@@ -5,7 +5,7 @@ using libMBIN.NMS.GameComponents;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(Size = 0x10, GUID = 0x6F3AFF718EB4F2ED, NameHash = 0x26C3924987148B0B)]
+    [NMS(Size = 0x10, Alignment = 0x8, GUID = 0x6F3AFF718EB4F2ED, NameHash = 0x26C3924987148B0B)]
     public class GcRewardMultiSpecificItems : NMSTemplate
     {
         public List<GcMultiSpecificItemEntry> Items;

--- a/libMBIN/Source/NMS/GameComponents/GcRewardSpecificSubstance.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcRewardSpecificSubstance.cs
@@ -5,7 +5,7 @@ using libMBIN.NMS.GameComponents;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(Size = 0x28, GUID = 0x7054017D3ADCD382, NameHash = 0xF3F4ABE3661F3779)]
+    [NMS(Size = 0x28, Alignment = 0x8, GUID = 0x7054017D3ADCD382, NameHash = 0xF3F4ABE3661F3779)]
     public class GcRewardSpecificSubstance : NMSTemplate
     {
         /* 0x00 */ public GcDefaultMissionProduct Default;

--- a/libMBIN/Source/NMS/GameComponents/GcRewardSpecificTech.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcRewardSpecificTech.cs
@@ -3,7 +3,7 @@ using libMBIN.NMS.GameComponents;
 
 namespace libMBIN.NMS.GameComponents
 {
-	[NMS(Size = 0x18, GUID = 0x7E6246CFE3EF3C03, NameHash = 0xDABE4D9A95799081)]
+    [NMS(Size = 0x18, Alignment = 0x8, GUID = 0x7E6246CFE3EF3C03, NameHash = 0xDABE4D9A95799081)]
     public class GcRewardSpecificTech : NMSTemplate
     {
         [NMS(Size = 0x10)]

--- a/libMBIN/Source/NMS/GameComponents/GcScannableComponentData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcScannableComponentData.cs
@@ -3,7 +3,7 @@ using libMBIN.NMS.GameComponents;
 
 namespace libMBIN.NMS.GameComponents
 {
-	[NMS(Size = 0x80, GUID = 0xCA5FBE1F6ACA4F92, NameHash = 0x74BA808E86F0EC01)]
+    [NMS(Size = 0x80, Alignment = 0x8, GUID = 0xCA5FBE1F6ACA4F92, NameHash = 0x74BA808E86F0EC01)]
     public class GcScannableComponentData : NMSTemplate
     {
         /* 0x00 */ public float ScanRange;

--- a/libMBIN/Source/NMS/GameComponents/GcShipOwnershipComponentData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcShipOwnershipComponentData.cs
@@ -3,7 +3,7 @@ using libMBIN.NMS.GameComponents;
 
 namespace libMBIN.NMS.GameComponents
 {
-	[NMS(Size = 0x150, GUID = 0xCEF2498474683652, NameHash = 0xA947081E204C32BB)]
+    [NMS(Size = 0x150, Alignment = 0x10, GUID = 0xCEF2498474683652, NameHash = 0xA947081E204C32BB)]
     public class GcShipOwnershipComponentData : NMSTemplate
     {
         public GcSpaceshipComponentData Data;

--- a/libMBIN/Source/NMS/Toolkit/TkCreatureTailParams.cs
+++ b/libMBIN/Source/NMS/Toolkit/TkCreatureTailParams.cs
@@ -5,7 +5,7 @@ using libMBIN.NMS.GameComponents;
 
 namespace libMBIN.NMS.Toolkit
 {
-	[NMS(Size = 0x70, GUID = 0xA4A9375C75E0A9D9, NameHash = 0xF5A68FEB65BA7107)]
+    [NMS(Size = 0x70, Alignment = 0x8, GUID = 0xA4A9375C75E0A9D9, NameHash = 0xF5A68FEB65BA7107)]
     public class TkCreatureTailParams : NMSTemplate
     {
         [NMS(Size = 0x20)]

--- a/libMBIN/Source/NMS/Toolkit/TkSketchComponentData.cs
+++ b/libMBIN/Source/NMS/Toolkit/TkSketchComponentData.cs
@@ -5,7 +5,7 @@ using libMBIN.NMS.GameComponents;
 
 namespace libMBIN.NMS.Toolkit
 {
-	[NMS(Size = 0x20, GUID = 0x229D20001EB4BC5A, NameHash = 0xBE4097172440769E)]
+    [NMS(Size = 0x20, Alignment = 0x8, GUID = 0x229D20001EB4BC5A, NameHash = 0xBE4097172440769E)]
     public class TkSketchComponentData : NMSTemplate
     {
         /* 0x00 */ public float GraphPosX;

--- a/libMBIN/Source/Template/NMSTemplate.cs
+++ b/libMBIN/Source/Template/NMSTemplate.cs
@@ -592,9 +592,6 @@ namespace libMBIN
                 for ( int i = 0; i < listObjects.Count; i++ ) {
                     var data = listObjects[i];
                     //writer.BaseStream.Position = additionalDataOffset; // addtDataOffset gets updated by child templates
-                    int alignment2 = entry.GetType().GetCustomAttribute<NMSAttribute>()?.Alignment ?? 0x8;
-                    writer.Align( alignment2, entryName); // todo: check if this alignment is correct
-                    long origPos = writer.BaseStream.Position;
                     if ( data.Item2.GetType().IsGenericType && data.Item2.GetType().GetGenericTypeDefinition() == typeof( List<> ) ) {
                         Type itemType = data.Item2.GetType().GetGenericArguments()[0];
 
@@ -604,6 +601,9 @@ namespace libMBIN
                             SerializeList( writer, (IList) data.Item2, data.Item1, ref listObjects, i + 1, listEnding );
                         }
                     } else {
+                        int alignment2 = data.Item2.GetType().GetCustomAttribute<NMSAttribute>()?.Alignment ?? 0x8;
+                        writer.Align( alignment2, data.Item2.GetType().Name );
+                        long origPos = writer.BaseStream.Position;
                         //DebugLog("this is it!!!");
                         //DebugLog($"0x{origPos:X}");
                         // first, write the correct offset at the correct location


### PR DESCRIPTION
With these changes I was able to convert to EXML and back to MBIN all the MBINs in the games files, except for INPUTTEST, the ANIM files and GCFLEETGLOBALS, with the only changes being in the first 16 bytes.
GCFLEETGLOBALS is because it contains a list of 0x20 length strings that are not on an 8 byte boundry, while SerializeList() forces an 8 byte alignment for the string types.
