### PR TITLE
Pin .NET SDK version to lowest v5 version

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.x'
+          dotnet-version: '5.0.100'
       - name: Set up Python 3.6
         uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
Pinning the SDK version to the lowest one in the CI so that we can maximise .net 5 runtime compatibility (currently it was needing 5.0.7 which not everyone may have, but everyone should have at least one 5.0.x version.