### PR TITLE
Changed field names to match what is in the EXE.

### DIFF
--- a/libMBIN/Source/NMS/GameComponents/GcAlienPodComponentData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcAlienPodComponentData.cs
@@ -18,7 +18,7 @@ namespace libMBIN.NMS.GameComponents
         /* 0x24 */ public float AgroSpookTime;
         /* 0x28 */ public float AgroSpookTimeMin;
         /* 0x2C */ public float AgroSpookTimeMax;
-        /* 0x30 */ public float GlowIntensitymin;
+        /* 0x30 */ public float GlowIntensityMin;
         /* 0x34 */ public float GlowIntensityMax;
         /* 0x38 */ public float InstaAgroDistance;
         /* 0x3C */ public float GunfireAgro;

--- a/libMBIN/Source/NMS/GameComponents/GcAntagonistPerception.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcAntagonistPerception.cs
@@ -15,7 +15,7 @@ namespace libMBIN.NMS.GameComponents
         /* 0x18 */ public float YFOV;
         public enum ViewShapeEnum { Pyramid, Cone };
         /* 0x1C */ public ViewShapeEnum ViewShape;
-        /* 0x20 */ public bool RayCast;
+        /* 0x20 */ public bool Raycast;
         [NMS(Size = 0x20)]
         /* 0x21 */ public string SenseLocator;
         [NMS(Size = 0x7, Ignore = true)]

--- a/libMBIN/Source/NMS/GameComponents/GcAtlasBasesRequest.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcAtlasBasesRequest.cs
@@ -11,7 +11,7 @@ namespace libMBIN.NMS.GameComponents
         public GcUniverseAddressData UniverseAddress;
         public GcGameMode GameMode;
         public int MaxResults;
-        public int MayBytes;
+        public int MaxBytes;
         public int MinVersion;
         public int MaxVersion;
         [NMS(Size = 0x20)]

--- a/libMBIN/Source/NMS/GameComponents/GcAtlasMessage.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcAtlasMessage.cs
@@ -9,7 +9,7 @@ namespace libMBIN.NMS.GameComponents
         public GcUniverseAddressData UniverseAddress;
         [NMS(Size = 0x80)]
         public string CustomName;
-        public Vector4f Positon;
+        public Vector4f Position;
         public int ColourIndex;
     }
 }

--- a/libMBIN/Source/NMS/GameComponents/GcAtlasRecvBaseList.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcAtlasRecvBaseList.cs
@@ -9,7 +9,7 @@ namespace libMBIN.NMS.GameComponents
     public class GcAtlasRecvBaseList : NMSTemplate
     {
         /* 0x00 */ public ulong ClientUserdata;
-        /* 0x08 */ public int NumberOfbases;
+        /* 0x08 */ public int NumberOfBases;
         [NMS(Size = 0x4, Ignore = true)]
         /* 0x0C */ public byte[] PaddingC;
         /* 0x10 */ public List<GcPersistentBase> Bases;

--- a/libMBIN/Source/NMS/GameComponents/GcAtlasRecvBaseQueryList.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcAtlasRecvBaseQueryList.cs
@@ -9,7 +9,7 @@ namespace libMBIN.NMS.GameComponents
     public class GcAtlasRecvBaseQueryList : NMSTemplate
     {
         /* 0x00 */ public ulong ClientUserdata;
-        /* 0x08 */ public int NumberOfbases;
+        /* 0x08 */ public int NumberOfBases;
         [NMS(Size = 0x4, Ignore = true)]
         /* 0x0C */ public byte[] PaddingC;
         /* 0x10 */ public List<GcPersistentBase> Bases;

--- a/libMBIN/Source/NMS/GameComponents/GcAtlasRecvDiscoveryList.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcAtlasRecvDiscoveryList.cs
@@ -8,7 +8,7 @@ namespace libMBIN.NMS.GameComponents
     [NMS(Size = 0x6E2A0, GUID = 0x9D3F6BF513471E7F, NameHash = 0x2A5A7D37C0DB81BA)]
     public class GcAtlasRecvDiscoveryList : NMSTemplate
     {
-        /* 0x00 */ public ulong ClientUserData;
+        /* 0x00 */ public ulong ClientUserdata;
         [NMS(Size = 0x8, Ignore = true)]
         /* 0x08 */ public byte[] padding8;
         /* 0x10 */ public int NumberOfThings;

--- a/libMBIN/Source/NMS/GameComponents/GcAtlasRecvFeaturedBasesQueryList.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcAtlasRecvFeaturedBasesQueryList.cs
@@ -9,7 +9,7 @@ namespace libMBIN.NMS.GameComponents
     public class GcAtlasRecvFeaturedBasesQueryList : NMSTemplate
     {
         /* 0x00 */ public ulong ClientUserdata;
-        /* 0x08 */ public int NumberOfbases;
+        /* 0x08 */ public int NumberOfBases;
         [NMS(Size = 0x4, Ignore = true)]
         /* 0x0C */ public byte[] PaddingC;
         /* 0x10 */ public List<GcPersistentBase> Bases;

--- a/libMBIN/Source/NMS/GameComponents/GcAtlasRecvMonumentList.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcAtlasRecvMonumentList.cs
@@ -10,6 +10,6 @@ namespace libMBIN.NMS.GameComponents
         public int NumberOfThings;
         [NMS(Size = 0x4, Ignore = true)]
         public byte[] PaddingC;
-        public GcAtlasMonument Mounments;
+        public GcAtlasMonument Monuments;
     }
 }

--- a/libMBIN/Source/NMS/GameComponents/GcAtlasRecvTotalContribution.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcAtlasRecvTotalContribution.cs
@@ -7,7 +7,7 @@ namespace libMBIN.NMS.GameComponents
 {
 	[NMS(Size = 0x18, GUID = 0x95AC0992C92BD05E, NameHash = 0x0BB8B54516B54A343, Alignment = 0x8)]
     public class GcAtlasRecvTotalContribution : NMSTemplate {
-        /* 0x0000 */ public long ClientUserData;
+        /* 0x0000 */ public long ClientUserdata;
         /* 0x0008 */ public bool Success;
         /* 0x0010 */ public long TotalContribution;
     }

--- a/libMBIN/Source/NMS/GameComponents/GcAtlasSendRequestBases.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcAtlasSendRequestBases.cs
@@ -13,7 +13,7 @@ namespace libMBIN.NMS.GameComponents
         // I think this isn't quite right but I'm not sure what to put instead...
         /* 0x08 */ public byte[] Padding8;
         /* 0x10 */ public GcUniverseAddressData UniverseAddress;
-        /* 0x28 */ public GcGameMode Gamemode;
+        /* 0x28 */ public GcGameMode GameMode;
         /* 0x2C */ public int MaxResults;
         /* 0x30 */ public int MaxBytes;
         /* 0x34 */ public int MinVersion;

--- a/libMBIN/Source/NMS/GameComponents/GcAtlasSendRequestTotalContribution.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcAtlasSendRequestTotalContribution.cs
@@ -7,7 +7,7 @@ namespace libMBIN.NMS.GameComponents
 {
 	[NMS(Size = 0x8, GUID = 0xDC9B438A409E6F01, NameHash = 0x43DB1432B149AF84, Alignment = 0x8)]
     public class GcAtlasSendRequestTotalContribution : NMSTemplate {
-        /* 0x0000 */ public ulong ClientUserData;
+        /* 0x0000 */ public ulong ClientUserdata;
     }
 
 }

--- a/libMBIN/Source/NMS/GameComponents/GcAtlasSendSubmitMonument.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcAtlasSendSubmitMonument.cs
@@ -6,12 +6,12 @@ namespace libMBIN.NMS.GameComponents
 	[NMS(Size = 0x1D0, GUID = 0xAE2027400EC63932, NameHash = 0xF4282F250D0EEBDB)]
     public class GcAtlasSendSubmitMonument : NMSTemplate
     {
-        /* 0x000 */ public ulong ClientUserData;
+        /* 0x000 */ public ulong ClientUserdata;
         [NMS(Size = 0x8, Ignore = true)]
         /* 0x008 */ public byte[] Padding8;
         /* 0x010 */ public GcAtlasMonument Monument;
 		public enum MonumentRolesEnum { Creator, CoCreator }
-		/* 0x1A0 */ public MonumentRolesEnum MonumentRoles;
+		/* 0x1A0 */ public MonumentRolesEnum MonumentRole;
         [NMS(Size = 0x20)]
         /* 0x1A4 */ public string OtherUser;
         [NMS(Size = 0xC, Ignore = true)]

--- a/libMBIN/Source/NMS/GameComponents/GcAtlasShared.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcAtlasShared.cs
@@ -4,7 +4,7 @@
     public class GcAtlasShared : NMSTemplate
     {
         // TODO: there is something fishy going on here...
-        public ulong ClientUserData;
+        public ulong ClientUserdata;
         [NMS(Size = 0x8, Ignore = true)]
         public byte[] EndPadding;
     }

--- a/libMBIN/Source/NMS/GameComponents/GcAtmosphereEntryComponentData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcAtmosphereEntryComponentData.cs
@@ -6,7 +6,7 @@ namespace libMBIN.NMS.GameComponents
 	[NMS(Size = 0x30, Alignment = 0x8, GUID = 0x1FA54D54FA89D565, NameHash = 0x90485A00D3954CE2)]
     public class GcAtmosphereEntryComponentData : NMSTemplate
     {
-        public bool AutEntry;
+        public bool AutoEntry;
         public float EntryTime;
         public float EntryOffset;
         public float EditTerrainRadius;

--- a/libMBIN/Source/NMS/GameComponents/GcBaseLinkGridConnectionDependency.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcBaseLinkGridConnectionDependency.cs
@@ -8,7 +8,7 @@ namespace libMBIN.NMS.GameComponents
     public class GcBaseLinkGridConnectionDependency : NMSTemplate
     {
         /* 0x00 */ public GcBaseLinkGridConnectionData Connection;
-        /* 0x38 */ public int DependentRateRate;
+        /* 0x38 */ public int DependentRate;
         public enum DependentEffectEnum { None, EnablesRate, DisablesRate, EnablesConnection, DisablesConnection }
         /* 0x3C */ public DependentEffectEnum DependentEffect;
         /* 0x40 */ public bool DisableWhenOffline;

--- a/libMBIN/Source/NMS/GameComponents/GcBuildingSpawnData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcBuildingSpawnData.cs
@@ -30,7 +30,7 @@ namespace libMBIN.NMS.GameComponents
         /* 0x594 */ public float MaxXZRotation;
         /* 0x598 */ public float Radius;
         /* 0x59C */ public float MinHeight;
-        /* 0x5A0 */ public float Maxheight;
+        /* 0x5A0 */ public float MaxHeight;
         /* 0x5A4 */ public int InstanceID;
         /* 0x5B0 */ public Vector3f AABBMin;
         /* 0x5C0 */ public Vector3f AABBMax;

--- a/libMBIN/Source/NMS/GameComponents/GcButtonSpawnOffset.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcButtonSpawnOffset.cs
@@ -13,6 +13,6 @@ namespace libMBIN.NMS.GameComponents
         /* 0x10 */ public float Facing;                     // [rdi+10h], eax
         /* 0x14 */ public int Count;                        // 3
         /* 0x18 */ public GcRealityCommonFactions Faction;
-        /* 0x1C */ public GcAISpaceshipRoles ShipRoles;     // [rdi+1Ch], eax
+        /* 0x1C */ public GcAISpaceshipRoles ShipRole;     // [rdi+1Ch], eax
     }
 }

--- a/libMBIN/Source/NMS/GameComponents/GcByteBeatTemplates.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcByteBeatTemplates.cs
@@ -8,7 +8,7 @@ namespace libMBIN.NMS.GameComponents
     [NMS(Size = 0xA8, GUID = 0xBC8B1A3D2F8ADF9F, NameHash = 0xBBB68492659143C4)]
     public class GcByteBeatTemplates : NMSTemplate
     {
-        /* 0x00 */ public List<NMSString0x40> InitalTrees;
+        /* 0x00 */ public List<NMSString0x40> InitialTrees;
         /* 0x10 */ public List<GcByteBeatTemplate> Templates;
         [NMS(Size = 0x12, EnumType = typeof(GcByteBeatToken.ByteBeatTokenEnum))]
         /* 0x20 */ public float[] CombinerWeights;

--- a/libMBIN/Source/NMS/GameComponents/GcCameraShakeComponentData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcCameraShakeComponentData.cs
@@ -8,7 +8,7 @@ namespace libMBIN.NMS.GameComponents
     [NMS(Size = 0x18, GUID = 0x8FC4FB96433D6E8D, NameHash = 0x77B3408A8150441E)]
     public class GcCameraShakeComponentData : NMSTemplate
     {
-        /* 0x0 */ public float DangerRadius;
+        /* 0x0 */ public float DangerRange;
         [NMS(Size = 0x4, Ignore = true)]
         /* 0x4 */ public byte[] Padding4;
         /* 0x8 */ public List<GcCameraShakeTriggerData> AnimTriggers;

--- a/libMBIN/Source/NMS/GameComponents/GcCameraShakeData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcCameraShakeData.cs
@@ -12,7 +12,7 @@ namespace libMBIN.NMS.GameComponents
         /* 0x10 */ public float TimeStart;
         /* 0x14 */ public float TotalTime;
         /* 0x18 */ public float DecayRate;
-        /* 0x1C */ public float StrengthSale;
+        /* 0x1C */ public float StrengthScale;
         /* 0x20 */ public float ThirdPersonDamp;
 
         /* 0x24 */ public GcCameraShakeCapturedData CapturedData;
@@ -22,8 +22,8 @@ namespace libMBIN.NMS.GameComponents
 
        /* 0x40 */  public GcCameraShakeMechanicalData MechanicalData;
 
-        /* 0xB0 */ public float FOVStrength;
-        /* 0xB4 */ public float FOVFrequency;
+        /* 0xB0 */ public float FovStrength;
+        /* 0xB4 */ public float FovFrequency;
 
         [NMS(Size = 0x8, Ignore = true)]
         /* 0xB8 */ public byte[] EndPadding;

--- a/libMBIN/Source/NMS/GameComponents/GcCameraWarpSettings.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcCameraWarpSettings.cs
@@ -26,6 +26,6 @@ namespace libMBIN.NMS.GameComponents
         public float OffsetXRange;
         public TkCurveType OffsetXCurve;
         public float RollRange;
-        public float YawRange;
+        public float YawnRange;
     }
 }

--- a/libMBIN/Source/NMS/GameComponents/GcCreatureAttractorComponentData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcCreatureAttractorComponentData.cs
@@ -10,7 +10,7 @@ namespace libMBIN.NMS.GameComponents
     {
         public bool Universal;
         public bool Static;
-        public float ArrivalDist;
+        public float ArriveDist;
         public enum AttractorTypeEnum { Food, Harvester }
         public AttractorTypeEnum AttractorType;
     }

--- a/libMBIN/Source/NMS/GameComponents/GcCreatureCrystalMovementData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcCreatureCrystalMovementData.cs
@@ -8,6 +8,6 @@ namespace libMBIN.NMS.GameComponents
 	[NMS(Size = 0x10, GUID = 0x35416C58F48CF5A9, NameHash = 0x46EB806ED8904120)]
     public class GcCreatureCrystalMovementData : NMSTemplate
     {
-        /* 0x0 */ public List<GcCreatureCrystalMovementDataParams> BiomeParams;
+        /* 0x0 */ public List<GcCreatureCrystalMovementDataParams> Params;
     }
 }

--- a/libMBIN/Source/NMS/GameComponents/GcCreatureDebugSpawnData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcCreatureDebugSpawnData.cs
@@ -9,7 +9,7 @@ namespace libMBIN.NMS.GameComponents
     public class GcCreatureDebugSpawnData : NMSTemplate
     {
         /* 0x00 */ public int CreatureIndex;
-        /* 0x04 */ public float InitalDelay;
+        /* 0x04 */ public float InitialDelay;
         /* 0x08 */ public List<GcCreatureDebugWaypoint> Waypoints;
         public enum OnCompleteEnum { Hold, Loop, Destroy };
         /* 0x18 */ public OnCompleteEnum OnComplete;

--- a/libMBIN/Source/NMS/GameComponents/GcCreatureFiendAttackData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcCreatureFiendAttackData.cs
@@ -16,7 +16,7 @@ namespace libMBIN.NMS.GameComponents
         [NMS(Size = 0x4, Ignore = true)]
         /* 0x4C */ public byte[] Padding4C;
         [NMS(Size = 0x10)]
-        /* 0x50 */ public string SplitProjectile;
+        /* 0x50 */ public string SpitProjectile;
         [NMS(Size = 0x40)]
         /* 0x60 */ public string AttackLight;
         /* 0xA0 */ public float IdleLightIntensity;

--- a/libMBIN/Source/NMS/GameComponents/GcCreatureFullBodyIKComponentData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcCreatureFullBodyIKComponentData.cs
@@ -21,7 +21,7 @@ namespace libMBIN.NMS.GameComponents
         /* 0x3C */ public float FootAngleSpeed;
         /* 0x40 */ public float MaxFootAngle;
         /* 0x44 */ public bool UsePistons;
-        /* 0x45 */ public bool Mesh;
+        /* 0x45 */ public bool Mech;
         [NMS(Size = 2, Ignore = true)]
         /* 0x46 */ public byte[] EndPadding;
     }

--- a/libMBIN/Source/NMS/GameComponents/GcCreaturePetTraits.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcCreaturePetTraits.cs
@@ -10,6 +10,6 @@ namespace libMBIN.NMS.GameComponents
     {
         // 0x3 entries
         public enum PetTraitsEnum { Helpfulness, Aggression, Independence }
-        public PetTraitsEnum PetTraits;
+        public PetTraitsEnum PetTrait;
     }
 }

--- a/libMBIN/Source/NMS/GameComponents/GcCreatureRidingPartModifier.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcCreatureRidingPartModifier.cs
@@ -9,7 +9,7 @@ namespace libMBIN.NMS.GameComponents
     public class GcCreatureRidingPartModifier : NMSTemplate
     {
         [NMS(Size = 0x20)]
-        /* 0x000 */ public string Partname;
+        /* 0x000 */ public string PartName;
         [NMS(Size = 0x100)]
         /* 0x020 */ public string JointName;
         /* 0x120 */ public float MinScale;

--- a/libMBIN/Source/NMS/GameComponents/GcCustomisationCameraData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcCustomisationCameraData.cs
@@ -8,7 +8,7 @@ namespace libMBIN.NMS.GameComponents
     {
         public int InteractionCameraIndex;
         [NMS(Size = 0x20)]
-        public string InteractionCameraFocusJoint;
+        public string InteracttionCameraFocusJoint;
         public float MinPitch;
         public float MaxPitch;
         public float MinYaw;

--- a/libMBIN/Source/NMS/GameComponents/GcCustomisationTextureGroup.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcCustomisationTextureGroup.cs
@@ -11,6 +11,6 @@ namespace libMBIN.NMS.GameComponents
         [NMS(Size = 0x20)]
         public string Title;
         [NMS(Size = 0x10)]
-        public string TextureOptionsGroup;
+        public string TextureOptionGroup;
     }
 }

--- a/libMBIN/Source/NMS/GameComponents/GcDebrisData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcDebrisData.cs
@@ -11,7 +11,7 @@ namespace libMBIN.NMS.GameComponents
         /* 0x88 */ public float Radius;
         /* 0x8C */ public float Scale;
         /* 0x90 */ public float Speed;
-        /* 0x94 */ public float AngularSpeed;
+        /* 0x94 */ public float AnglularSpeed;
         /* 0x98 */ public GcSeed OverrideSeed;
     }
 }

--- a/libMBIN/Source/NMS/GameComponents/GcDiscoveryOwner.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcDiscoveryOwner.cs
@@ -15,6 +15,6 @@ namespace libMBIN.NMS.GameComponents
         public string Username;
         [NMS(Size = 0x40)]
         public string Platform;
-        public int TimeStamp;
+        public int Timestamp;
     }
 }

--- a/libMBIN/Source/NMS/GameComponents/GcDungeonGenerationParams.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcDungeonGenerationParams.cs
@@ -18,7 +18,7 @@ namespace libMBIN.NMS.GameComponents
         /* 0x1C */ public float XProbability;
         /* 0x20 */ public float YProbability;
         /* 0x24 */ public float ZProbability;
-        /* 0x28 */ public float StraightProbability;
+        /* 0x28 */ public float StraightMultiplier;
         [NMS(Size = 0x4, Ignore = true)]
         /* 0x2C */ public byte[] Padding2C;
         /* 0x30 */ public List<GcDungeonRoomParams> MainRoomTypes;

--- a/libMBIN/Source/NMS/GameComponents/GcEnvironmentProperties.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcEnvironmentProperties.cs
@@ -8,7 +8,7 @@ namespace libMBIN.NMS.GameComponents
     [NMS(Size = 0x78, GUID = 0x201EF4D59CBBD069, NameHash = 0xB125AED843BB9164)]
     public class GcEnvironmentProperties : NMSTemplate
     {
-        /* 0x00 */ public float FlightFogheight;
+        /* 0x00 */ public float FlightFogHeight;
         /* 0x04 */ public float FlightFogBlend;
         /* 0x08 */ public float CloudHeightMin;
         /* 0x0C */ public float CloudHeightMax;

--- a/libMBIN/Source/NMS/GameComponents/GcFontTable.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcFontTable.cs
@@ -3,16 +3,10 @@ using libMBIN.NMS.GameComponents;
 
 namespace libMBIN.NMS.GameComponents
 {
-	[NMS(Size = 0x420, GUID = 0xB9913A609DA490D3, NameHash = 0xD77829A90743F12E)]
-	public class GcFontTable : NMSTemplate
-	{
-		public GcFontData Table1;
-		public GcFontData Table2;
-		public GcFontData Table3;
-		public GcFontData Table4;
-		public GcFontData Table5;
-		public GcFontData Table6;
-		public GcFontData Table7;
-		public GcFontData Table8;
-	}
+    [NMS(Size = 0x420, GUID = 0xB9913A609DA490D3, NameHash = 0xD77829A90743F12E)]
+    public class GcFontTable : NMSTemplate
+    {
+        [NMS(Size = 0x8)]
+        public GcFontData[] Table;
+    }
 }

--- a/libMBIN/Source/NMS/GameComponents/GcGalaxyCameraData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcGalaxyCameraData.cs
@@ -25,7 +25,7 @@ namespace libMBIN.NMS.GameComponents
         /* 0x40 */ public float ZoomOutPushDist;                // 400CCCCDh
         /* 0x44 */ public float ZoomOutRate;                    // 3ECCCCCDh
         /* 0x48 */ public float ZoomInRate;                     // 40400000h
-        /* 0x4C */ public float MinZoomDIstance;
+        /* 0x4C */ public float MinZoomDistance;
         /* 0x50 */ public float MaxZoomDistance;
         /* 0x54 */ public float MinPushingZoomDistance;
         /* 0x58 */ public float MinPushingZoomDistanceScaler;

--- a/libMBIN/Source/NMS/GameComponents/GcGalaxyInfoIcons.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcGalaxyInfoIcons.cs
@@ -16,7 +16,7 @@ namespace libMBIN.NMS.GameComponents
         [NMS(Size = 0x3, EnumType = typeof(GcPlayerConflictData.ConflictLevelEnum))]
         /* 0x9CC */ public TkTextureResource[] ConflictIcons;
         /* 0xB58 */ public TkTextureResource ConflictTechNotInstalledIcon;
-        /* 0xBDC */ public TkTextureResource Warpicon;
+        /* 0xBDC */ public TkTextureResource WarpIcon;
         /* 0xC60 */ public TkTextureResource WarpErrorIcon;
         /* 0xCE4 */ public TkTextureResource WarpTechNotInstalledIcon;
     }

--- a/libMBIN/Source/NMS/GameComponents/GcInteractionBufferType.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcInteractionBufferType.cs
@@ -9,6 +9,6 @@ namespace libMBIN.NMS.GameComponents
         // 0xB entries
 		public enum InterationBufferTypeEnum { Distress_Signal, Crate, Destructable, Terrain, Cost, Building, Creature, Maintenance,
                                                Personal, Personal_Maintenance, FireteamSync }
-		public InterationBufferTypeEnum InterationBufferType;
+		public InterationBufferTypeEnum InteractionBufferType;
     }
 }

--- a/libMBIN/Source/NMS/GameComponents/GcInventoryLayoutGenerationDataEntry.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcInventoryLayoutGenerationDataEntry.cs
@@ -10,7 +10,7 @@ namespace libMBIN.NMS.GameComponents
     {
         public int MinSlots;            // 1
         public int MaxSlots;            // 5
-        public int MinExtraTech;        // 1
-        public int MaxExtraTech;        // 3
+        public int MinTechSlots;        // 1
+        public int MaxTechSlots;        // 3
     }
 }

--- a/libMBIN/Source/NMS/GameComponents/GcInventorySlotActionData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcInventorySlotActionData.cs
@@ -11,7 +11,7 @@ namespace libMBIN.NMS.GameComponents
         /* 0x02 */ public bool Scales;
         /* 0x04 */ public float Time;                       // 3F800000h
         /* 0x08 */ public float ScaleAtMin;                 // 3F800000h
-        /* 0x0C */ public float SclaeAtMax;                 // 40000000h
+        /* 0x0C */ public float ScaleAtMax;                 // 40000000h
         /* 0x10 */ public TkCurveType AnimCurve;
         /* 0x14 */ public GcAudioWwiseEvents SuitAudio;
         /* 0x18 */ public GcAudioWwiseEvents ActionAudio;

--- a/libMBIN/Source/NMS/GameComponents/GcMaintenanceComponentData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcMaintenanceComponentData.cs
@@ -31,8 +31,8 @@ namespace libMBIN.NMS.GameComponents
         [NMS(Size = 0x3, Ignore = true)]
         /* 0x02D */ public byte[] Padding2D;
 
-        /* 0x030 */ public TkModelRendererData ModelRendererData;
-        /* 0x0E0 */ public TkModelRendererData ModelRendererDataAlt;
+        /* 0x030 */ public TkModelRendererData ModelRenderData;
+        /* 0x0E0 */ public TkModelRendererData ModelRenderDataAlt;
 
 		public enum ModelRendererResourceEnum { ModelNode, MasterModelNode }
 		/* 0x190 */ public ModelRendererResourceEnum ModelRendererResource;

--- a/libMBIN/Source/NMS/GameComponents/GcMaintenanceElement.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcMaintenanceElement.cs
@@ -14,7 +14,7 @@ namespace libMBIN.NMS.GameComponents
         /* 0x08 */ public string Id;
         /* 0x18 */ public float MinRandAmount;
         /* 0x1C */ public float MaxRandAmount;
-        /* 0x20 */ public int MaxCapactiy;
+        /* 0x20 */ public int MaxCapacity;
         /* 0x24 */ public float AmountEmptyTimePeriod;
 		public enum UpdateTypeEnum { UpdatesAlways, UpdateOnlyWhenComplete, UpdateOnlyWhenNotComplete }
 		/* 0x28 */ public UpdateTypeEnum UpdateType;

--- a/libMBIN/Source/NMS/GameComponents/GcMechDebugSpawnData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcMechDebugSpawnData.cs
@@ -18,7 +18,7 @@ namespace libMBIN.NMS.GameComponents
         /* 0x4C */ public bool UseCustomisation;
         [NMS(Size = 0x3, Ignore = true)]
         /* 0x4D */ public byte[] Padding4D;
-        /* 0x50 */ public GcCharacterCustomisationSaveData CustomisationData;
+        /* 0x50 */ public GcCharacterCustomisationSaveData CustomisatonData;
         [NMS(Size = 0x8, Ignore = true)]
         /* 0xA8 */ public byte[] EndPadding;
     }

--- a/libMBIN/Source/NMS/GameComponents/GcMessageFiendCrime.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcMessageFiendCrime.cs
@@ -8,7 +8,7 @@ namespace libMBIN.NMS.GameComponents
 	[NMS(Size = 0x20, GUID = 0x5873ED86AF6E466E, NameHash = 0x37D134945C6DC0E)]
     public class GcMessageFiendCrime : NMSTemplate
     {
-        public Vector4f Positon;
+        public Vector4f Position;
         public GcFiendCrime FiendCrimeType;
         public float Value;
         [NMS(Size = 0x4, Ignore = true)]

--- a/libMBIN/Source/NMS/GameComponents/GcMissionConditionBasePartsQuery.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcMissionConditionBasePartsQuery.cs
@@ -6,7 +6,7 @@ namespace libMBIN.NMS.GameComponents
 	[NMS(Size = 0xE0, GUID = 0x6BA56557969E3928, NameHash = 0xDC4640E07A221674)]
     public class GcMissionConditionBasePartsQuery : NMSTemplate
     {
-        public GcBasePartSearchFilter PartsSeachFilter;
+        public GcBasePartSearchFilter PartsSearchFilter;
         public int MinPartsFound;
         public int MaxPartsFound;
         public GcBaseSearchFilter ExcludeBasesFilter;

--- a/libMBIN/Source/NMS/GameComponents/GcMissionSequenceCommunicator.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcMissionSequenceCommunicator.cs
@@ -11,7 +11,7 @@ namespace libMBIN.NMS.GameComponents
         [NMS(Size = 0x80)]
         /* 0x080 */ public string VRMessage;
         [NMS(Size = 0x80)]
-        /* 0x100 */ public string OSTMessage;
+        /* 0x100 */ public string OSDMessage;
         /* 0x180 */ public GcPlayerCommunicatorMessage Comms;
         /* 0x1D0 */ public bool AutoOpen;
         [NMS(Size = 0x80)]

--- a/libMBIN/Source/NMS/GameComponents/GcMissionSequenceCompleteMission.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcMissionSequenceCompleteMission.cs
@@ -7,7 +7,7 @@ namespace libMBIN.NMS.GameComponents
     public class GcMissionSequenceCompleteMission : NMSTemplate
     {
         [NMS(Size = 0x10)]
-        public string Misssion;
+        public string Mission;
         public bool UseSeed;
         [NMS(Size = 0x80)]
         public string DebugText;

--- a/libMBIN/Source/NMS/GameComponents/GcMissionSequenceDoMissionsForFaction.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcMissionSequenceDoMissionsForFaction.cs
@@ -10,7 +10,7 @@ namespace libMBIN.NMS.GameComponents
         /* 0x000 */ public string MessageGetToSpace;
         /* 0x080 */ public GcFactionSelectOptions SelectFrom;
 
-        /* 0x088 */ public int AmountMine;
+        /* 0x088 */ public int AmountMin;
         /* 0x08C */ public int AmountMax;
         [NMS(Size = 0x80)]
         /* 0x190 */ public string DebugText;

--- a/libMBIN/Source/NMS/GameComponents/GcMissionSequenceFeed.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcMissionSequenceFeed.cs
@@ -10,7 +10,7 @@ namespace libMBIN.NMS.GameComponents
         public string Message;
         public bool RequireSpecificBait;
         public int AmountMin;
-        public int Amountmax;
+        public int AmountMax;
         [NMS(Size = 0x80)]
         public string DebugText;
     }

--- a/libMBIN/Source/NMS/GameComponents/GcMissionSequenceStartScanEvent.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcMissionSequenceStartScanEvent.cs
@@ -12,7 +12,7 @@ namespace libMBIN.NMS.GameComponents
         [NMS(Size = 0x20)]
         /* 0x008 */ public string Event;
         /* 0x028 */ public float Time;
-        /* 0x02C */ public bool AllowOtherPlayerBase;
+        /* 0x02C */ public bool AllowOtherPlayersBase;
         [NMS(Size = 0x80)]
         /* 0x02D */ public string DebugText;
         [NMS(Size = 0x3, Ignore = true)]

--- a/libMBIN/Source/NMS/GameComponents/GcMissionSequenceWaitRealTimeCombat.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcMissionSequenceWaitRealTimeCombat.cs
@@ -18,7 +18,7 @@ namespace libMBIN.NMS.GameComponents
         /* 0x10C */ public byte[] Padding10C;
         [NMS(Size = 0x10)]
         /* 0x110 */ public string DisplayStat;
-        /* 0x120 */ public bool StatFromnow;
+        /* 0x120 */ public bool StatFromNow;
         [NMS(Size = 0x80)]
         /* 0x121 */ public string DebugText;
         [NMS(Size = 0x7, Ignore = true)]

--- a/libMBIN/Source/NMS/GameComponents/GcModelExplosionRule.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcModelExplosionRule.cs
@@ -9,7 +9,7 @@ namespace libMBIN.NMS.GameComponents
     public class GcModelExplosionRule : NMSTemplate
     {
         public enum MatchNodeTypeEnum { Any, Mesh, Model, Joint }
-        /* 0x00 */ public MatchNodeTypeEnum GetMatchNodeType;
+        /* 0x00 */ public MatchNodeTypeEnum MatchNodeType;
         public enum MatchNameEnum { ContainsString, ExactString }
         /* 0x04 */ public MatchNameEnum MatchName;
         [NMS(Size = 0x20)]

--- a/libMBIN/Source/NMS/GameComponents/GcNPCColourGroup.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcNPCColourGroup.cs
@@ -11,7 +11,7 @@ namespace libMBIN.NMS.GameComponents
         public float Rarity;
         [NMS(Size = 0xC, Ignore = true)]
         public byte[] Padding4;
-        public Colour primary;
+        public Colour Primary;
         public List<Colour> Secondary;
     }
 }

--- a/libMBIN/Source/NMS/GameComponents/GcNPCInteractiveObjectState.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcNPCInteractiveObjectState.cs
@@ -16,7 +16,7 @@ namespace libMBIN.NMS.GameComponents
         /* 0x12 */ public bool LookAtModel;
         [NMS(Size = 0x40)]
         /* 0x14 */ public string LookAtNode;
-        /* 0x54 */ public bool FaceLookA;
+        /* 0x54 */ public bool FaceLookAt;
         /* 0x55 */ public bool MaintainLookAt;
         /* 0x56 */ public bool PlayIdles;
         /* 0x57 */ public bool CanConverse;

--- a/libMBIN/Source/NMS/GameComponents/GcNPCPlacementInfo.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcNPCPlacementInfo.cs
@@ -13,7 +13,7 @@ namespace libMBIN.NMS.GameComponents
         [NMS(Size = 0x20)]
         /* 0x10 */ public string SpawnUnderNodeName;
         [NMS(Size = 0x20)]
-        /* 0x30 */ public string PlacementNodeName;
+        /* 0x30 */ public string PlacmentNodeName;
         /* 0x50 */ public bool MustPlace;
         /* 0x54 */ public float SpawnChance;
         /* 0x58 */ public float FractionOfNodesActive;

--- a/libMBIN/Source/NMS/GameComponents/GcNPCReactionData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcNPCReactionData.cs
@@ -8,6 +8,6 @@ namespace libMBIN.NMS.GameComponents
 	[NMS(Size = 0x10, GUID = 0x31D8EAFAAE2B4184, NameHash = 0xA83B1CD89A122A08)]
     public class GcNPCReactionData : NMSTemplate
     {
-        public List<GcNPCReactionEntry> Rections;
+        public List<GcNPCReactionEntry> Reactions;
     }
 }

--- a/libMBIN/Source/NMS/GameComponents/GcObjectSpawnData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcObjectSpawnData.cs
@@ -19,7 +19,7 @@ namespace libMBIN.NMS.GameComponents
         /* 0x2D0 */ public List<GcTerrainTileType> ExtraTileTypes;
         [NMS(Size = 0x10)]
         /* 0x2E0 */ public string Placement;
-        /* 0x2F0 */ public GcSeed PlacementSeed;
+        /* 0x2F0 */ public GcSeed Seed;
 		public enum PlacementPriorityEnum { Low, Normal, High }
 		/* 0x300 */ public PlacementPriorityEnum PlacementPriority;
         /* 0x304 */ public float Coverage;

--- a/libMBIN/Source/NMS/GameComponents/GcObjectSpawnDataArray.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcObjectSpawnDataArray.cs
@@ -10,6 +10,6 @@ namespace libMBIN.NMS.GameComponents
     {
         public GcTerrainTileType TileType;
         public int MaxObjectsToSpawn;
-        public List<GcObjectSpawnData> ObjectData;
+        public List<GcObjectSpawnData> Objects;
     }
 }

--- a/libMBIN/Source/NMS/GameComponents/GcPassiveFrigateIncome.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcPassiveFrigateIncome.cs
@@ -7,7 +7,7 @@ namespace libMBIN.NMS.GameComponents
     public class GcPassiveFrigateIncome : NMSTemplate
     {
         [NMS(Size = 0x10)]
-        /* 0x00 */ public string IncomeID;
+        /* 0x00 */ public string IncomeId;
         /* 0x10 */ public GcInventoryType IncomeType;
         /* 0x14 */ public int AmountOfIncomeRewarded;
         /* 0x18 */ public int ForEveryXAmountOfTheStat;

--- a/libMBIN/Source/NMS/GameComponents/GcPerformanceFlyby.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcPerformanceFlyby.cs
@@ -11,7 +11,7 @@ namespace libMBIN.NMS.GameComponents
         public float Length;            // 44FA0000h
         public float Offset;            // 43480000h
         public bool Locked;             // 0
-        public float LockedOffset;      // 42C80000h
+        public float LockOffset;      // 42C80000h
         public float LockTime;          // 40A00000h
         public float LockSpeed;         // 3F000000h
     }

--- a/libMBIN/Source/NMS/GameComponents/GcPersistentBBObjectData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcPersistentBBObjectData.cs
@@ -8,7 +8,7 @@ namespace libMBIN.NMS.GameComponents
     {
         /* 0x00 */ public ulong Timestamp;
         [NMS(Size = 0x10)]
-        /* 0x08 */ public string ObjectId;
+        /* 0x08 */ public string ObjectID;
         /* 0x18 */ public ulong GalacticAddress;
         /* 0x20 */ public ulong RegionSeed;
         /* 0x28 */ public ulong UserData;

--- a/libMBIN/Source/NMS/GameComponents/GcPersistentBaseEntry.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcPersistentBaseEntry.cs
@@ -10,7 +10,7 @@ namespace libMBIN.NMS.GameComponents
     {
         /* 0x00 */ public ulong Timestamp;
         [NMS(Size = 0x10)]
-        /* 0x08 */ public string ObjectId;
+        /* 0x08 */ public string ObjectID;
         /* 0x18 */ public ulong UserData;
         /* 0x20 */ public Vector4f Position;
         /* 0x30 */ public Vector4f Up;

--- a/libMBIN/Source/NMS/GameComponents/GcPlayerCharacterStateData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcPlayerCharacterStateData.cs
@@ -25,9 +25,9 @@ namespace libMBIN.NMS.GameComponents
         [NMS(Size = 0x10)]
         public string HitReact0H;
         [NMS(Size = 0x10)]
-        public string HitReac1H;
+        public string HitReact1H;
         [NMS(Size = 0x10)]
-        public string HitReac2H;
+        public string HitReact2H;
         public bool KeepHeadForward;
         [NMS(Size = 0x7, Ignore = true)]
         public byte[] EndPadding;

--- a/libMBIN/Source/NMS/GameComponents/GcPlayerCommunicatorMessageWeighted.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcPlayerCommunicatorMessageWeighted.cs
@@ -7,7 +7,7 @@ namespace libMBIN.NMS.GameComponents
     public class GcPlayerCommunicatorMessageWeighted : NMSTemplate
     {
         public GcPlayerCommunicatorMessage Message;
-        public int Weighted;
+        public int Weight;
         [NMS(Size = 0x4, Ignore = true)]
         public byte[] EndPadding;
     }

--- a/libMBIN/Source/NMS/GameComponents/GcPlayerFullBodyIKComponentData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcPlayerFullBodyIKComponentData.cs
@@ -26,7 +26,7 @@ namespace libMBIN.NMS.GameComponents
 		/* 0x300 */ public PlayerHeadUpAxisEnum PlayerHeadUpAxis;
         [NMS(Size = 0x4, Ignore = true)]
         /* 0x304 */ public byte[] Padding304;
-        /* 0x308 */ public List<GcCreatureIkData> JointDataDepreciated;
+        /* 0x308 */ public List<GcCreatureIkData> JointDataDeprecated;
         /* 0x318 */ public bool UseFootGlue;
         [NMS(Size = 0x3, Ignore = true)]
         /* 0x319 */ public byte[] Padding319;

--- a/libMBIN/Source/NMS/GameComponents/GcPlayerMissionUpgradeMapEntry.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcPlayerMissionUpgradeMapEntry.cs
@@ -15,6 +15,6 @@ namespace libMBIN.NMS.GameComponents
         [NMS(Size = 0x10)]
         /* 0x18 */ public string NewMission;
 
-        /* 0x28 */ public List<NMSString0x10> CompleteMissions;
+        /* 0x28 */ public List<NMSString0x10> CompletedMissions;
     }
 }

--- a/libMBIN/Source/NMS/GameComponents/GcPlayerMissionUpgradeMapTable.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcPlayerMissionUpgradeMapTable.cs
@@ -8,6 +8,6 @@ namespace libMBIN.NMS.GameComponents
 	[NMS(Size = 0x10, GUID = 0x54511EBAE64FC462, NameHash = 0xDA977EF5139B54E5)]
     public class GcPlayerMissionUpgradeMapTable : NMSTemplate
     {
-        public List<GcPlayerMissionUpgradeMapEntry> MissionUpgradeTable;
+        public List<GcPlayerMissionUpgradeMapEntry> MissionProgressTable;
     }
 }

--- a/libMBIN/Source/NMS/GameComponents/GcPlayerSpaceshipWarpData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcPlayerSpaceshipWarpData.cs
@@ -17,6 +17,6 @@ namespace libMBIN.NMS.GameComponents
 		/* 0x020 */ public float ExitHoldAlphaTime;
 		/* 0x024 */ public TkCurveType ExitTunnelCurve;
 		/* 0x028 */ public float ExitTunnelDistance;
-		/* 0x02C */ public float ExitWorldDistance;
+		/* 0x02C */ public float ExitWorldlDistance;
     }
 }

--- a/libMBIN/Source/NMS/GameComponents/GcPlayerStateData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcPlayerStateData.cs
@@ -19,7 +19,7 @@ namespace libMBIN.NMS.GameComponents
         /* 0x00458 */ public GcInventoryContainer ShipInventory;
         /* 0x005B8 */ public GcInventoryContainer WeaponInventory;
         [NMS(Size = 0x3)]
-        /* 0x00718 */ public GcMultitoolData[] MultiTools;
+        /* 0x00718 */ public GcMultitoolData[] Multitools;
         /* 0x00C58 */ public int ActiveMultioolIndex;
         [NMS(Size = 0x4, Ignore = true)]
         /* 0x00C5C */ public byte[] PaddingC5C;
@@ -270,7 +270,7 @@ namespace libMBIN.NMS.GameComponents
         /* 0x2BD58 */ public float VRCameraOffset;
         [NMS(Size = 0x4, Ignore = true)]
         /* 0x2BD5C */ public byte[] Padding2BD5C;
-        /* 0x2BD60 */ public GcSeasonalGameModeData SeasonalData;
+        /* 0x2BD60 */ public GcSeasonalGameModeData SeasonData;
         /* 0x2C1B0 */ public GcSeasonStateData SeasonState;
         /* 0x2C200 */ public bool RestartAllInactiveSeasonalMissions;
         [NMS(Size = 0x7, Ignore = true)]

--- a/libMBIN/Source/NMS/GameComponents/GcProceduralProductWord.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcProceduralProductWord.cs
@@ -8,7 +8,7 @@ namespace libMBIN.NMS.GameComponents
     public class GcProceduralProductWord : NMSTemplate
     {
         /* 0x00 */ public GcNameGeneratorWord Word;
-        /* 0x28 */ public GcNameGeneratorWord UncommonWordWord;
+        /* 0x28 */ public GcNameGeneratorWord UncommonWord;
         /* 0x50 */ public GcNameGeneratorWord RareWord;
         [NMS(Size = 0x20)]
         /* 0x78 */ public string ReplaceKey;

--- a/libMBIN/Source/NMS/GameComponents/GcProductData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcProductData.cs
@@ -67,7 +67,7 @@ namespace libMBIN.NMS.GameComponents
         /* 0x3A0 */ public string PinObjective;
         [NMSDescription("Notification hints to collect this item. This string is referenced in each language file for translation")]
         [NMS(Size = 0x20)]
-        /* 0x3C0 */ public string PinObjeectiveTip;
+        /* 0x3C0 */ public string PinObjectiveTip;
         /* 0x3E0 */ public bool CookingIngredient;
         /* 0x3E4 */ public float CookingValue;
         /* 0x3E8 */ public bool GoodForSelling;

--- a/libMBIN/Source/NMS/GameComponents/GcProductProceduralOnlyData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcProductProceduralOnlyData.cs
@@ -7,7 +7,7 @@ namespace libMBIN.NMS.GameComponents
     public class GcProductProceduralOnlyData : NMSTemplate
     {
         /* 0x000 */ public int DropWeight;
-        /* 0x004 */ public int BasevalueMin;
+        /* 0x004 */ public int BaseValueMin;
         /* 0x008 */ public int BaseValueMax;
         /* 0x00C */ public int AgeMin;
         /* 0x010 */ public int AgeMax;

--- a/libMBIN/Source/NMS/GameComponents/GcPulseEncounterInfo.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcPulseEncounterInfo.cs
@@ -15,7 +15,7 @@ namespace libMBIN.NMS.GameComponents
         /* 0x050 */ public TkTextureResource MarkerIcon;
         [NMS(Size = 0x4, Ignore = true)]
         /* 0x0D4 */ public byte[] PaddingD4;
-        /* 0x0D8 */ public GcPulseEncounterSpawnConditions SpawnCondition;
+        /* 0x0D8 */ public GcPulseEncounterSpawnConditions SpawnConditions;
         /* 0x138 */ public float SpawnChance;
         /* 0x13C */ public float SpawnDistance;
         /* 0x140 */ public GcAudioWwiseEvents AudioEvent;

--- a/libMBIN/Source/NMS/GameComponents/GcQuestItemPlacementRule.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcQuestItemPlacementRule.cs
@@ -16,6 +16,6 @@ namespace libMBIN.NMS.GameComponents
         /* 0x18 */ public string MustBeBeforeQuestItem;
         [NMS(Size = 0x10)]
         /* 0x28 */ public string MustBeAfterQuestItem;
-        /* 0x38 */ public List<NMSString0x10> ValidRoomsIDs;
+        /* 0x38 */ public List<NMSString0x10> ValidRoomIDs;
     }
 }

--- a/libMBIN/Source/NMS/GameComponents/GcRealityManagerData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcRealityManagerData.cs
@@ -37,7 +37,7 @@ namespace libMBIN.NMS.GameComponents
         /* 0x0778 */ public string RecipeTable;
         [NMS(Size = 0x80)]
         /* 0x07F8 */ public string AlienWordsTable;
-        /* 0x0878 */ public List<NMSString0x80> AlienPuzzlesTables;
+        /* 0x0878 */ public List<NMSString0x80> AlienPuzzleTables;
         [NMS(Size = 0x72, EnumType = typeof(GcInteractionType.InteractionTypeEnum))]
         /* 0x0888 */ public bool[] LoopInteractionPuzzles;
         [NMS(Size = 0x72, EnumType = typeof(GcInteractionType.InteractionTypeEnum))]
@@ -124,7 +124,7 @@ namespace libMBIN.NMS.GameComponents
         /* 0xD668 */ public List<NMSString0x10> NeverOfferedForSale;
         public enum GoodsTypeEnum { Commodity, Technology, Fuel, Tradeable, Special }
         [NMS(Size = 0x5, EnumType = typeof(GoodsTypeEnum))]         // TODO: not sure about these values....
-        /* 0xD678 */ public float[] NormalizedPriceLimits;
+        /* 0xD678 */ public float[] NormalisedPriceLimits;
         [NMS(Size = 0x4, Ignore = true)]
         /* 0xD68C */ public byte[] PaddingD68C;
         /* 0xD690 */ public List<GcFiendCrimeSpawnTable> FiendCrimeSpawnTable;

--- a/libMBIN/Source/NMS/GameComponents/GcRealitySubstanceData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcRealitySubstanceData.cs
@@ -29,7 +29,7 @@ namespace libMBIN.NMS.GameComponents
         /* 0x1D8 */ public GcItemPriceModifiers Cost;
         /* 0x1EC */ public float NormalisedValueOnWorld;
         /* 0x1F0 */ public float NormalisedValueOffWorld;
-        /* 0x1F4 */ public GcTradeCategory tradeCategory;
+        /* 0x1F4 */ public GcTradeCategory TradeCategory;
         /* 0x1F8 */ public bool WikiEnabled;
         /* 0x1FC */ public float EconomyInfluenceMultiplier;
         [NMS(Size = 0x20)]

--- a/libMBIN/Source/NMS/GameComponents/GcRewardAssessCookedProduct.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcRewardAssessCookedProduct.cs
@@ -5,12 +5,12 @@ using libMBIN.NMS.GameComponents;
 
 namespace libMBIN.NMS.GameComponents
 {
-	[NMS(Size = 0x18, GUID = 0x93EC6032E16C9265, NameHash = 0x904C594862FC894E)]
+    [NMS(Size = 0x18, GUID = 0x93EC6032E16C9265, NameHash = 0x904C594862FC894E)]
     public class GcRewardAssessCookedProduct : NMSTemplate
     {
         public int AmountWorst;
         public int AmountBad;
-        public int Amountbad;
+        public int AmountAverage;
         public int AmountGood;
         public int AmountBest;
         public int AmountBestUpper;

--- a/libMBIN/Source/NMS/GameComponents/GcRewardMultiSpecificTechRecipes.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcRewardMultiSpecificTechRecipes.cs
@@ -12,7 +12,7 @@ namespace libMBIN.NMS.GameComponents
 		[NMS(Size = 0x10)]
         /* 0x10 */ public string DisplayTechId;
         [NMS(Size = 0x20)]
-        /* 0x20 */ public string Setname;
+        /* 0x20 */ public string SetName;
         /* 0x40 */ public bool Silent;
         [NMS(Size = 0x7, Ignore = true)]
         /* 0x41 */ public byte[] EndPadding;

--- a/libMBIN/Source/NMS/GameComponents/GcRewardSecondarySubstance.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcRewardSecondarySubstance.cs
@@ -8,7 +8,7 @@ namespace libMBIN.NMS.GameComponents
     {
         [NMS(Size = 0x10)]
         public string ID;
-        public float Amountfactor;
+        public float AmountFactor;
         public bool RewardAsBlobs;
         [NMS(Size = 0x3, Ignore = true)]
         public byte[] EndPadding;

--- a/libMBIN/Source/NMS/GameComponents/GcRewardSendChatMessage.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcRewardSendChatMessage.cs
@@ -7,7 +7,7 @@ namespace libMBIN.NMS.GameComponents
     public class GcRewardSendChatMessage : NMSTemplate
     {
         [NMS(Size = 0x10)]
-        public string StatusMessageID;
+        public string StatusMessageId;
         [NMS(Size = 0x20)]
         public string CustomText;
     }

--- a/libMBIN/Source/NMS/GameComponents/GcRewardSpecificProductRecipe.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcRewardSpecificProductRecipe.cs
@@ -8,7 +8,7 @@ namespace libMBIN.NMS.GameComponents
     {
         [NMS(Size = 0x10)]
         public string Id;
-        public bool Slient;
+        public bool Silent;
         [NMS(Size = 0x7, Ignore = true)]
         public byte[] EndPadding;
     }

--- a/libMBIN/Source/NMS/GameComponents/GcRewardUnlockTitle.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcRewardUnlockTitle.cs
@@ -7,7 +7,7 @@ namespace libMBIN.NMS.GameComponents
     public class GcRewardUnlockTitle : NMSTemplate
     {
         [NMS(Size = 0x10)]
-        /* 0x00 */ public string titleID;
+        /* 0x00 */ public string TitleID;
         /* 0x10 */ public bool NoMusic;
         /* 0x11 */ public bool ShowEvenIfAlreadyUnlocked;
         [NMS(Size = 0x6, Ignore = true)]

--- a/libMBIN/Source/NMS/GameComponents/GcScannableComponentData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcScannableComponentData.cs
@@ -17,7 +17,7 @@ namespace libMBIN.NMS.GameComponents
         /* 0x32 */ public bool DisableIfBuildingPart;
         /* 0x33 */ public bool DisableIfInBase;
         /* 0x34 */ public bool UseModelNode;
-        /* 0x38 */ public GcScannerIconTypes IconType;
+        /* 0x38 */ public GcScannerIconTypes Icon;
 		public enum ScannableTypeEnum { Binoculars, BinocularsHotspots, Scanner, Marker, None }
 		/* 0x3C */ public ScannableTypeEnum ScannableType;
         /* 0x40 */ public bool IsPlacedMarker;

--- a/libMBIN/Source/NMS/GameComponents/GcScannerBuildingIconTypes.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcScannerBuildingIconTypes.cs
@@ -12,6 +12,6 @@ namespace libMBIN.NMS.GameComponents
             TechResource, FuelResource, MineralResource, SpaceAnomaly, SpaceAtlas, ExternalBase, PlanetBaseTerminal, Nexus, AbandonedFreighter,
             Telescope, Outpost, UpgradePod, Cog, Ruins, Portal, Library, Abandoned, SmallBuilding, StoryGlitch, GraveInCave, HoloHub
         }
-		public ScanBuildingIconTypesEnum ScanBuildingIconTypes;
+		public ScanBuildingIconTypesEnum ScanBuildingIconType;
     }
 }

--- a/libMBIN/Source/NMS/GameComponents/GcScannerIcons.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcScannerIcons.cs
@@ -60,8 +60,8 @@ namespace libMBIN.NMS.GameComponents
         /* 0xF994 */ public GcScannerIcon MessageBeacon;
         /* 0xFAA0 */ public GcScannerIcon MessageBeaconSmall;
         /* 0xFBAC */ public GcScannerIcon BaseBuildingMarker;
-        /* 0xFCB8 */ public GcScannerIcon PlanetNorthPole;
-        /* 0xFDC4 */ public GcScannerIcon PlanetSouthPole;
+        /* 0xFCB8 */ public GcScannerIcon PlanetPoleNorth;
+        /* 0xFDC4 */ public GcScannerIcon PlanetPoleSouth;
         /* 0xFED0 */ public GcScannerIcon MonumentMarker;
         /* 0xFFDC */ public GcScannerIcon NetworkPlayerMarker;
         /* 0x100E8 */ public GcScannerIcon NetworkPlayerMarkerShip;

--- a/libMBIN/Source/NMS/GameComponents/GcShootableComponentData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcShootableComponentData.cs
@@ -27,7 +27,7 @@ namespace libMBIN.NMS.GameComponents
         /* 0x36 */ public bool HitEffectEnabled;
         /* 0x37 */ public bool HitEffectEntireModel;
         /* 0x38 */ public bool IsArmoured;
-        /* 0x39 */ public bool IgnoreTerrainEditKill;
+        /* 0x39 */ public bool IgnoreTerrainEditKills;
         [NMS(Size = 0x20)]
         /* 0x3A */ public string NameOverride;
         [NMS(Size = 0x6, Ignore = true)]

--- a/libMBIN/Source/NMS/GameComponents/GcStatsBonus.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcStatsBonus.cs
@@ -6,7 +6,7 @@ namespace libMBIN.NMS.GameComponents
 	[NMS(Size = 0xC, GUID = 0x19071614D76515B5, NameHash = 0xBAC710ADD80D9C59)]
     public class GcStatsBonus : NMSTemplate
     {
-        public GcStatsTypes StatsTypes;
+        public GcStatsTypes StatType;
         public float Bonus;
         public int Level;
     }

--- a/libMBIN/Source/NMS/GameComponents/GcTextPreset.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcTextPreset.cs
@@ -6,8 +6,8 @@ namespace libMBIN.NMS.GameComponents
 	[NMS(Size = 0x70, GUID = 0xF7836692C9FF6FC1, NameHash = 0x4CF465C68C10EBB4)]
     public class GcTextPreset : NMSTemplate
     {
-        public GcFontTypesEnum FontType;
-        public NMSTemplate TextStyle;
+        public GcFontTypesEnum Font;
+        public NMSTemplate Style;
 
         public float Height;
         public Colour Colour;

--- a/libMBIN/Source/NMS/GameComponents/GcThereminComponentData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcThereminComponentData.cs
@@ -10,7 +10,7 @@ namespace libMBIN.NMS.GameComponents
         /* 0x00 */ public string VolumeBBName;
         /* 0x20 */ public float VolumeMinDist;
         /* 0x24 */ public float VolumeMaxDist;
-        /* 0x28 */ public float MinVolumne;
+        /* 0x28 */ public float MinVolume;
         /* 0x2C */ public float MaxVolume;
         [NMS(Size = 0x20)]
         /* 0x30 */ public string PitchStartLocator;

--- a/libMBIN/Source/NMS/GameComponents/GcUnlockableItemTreeGroups.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcUnlockableItemTreeGroups.cs
@@ -10,6 +10,6 @@ namespace libMBIN.NMS.GameComponents
     {
         // 0xB entries
         public enum UnlockableItemTreeEnum { Test, BasicBaseParts, BasicTechParts, BaseParts, SpecialBaseParts, SuitTech, ShipTech, WeapTech, ExocraftTech, CraftProducts, FreighterTech }
-        public UnlockableItemTreeEnum GetUnlockableItemTree;
+        public UnlockableItemTreeEnum UnlockableItemTree;
     }
 }

--- a/libMBIN/Source/NMS/GameComponents/GcUnlockableTreeCostType.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcUnlockableTreeCostType.cs
@@ -16,6 +16,6 @@ namespace libMBIN.NMS.GameComponents
         [NMS(Size = 0x10)]
         /* 0x18 */ public string TypeID;
         [NMS(Size = 0x20)]
-        /* 0x28 */ public string CantAffortString;
+        /* 0x28 */ public string CantAffordString;
     }
 }

--- a/libMBIN/Source/NMS/GameComponents/GcVehicleData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcVehicleData.cs
@@ -44,7 +44,7 @@ namespace libMBIN.NMS.GameComponents
         /* 0x490 */ public Vector3f CollDimensions;
         /* 0x4A0 */ public Vector3f InertiaDimensions;
         /* 0x4B0 */ public float CollRadius;
-        /* 0x4B4 */ public float InertiaMull;
+        /* 0x4B4 */ public float InertiaMul;
         /* 0x4B8 */ public float WheelSuspensionlength;
         /* 0x4BC */ public float WheelSuspensionForce;
         /* 0x4C0 */ public float WheelSuspensionDamping;
@@ -71,7 +71,7 @@ namespace libMBIN.NMS.GameComponents
         /* 0x514 */ public float WheelSideFrictionStaticThreshold;
         /* 0x518 */ public bool LockVehicleAxis;
         /* 0x51C */ public float TurningWheelForce;
-        /* 0x520 */ public float TurningWheelForceVR;
+        /* 0x520 */ public float TurningWheelForceDamperVR;
         /* 0x524 */ public float TurningWheelFrictionOmega;
         /* 0x528 */ public float TurningWheelFrictionNonBraking;
         /* 0x52C */ public float TurningWheelFrictionBraking;

--- a/libMBIN/Source/NMS/GameComponents/GcWeaponClasses.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcWeaponClasses.cs
@@ -7,6 +7,6 @@ namespace libMBIN.NMS.GameComponents
     public class GcWeaponClasses : NMSTemplate
     {
 		public enum WeaponClassEnum { Pistol, Rifle, Pristine, Alien }
-		public WeaponClassEnum WeaponClass;
+		public WeaponClassEnum WeaponStatClass;
     }
 }

--- a/libMBIN/Source/NMS/Toolkit/TkAnimAnimNode.cs
+++ b/libMBIN/Source/NMS/Toolkit/TkAnimAnimNode.cs
@@ -13,7 +13,7 @@ namespace libMBIN.NMS.Toolkit
         [NMS(Size = 0x40)]
         public string PhaseIn;
         public TkCurveType PhaseCurve;
-        public float PhseRangeBegin;
+        public float PhaseRangeBegin;
         public float PhaseRangeEnd;
         [NMS(Size = 0x4, Ignore = true)]
         public byte[] EndPadding;

--- a/libMBIN/Source/NMS/Toolkit/TkAnimDetailSettingsData.cs
+++ b/libMBIN/Source/NMS/Toolkit/TkAnimDetailSettingsData.cs
@@ -9,7 +9,7 @@ namespace libMBIN.NMS.Toolkit
     public class TkAnimDetailSettingsData : NMSTemplate
     {
         public float Distance;
-        public bool DisableAnims;
+        public bool DisableAnim;
         public int NumCulledFrames;
     }
 }

--- a/libMBIN/Source/NMS/Toolkit/TkAnimationComponentData.cs
+++ b/libMBIN/Source/NMS/Toolkit/TkAnimationComponentData.cs
@@ -11,7 +11,7 @@ namespace libMBIN.NMS.Toolkit
         /* 0x000 */ public TkAnimationData Idle;
         /* 0x138 */ public List<TkAnimationData> Anims;
         /* 0x148 */ public List<TkAnimBlendTree> Trees;
-        /* 0x158 */ public bool NetSyncAnimation;
+        /* 0x158 */ public bool NetSyncAnimations;
         [NMS(Size = 0x7, Ignore = true)]
         /* 0x159 */ public byte[] Padding159;
         /* 0x160 */ public List<TkAnimJointLODData> JointLODOverrides;

--- a/libMBIN/Source/NMS/Toolkit/TkCavesEnum.cs
+++ b/libMBIN/Source/NMS/Toolkit/TkCavesEnum.cs
@@ -9,6 +9,6 @@ namespace libMBIN.NMS.Toolkit
     public class TkCavesEnum : NMSTemplate
     {
         public enum CavesTypesEnum { Underground }
-        public CavesTypesEnum CavesTypes;
+        public CavesTypesEnum CaveTypes;
     }
 }

--- a/libMBIN/Source/NMS/Toolkit/TkControllerSpecification.cs
+++ b/libMBIN/Source/NMS/Toolkit/TkControllerSpecification.cs
@@ -8,7 +8,7 @@ namespace libMBIN.NMS.Toolkit
     {
         [NMS(Size = 0x10)]
         public string Id;
-        public TkButtonImageLookup ImageLookup;
+        public TkButtonImageLookup ButtonImageLookup;
         public TkAxisImageLookup AxisImageLookup;
         public TkChordsImageLookup ChordsImageLookup;
     }

--- a/libMBIN/Source/NMS/Toolkit/TkCreatureTailComponentData.cs
+++ b/libMBIN/Source/NMS/Toolkit/TkCreatureTailComponentData.cs
@@ -9,7 +9,7 @@ namespace libMBIN.NMS.Toolkit
     public class TkCreatureTailComponentData : NMSTemplate
     {
         /* 0x00 */ public GcPrimaryAxis LengthAxis;
-        /* 0x04 */ public bool CanuseDefaultParams;
+        /* 0x04 */ public bool CanUseDefaultParams;
         [NMS(Size = 0x3, Ignore = true)]
         /* 0x05 */ public byte[] Padding5;
         /* 0x08 */ public TkCreatureTailParams DefaultParams;

--- a/libMBIN/Source/NMS/Toolkit/TkEntitlementListData.cs
+++ b/libMBIN/Source/NMS/Toolkit/TkEntitlementListData.cs
@@ -9,6 +9,6 @@ namespace libMBIN.NMS.Toolkit
         [NMS(Size = 0x10)]
         public string EntitlementId;
         [NMS(Size = 0x40)]
-        public string ServicesID;
+        public string ServiceID;
     }
 }

--- a/libMBIN/Source/NMS/Toolkit/TkGameSettings.cs
+++ b/libMBIN/Source/NMS/Toolkit/TkGameSettings.cs
@@ -13,7 +13,7 @@ namespace libMBIN.NMS.Toolkit
 
         [NMS(Size = 0x4, Ignore = true)]
         public byte[] Padding4;
-        public List<GcInputActionMapping> Keymapping;
+        public List<GcInputActionMapping> KeyMapping;
         public List<GcInputActionMapping2> KeyMapping2;
     }
 }

--- a/libMBIN/Source/NMS/Toolkit/TkGraphicsSettings.cs
+++ b/libMBIN/Source/NMS/Toolkit/TkGraphicsSettings.cs
@@ -14,7 +14,7 @@ namespace libMBIN.NMS.Toolkit
         /* 0x08 */ public int Monitor;
         [NMS(Size = 0x4, Ignore = true)]
         /* 0x0C */ public byte[] PaddingC;
-        /* 0x10 */ public List<NMSString0x100> TkMonitorNames;
+        /* 0x10 */ public List<NMSString0x100> MonitorNames;
         /* 0x20 */ public int ResolutionWidth;
         /* 0x24 */ public int ResolutionHeight;
         /* 0x28 */ public float ResolutionScale;

--- a/libMBIN/Source/NMS/Toolkit/TkNGuiTextStyleData.cs
+++ b/libMBIN/Source/NMS/Toolkit/TkNGuiTextStyleData.cs
@@ -11,7 +11,7 @@ namespace libMBIN.NMS.Toolkit
         /* 0x14 */ public float FontSpacing;
         /* 0x18 */ public bool IsIndented;
         /* 0x19 */ public bool HasDropShadow;
-        /* 0x20 */ public Colour DropShadowColour;
+        /* 0x20 */ public Colour ShadowColour;
         /* 0x30 */ public float DropShadowAngle;
         /* 0x34 */ public float DropShadowOffset;
         /* 0x38 */ public bool HasOutline;

--- a/libMBIN/Source/NMS/Toolkit/TkVoxelGeneratorData.cs
+++ b/libMBIN/Source/NMS/Toolkit/TkVoxelGeneratorData.cs
@@ -21,7 +21,7 @@ namespace libMBIN.NMS.Toolkit
         [NMS(Size = 0x7, EnumType = typeof(TkFeaturesEnum.FeatureTypesEnum))]
         /* 0x134C */ public TkNoiseFeatureData[] Features;
         [NMS(Size = 1, EnumType = typeof(TkCavesEnum.CavesTypesEnum))]
-        /* 0x1528 */ public TkNoiseCaveData[] CavesUnderground;
+        /* 0x1528 */ public TkNoiseCaveData[] Caves;
         /* 0x15B0 */ public float MinimumCaveDepth;
         /* 0x15B4 */ public float CaveRoofSmoothingDist;
         /* 0x15B8 */ public float MaximumSeaLevelCaveDepth;


### PR DESCRIPTION
For your consideration.

The actuall substitutions were done from a list with a perl script.
These are the field names that don't match any string in the exe I have.
Where the changes is just a changes in case I did not check that the name is correct just that the substituion is a unique capialization of the string in the exe.

I've not changed the following:
1. Anything in GcCreatureInfo that had "Float" appeneded to it to make it unique.
2. "BaseBuildingObjectType" in GcBaseBuildingObjectTypes because that class along with GcCustomisationJetpackThrusterEffects are not in the exe.
3. "SharedData" in GcAtlasSendSubmitContributionActual because it is an internal class that has not been updated and does not appear to have a field of that type.
