### PR TITLE
implicit string conversions to NMSString and VariableSizeString classes - take 2.

### DIFF
--- a/MBINCompiler.sln
+++ b/MBINCompiler.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2036
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31313.79
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MBINCompiler", "MBINCompiler\MBINCompiler.csproj", "{CE736EF9-7BE9-4FF0-9551-78F0071AA373}"
 EndProject
@@ -29,6 +29,8 @@ EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		libMBIN\libMBIN-Shared.projitems*{b6850f17-d8fd-48de-9cf2-240f1ba87236}*SharedItemsImports = 13
+		libMBIN\libMBIN-Shared.projitems*{ce736ef9-7be9-4ff0-9551-78f0071aa373}*SharedItemsImports = 5
+		libMBIN\libMBIN-Shared.projitems*{f2d295a6-d082-4eb4-8fc9-f4687f674939}*SharedItemsImports = 5
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/MBINCompilerDocs/MBINCompilerDocs.csproj
+++ b/MBINCompilerDocs/MBINCompilerDocs.csproj
@@ -19,10 +19,9 @@
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="libMBIN, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Build\Release\libMBIN.dll</HintPath>
-    </Reference>
+    <ProjectReference Include="..\libMBIN-DLL\libMBIN-DLL.csproj" />
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/libMBIN/Source/NMS/BaseTypes/NMSString0x10.cs
+++ b/libMBIN/Source/NMS/BaseTypes/NMSString0x10.cs
@@ -22,5 +22,6 @@ namespace libMBIN.NMS
         public NMSString0x10() { }
 
         public static implicit operator NMSString0x10(string str) => new NMSString0x10(str);
-    }
+		public static implicit operator string ( NMSString0x10 str ) => str.Value;
+	}
 }

--- a/libMBIN/Source/NMS/BaseTypes/NMSString0x100.cs
+++ b/libMBIN/Source/NMS/BaseTypes/NMSString0x100.cs
@@ -20,5 +20,8 @@ namespace libMBIN.NMS
         }
 
         public NMSString0x100() { }
-    }
+
+		public static implicit operator NMSString0x100 ( string str ) => new NMSString0x100(str);
+		public static implicit operator string ( NMSString0x100 str ) => str.Value;
+	}
 }

--- a/libMBIN/Source/NMS/BaseTypes/NMSString0x20.cs
+++ b/libMBIN/Source/NMS/BaseTypes/NMSString0x20.cs
@@ -20,5 +20,8 @@ namespace libMBIN.NMS
         }
 
         public NMSString0x20() { }
-    }
+
+		public static implicit operator NMSString0x20 ( string str ) => new NMSString0x20(str);
+		public static implicit operator string ( NMSString0x20 str ) => str.Value;
+	}
 }

--- a/libMBIN/Source/NMS/BaseTypes/NMSString0x200.cs
+++ b/libMBIN/Source/NMS/BaseTypes/NMSString0x200.cs
@@ -20,5 +20,8 @@ namespace libMBIN.NMS
         }
 
         public NMSString0x200() { }
-    }
+
+		public static implicit operator NMSString0x200 ( string str ) => new NMSString0x200(str);
+		public static implicit operator string ( NMSString0x200 str ) => str.Value;
+	}
 }

--- a/libMBIN/Source/NMS/BaseTypes/NMSString0x20A.cs
+++ b/libMBIN/Source/NMS/BaseTypes/NMSString0x20A.cs
@@ -21,5 +21,8 @@ namespace libMBIN.NMS
         }
 
         public NMSString0x20A() { }
-    }
+
+		public static implicit operator NMSString0x20A ( string str ) => new NMSString0x20A(str);
+		public static implicit operator string ( NMSString0x20A str ) => str.Value;
+	}
 }

--- a/libMBIN/Source/NMS/BaseTypes/NMSString0x40.cs
+++ b/libMBIN/Source/NMS/BaseTypes/NMSString0x40.cs
@@ -20,5 +20,8 @@ namespace libMBIN.NMS
         }
 
         public NMSString0x40() { }
-    }
+
+		public static implicit operator NMSString0x40 ( string str ) => new NMSString0x40(str);
+		public static implicit operator string ( NMSString0x40 str ) => str.Value;
+	}
 }

--- a/libMBIN/Source/NMS/BaseTypes/NMSString0x400.cs
+++ b/libMBIN/Source/NMS/BaseTypes/NMSString0x400.cs
@@ -20,5 +20,8 @@ namespace libMBIN.NMS
         }
 
         public NMSString0x400() { }
-    }
+
+		public static implicit operator NMSString0x400 ( string str ) => new NMSString0x400(str);
+		public static implicit operator string ( NMSString0x400 str ) => str.Value;
+	}
 }

--- a/libMBIN/Source/NMS/BaseTypes/NMSString0x80.cs
+++ b/libMBIN/Source/NMS/BaseTypes/NMSString0x80.cs
@@ -20,5 +20,8 @@ namespace libMBIN.NMS
         }
 
         public NMSString0x80() { }
-    }
+
+		public static implicit operator NMSString0x80 ( string str ) => new NMSString0x80(str);
+		public static implicit operator string ( NMSString0x80 str ) => str.Value;
+	}
 }

--- a/libMBIN/Source/NMS/BaseTypes/NMSString0x800.cs
+++ b/libMBIN/Source/NMS/BaseTypes/NMSString0x800.cs
@@ -20,5 +20,8 @@ namespace libMBIN.NMS
         }
 
         public NMSString0x800() { }
-    }
+
+		public static implicit operator NMSString0x800 ( string str ) => new NMSString0x800(str);
+		public static implicit operator string ( NMSString0x800 str ) => str.Value;
+	}
 }

--- a/libMBIN/Source/NMS/BaseTypes/VariableSizeString.cs
+++ b/libMBIN/Source/NMS/BaseTypes/VariableSizeString.cs
@@ -7,5 +7,8 @@ namespace libMBIN.NMS
     public class VariableSizeString : NMSTemplate
     {
         public string Value;
-    }
+
+		public static implicit operator VariableSizeString ( string str ) => new VariableSizeString { Value = str };
+		public static implicit operator string ( VariableSizeString str ) => str.Value;
+	}
 }


### PR DESCRIPTION
Add: implicit string conversions to NMSString and VariableSizeString classes - take 2.
Fix: Correct MBINCompilerDocs reference to libMBIN.
