### PR TITLE
Modify GetString method for version to left pad with 0

### DIFF
--- a/libMBIN/Source/Version.cs
+++ b/libMBIN/Source/Version.cs
@@ -59,8 +59,8 @@
         ///     Eg. "1.1.0" (Release) or "1.1.0-pre1" (Pre-Release)
         /// </summary>
         /// <returns>"{<see cref="Major"/>}.{<see cref="Minor"/>}.{<see cref="Release"/>}{<see cref="GetSuffix">Suffix</see>}"</returns>
-        public static string GetString() => AssemblyVersion.ToString( 3 ) + GetSuffix();
-
+        public static string GetString() {
+            return $"{AssemblyVersion.Major}.{AssemblyVersion.Minor:00}.{AssemblyVersion.Build}"  + GetSuffix();
+        }
     }
-
 }


### PR DESCRIPTION
This changes how the version is converted to a string. The 2nd component of the version (minor) will be left padded with a 0, so that we can keep the versions more in line with what HG does (ie. current version is 4.04).
This should reduce confusion around tagging releases as we'll be able to actually tag the release as `v4.04.0-pre2` (eg)