### PR TITLE
[MRG] Unroll AggregateExceptions.

### DIFF
--- a/MBINCompiler/Source/CommandLine.cs
+++ b/MBINCompiler/Source/CommandLine.cs
@@ -63,7 +63,15 @@ namespace MBINCompiler {
         private static long lastPosition = 0;
 
         public static int ShowException( Exception e, bool wait=true ) {
-            string msg = ( e.GetType() == typeof( CompilerException ) ) ? e.InnerException?.Message : null;
+            if ( e is AggregateException ae ) {
+                foreach ( var ie in ae.InnerExceptions ) {
+                    ShowException( ie, false );
+                }
+                WaitForKeypress( wait );
+                return (int) ErrorCode.Unknown;
+            }
+
+            string msg = ( e is CompilerException ) ? e.InnerException?.Message : null;
             if ( (Logger.LogStream?.BaseStream.Position ?? 0) != lastPosition ) Logger.LogMessage( "" ); // new line, log only
             ShowError( $"[{e.GetType().Name}]: {msg ?? e.Message}", wait: false );
             using ( var indent = new Logger.IndentScope() ) {

--- a/MBINCompiler/Source/Commands/Convert.cs
+++ b/MBINCompiler/Source/Commands/Convert.cs
@@ -320,7 +320,7 @@ namespace MBINCompiler.Commands {
         /// how to handle the file.
         /// </summary>
         /// <param name="file">The file path to check.</param>
-        /// <param name="fileMode">When the methord returns, contains the file mode.</param>
+        /// <param name="fileMode">When the method returns, contains the file mode.</param>
         /// <returns>true if the file mode is safe to use, otherwise false</returns>
         private static bool GetFileMode( string file, out FileMode fileMode ) {
             FileMode mode = FileMode.CreateNew; // OverwriteMode.Never or file doesn't exist


### PR DESCRIPTION
Trying this again.

The AggregateException is throw from Task.WaitAll().
It only happend with threading is enabled an the --force option is not used.

Currently without --force when threading is disabled it stops after the first error.
But without --force when  threadding is enabled it waits until it has finished processing all the files and then if there was any exceptions along the way it skips the summary and shows the AggregateException message.

So my question is what should it do when you've not used the --force option, threadding is enabled and you get an exception?