### PR TITLE
Mostly revert changes to CI so that MBINCompiler path is relative

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -29,9 +29,6 @@ jobs:
           cp Build/Release/net5/MBINCompiler.exe MBINCompiler.exe
           cp Build/Release/net5/libMBIN.dll libMBIN.dll
           cp Build/Release/net6/libMBIN.dll libMBIN-dotnet6.dll
-      - name: Get MBINCompiler version
-        run: echo "VERSION=$(Build/Release/net5/MBINCompiler.exe version | awk '{print $2}')" >> $GITHUB_ENV
-        shell: bash
       - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:
@@ -68,7 +65,9 @@ jobs:
         with:
           name: MBINCompiler
       - name: Get MBINCompiler tag version
-        run: echo "TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+        run: |
+          echo "VERSION=$(./MBINCompiler.exe version | awk '{print $2}')" >> $GITHUB_ENV
+          echo "TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
         shell: bash
       - name: Upload resources if version matches
         if: env.VERSION == env.TAG


### PR DESCRIPTION
Looks like environment variables set in previous jobs don't persist to other jobs...