### PR TITLE
misc changes, hopefully fixes CI

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -52,6 +52,7 @@ jobs:
             libMBIN-dotnet4.dll
             libMBIN-dotnet6.dll
             MBINCompiler.exe
+            MBINCompiler-dotnet6.exe
             libMBIN.dll
             report.json
             mapping.json

--- a/Tools/auto_extract/extract.cfg.sample
+++ b/Tools/auto_extract/extract.cfg.sample
@@ -6,3 +6,4 @@ wait_time = 5
 close_NMS_process = true
 replace_existing_files = false
 output_dir = ../../libMBIN/
+write_guid_json = false

--- a/libMBIN/Source/Template/NMSTemplate.cs
+++ b/libMBIN/Source/Template/NMSTemplate.cs
@@ -728,8 +728,11 @@ namespace libMBIN
                             writer.Write((uint)Enum.Parse(field.FieldType, fieldData.ToString()));
                         } else if (enumType.Name == "UInt16") {
                             writer.Write((ushort)Enum.Parse(field.FieldType, fieldData.ToString()));
-                        } else {
+                        } else if (enumType.Name == "Byte") {
                             writer.Write((byte)Enum.Parse(field.FieldType, fieldData.ToString()));
+                        } else {
+                            // Fall back to int parsing just in case the enum has no type specified.
+                            writer.Write((int)Enum.Parse(field.FieldType, fieldData.ToString()));
                         }
 
                     } else if ( fieldType.BaseType == typeof( NMSTemplate ) ) {
@@ -1365,8 +1368,11 @@ namespace libMBIN
                                 return (uint)Enum.Parse(field.FieldType, xmlProperty.Value);
                             } else if (enumType.Name == "UInt16") {
                                 return (ushort)Enum.Parse(field.FieldType, xmlProperty.Value);
-                            } else {
+                            } else if (enumType.Name == "Byte") {
                                 return (byte)Enum.Parse(field.FieldType, xmlProperty.Value);
+                            } else {
+                                // Fall back to int parsing just in case the enum has no type specified.
+                                return (int)Enum.Parse(field.FieldType, xmlProperty.Value);
                             }
                         } catch (ArgumentException) {
                             // material flags can have a custom suffix


### PR DESCRIPTION
A small change to make sure the enum backup value is sensible.
Also hopefully fixed the CI for releases and added some extra code to create a mapping of class names to GUID's. Not useful for anything now so turned off by default in the extractor