### PR TITLE
Update CI with build matrix

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -3,37 +3,44 @@ name: MBINCompiler
 on:
   # Run on all branches except for the gh-pages branch
   push:
+    paths-ignore:
+      - '*.md'
     branches-ignore:
       - 'gh-pages'
   pull_request:
+    paths-ignore:
+      - '*.md'
     branches-ignore:
       - 'gh-pages'
   create:
 
 jobs:
-  build:
-    name: Build artefacts
-    runs-on: windows-latest
+  build_test:
+    name: Build artefacts - ${{ matrix.os.name }}/${{ matrix.dotnet.framework }}
+    runs-on: ${{ matrix.os.name }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [{name: 'Ubuntu', runtime: 'linux-x64'}, {name: 'Windows', runtime: 'win-x64'}]
+        dotnet: [{framework: 'net6.0', version: '6.0.0'}, {framework: 'net7.0', version: '7.0.0'}]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: |
-            6.0.100
-            7.0.100
-      - name: Build Windows binaries
+      - name: Build ${{ matrix.os.name }}-dotnet ${{ matrix.dotnet }} binaries
         run: |
-          dotnet publish libMBIN-DLL -c Release -f net6.0 -r win-x64 -o Build/Release/net6/ /nowarn:cs0618
-          dotnet publish MBINCompiler -c Release -f net6.0 -r win-x64 -o Build/Release/net6/ /nowarn:cs0618
-          dotnet publish SaveFileMapping -c Release -f net6.0 -r win-x64 -o Build/Release/net6/ /nowarn:cs0618
-          dotnet publish libMBIN-DLL -c Release -f net7.0 -r win-x64 -o Build/Release/net7/ /nowarn:cs0618
-          dotnet publish MBINCompiler -c Release -f net7.0 -r win-x64 -o Build/Release/net7/ /nowarn:cs0618
+          sed -i '\|<TargetFrameworks>net6.0;net7.0</TargetFrameworks>|a\    <RuntimeFrameworkVersion>${{ matrix.dotnet.version }}</RuntimeFrameworkVersion>' ./MBINCompiler/MBINCompiler.csproj
+          sed -i '\|<TargetFrameworks>net6.0;net7.0</TargetFrameworks>|a\    <RuntimeFrameworkVersion>${{ matrix.dotnet.version }}</RuntimeFrameworkVersion>' ./libMBIN-DLL/libMBIN-DLL.csproj
+          dotnet publish libMBIN-DLL --no-self-contained -c Release -f ${{ matrix.dotnet.framework }} -r ${{ matrix.os.runtime }} /nowarn:cs0618
+          dotnet publish MBINCompiler --no-self-contained -c Release -f ${{ matrix.dotnet.framework }} -r ${{ matrix.os.runtime }} /nowarn:cs0618
       - name: Move the exe so the tests can find it easier
         run: |
-          cp Build/Release/net6/MBINCompiler.exe MBINCompiler.exe
-          cp Build/Release/net6/libMBIN.dll libMBIN.dll
-          cp Build/Release/net7/MBINCompiler.exe MBINCompiler-dotnet7.exe
-          cp Build/Release/net7/libMBIN.dll libMBIN-dotnet7.dll
+          cp Build/Release/${{ matrix.dotnet.framework }}/${{ matrix.os.runtime }}/publish/MBINCompiler.exe MBINCompiler.exe
+          cp Build/Release/${{ matrix.dotnet.framework }}/${{ matrix.os.runtime }}/publish/libMBIN.dll libMBIN.dll
+        if: ${{matrix.os.name  == 'Windows' }}
+      - name: Move the exe so the tests can find it easier
+        run: |
+          cp Build/Release/${{ matrix.dotnet.framework }}/${{ matrix.os.runtime }}/publish/MBINCompiler MBINCompiler.exe
+          cp Build/Release/${{ matrix.dotnet.framework }}/${{ matrix.os.runtime }}/publish/libMBIN.dll libMBIN.dll
+        if: ${{matrix.os.name  == 'Ubuntu' }}
       - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:
@@ -43,32 +50,66 @@ jobs:
           python -m pip install --upgrade pip
           pip install pytest requests
       - name: Run tests
-        run: python -m pytest --mbincompiler_path="MBINCompiler.exe" --tb=no --report
-      - name: Generate save data mapping
-        run : Build/Release/net6/SaveFileMapping.exe
-        shell: bash
-      - name: Upload binary for release
+        run: python -m pytest --mbincompiler_path="./MBINCompiler.exe" --tb=no --report
+      - name: Upload Windows binaries
         uses: actions/upload-artifact@v3
         with:
-          name: MBINCompiler
+          name: MBINCompiler-${{ matrix.os.name }}-${{ matrix.dotnet.framework }}
           path: |
             MBINCompiler.exe
             libMBIN.dll
-            MBINCompiler-dotnet7.exe
-            libMBIN-dotnet7.dll
-            report.json
-            mapping.json
+        if: ${{matrix.os.name  == 'Windows' }}
+      - name: Upload Linux binaries
+        uses: actions/upload-artifact@v3
+        with:
+          name: MBINCompiler-${{ matrix.os.name }}-${{ matrix.dotnet.framework }}
+          path: |
+            MBINCompiler.exe
+            MBINCompiler.dll
+            libMBIN.dll
+        if: ${{matrix.os.name  == 'Ubuntu' }}
+      - name: Upload report
+        uses: actions/upload-artifact@v3
+        with:
+          name: MBINCompiler-report
+          path: report.json
+        if: ${{matrix.os.name  == 'Windows' && matrix.dotnet.framework == 'net6.0'}}
+  save_mapping:
+    name: Build save file mapping and generate mapping
+    runs-on: Windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build SaveFileMapping binary
+        run: dotnet publish SaveFileMapping -c Release -f net6.0 -r win-x64 -o Build/Release/net6/ /nowarn:cs0618
+      - name: Generate save data mapping
+        run : Build/Release/net6/SaveFileMapping.exe
+        shell: bash
+      - name: Upload report
+        uses: actions/upload-artifact@v3
+        with:
+          name: savedata-mapping
+          path: mapping.json
   release:
     name: Release MBINCompiler binaries and other data
     # Only run this job if the commit was tagged.
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
     runs-on: windows-latest
-    needs: [build]
+    needs: [build_test, save_mapping]
     steps:
       - name: Download files for release
-        uses: actions/download-artifact@v2
-        with:
-          name: MBINCompiler
+        uses: actions/download-artifact@v3
+      - name: Rename files for release
+        run: |
+          mv MBINCompiler-Windows-net6.0/MBINCompiler.exe MBINCompiler.exe
+          mv MBINCompiler-Windows-net6.0/libMBIN.dll libMBIN.dll
+          mv MBINCompiler-Windows-net7.0/MBINCompiler.exe MBINCompiler-dotnet7.exe
+          mv MBINCompiler-Windows-net7.0/libMBIN.dll libMBIN-dotnet7.dll
+          mv MBINCompiler-Ubuntu-net6.0/MBINCompiler.exe MBINCompiler-linux
+          mv MBINCompiler-Ubuntu-net6.0/libMBIN.dll libMBIN-linux.dll
+          mv MBINCompiler-Ubuntu-net7.0/MBINCompiler.exe MBINCompiler-linux-dotnet7
+          mv MBINCompiler-Ubuntu-net7.0/libMBIN.dll libMBIN-linux-dotnet7.dll
+          mv savedata-mapping/mapping.json mapping.json
+          mv MBINCompiler-report/report.json report.json
       - name: Get MBINCompiler tag version
         run: |
           echo "VERSION=$(./MBINCompiler.exe version | awk '{print $2}')" >> $GITHUB_ENV
@@ -86,6 +127,10 @@ jobs:
             libMBIN.dll
             MBINCompiler-dotnet7.exe
             libMBIN-dotnet7.dll
+            MBINCompiler-linux
+            libMBIN-linux.dll
+            MBINCompiler-linux-dotnet7
+            libMBIN-linux-dotnet7.dll
             report.json
             mapping.json
         env:

--- a/MBINCompiler/MBINCompiler.csproj
+++ b/MBINCompiler/MBINCompiler.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <RuntimeIdentifiers>linux-x64;win-x64</RuntimeIdentifiers>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
@@ -48,32 +48,6 @@
     <RuntimeIdentifiers>linux-x64;win-x64</RuntimeIdentifiers>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
-
-  <Target Name="Clean-DotNetExe" AfterTargets="Clean" Condition="$(TargetFramework.StartsWith('netcore'))">
-    <Delete Files="$(TargetDir)$(TargetName).exe" />
-  </Target>
-
-  <Target Name="Build-DotNetExe" AfterTargets="Build" Condition="$(TargetFramework.StartsWith('netcore')) and '$(IsNestedBuild)' != 'true'">
-    <Message Text="SolutionDir = $(SolutionDir)" />
-    <Message Text="ProjectPath = $(ProjectPath)" />
-    <Message Text="OutDir      = $(OutDir)" />
-    <Message Text="OutputDir   = $(OutputDir)" />
-    <Message Text="TargetDir   = $(TargetDir)" />
-    <Message Text="TargetName  = $(TargetName)" />
-
-    <Exec ConsoleToMSBuild="true" Command="dotnet build &quot;$(ProjectPath)&quot; /p:CopyLocalLockFileAssemblies=false;IsNestedBuild=true --output &quot;$(TargetDir)stage/&quot;">
-      <Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
-    </Exec>
-    <Copy SourceFiles="$(TargetDir)stage/$(TargetName).exe" DestinationFolder="$(TargetDir)" />
-    <RemoveDir Directories="$(TargetDir)stage/" />
-
-    <Exec ConsoleToMSBuild="true" IgnoreExitCode="true" Command="dotnet tool install --tool-path ../.nuget/tools dotnet-warp">
-      <Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
-    </Exec>
-    <Exec ConsoleToMSBuild="true" Command="&quot;../.nuget/tools/dotnet-warp&quot; -v -p:CopyLocalLockFileAssemblies=false;IsNestedBuild=true -o &quot;$(TargetDir)$(TargetName).exe&quot;">
-      <Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
-    </Exec>
-  </Target>
 
   <Import Project="..\libMBIN\libMBIN-Shared.projitems" Label="Shared" />
 

--- a/SaveFileMapping/SaveFileMapping.csproj
+++ b/SaveFileMapping/SaveFileMapping.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <RuntimeIdentifiers>linux-x64;win-x64</RuntimeIdentifiers>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>

--- a/build-net6.bat
+++ b/build-net6.bat
@@ -1,3 +1,2 @@
-dotnet publish -c Release -f net6.0 -r linux-x64 -o Build/Release/net6/ /nowarn:cs0618
-dotnet publish -c Release -f net6.0 -r win-x64 -o Build/Release/net6/ /nowarn:cs0618
+dotnet publish --no-self-contained -c Release -f net6.0 -r win-x64 /nowarn:cs0618
 pause

--- a/build-net6.sh
+++ b/build-net6.sh
@@ -1,2 +1,1 @@
-dotnet publish -c Release -f net6.0 --no-self-contained -r linux-x64 -o Build/Release/net6/ /nowarn:cs0618
-dotnet publish -c Release -f net6.0 --no-self-contained -r win-x64 -o Build/Release/net6/ /nowarn:cs0618
+dotnet publish --no-self-contained -c Release -f net6.0 -r linux-x64 /nowarn:cs0618

--- a/build-net7.bat
+++ b/build-net7.bat
@@ -1,3 +1,2 @@
-dotnet publish -c Release -f net7.0 -r linux-x64 -o Build/Release/net7/ /nowarn:cs0618
-dotnet publish -c Release -f net7.0 -r win-x64 -o Build/Release/net7/ /nowarn:cs0618
+dotnet publish --no-self-contained -c Release -f net7.0 -r win-x64 /nowarn:cs0618
 pause

--- a/build-net7.sh
+++ b/build-net7.sh
@@ -1,2 +1,1 @@
-dotnet publish -c Release -f net7.0 --no-self-contained -r linux-x64 -o Build/Release/net7/ /nowarn:cs0618
-dotnet publish -c Release -f net7.0 --no-self-contained -r win-x64 -o Build/Release/net7/ /nowarn:cs0618
+dotnet publish --no-self-contained -c Release -f net7.0 -r linux-x64 /nowarn:cs0618

--- a/libMBIN-DLL/libMBIN-DLL.csproj
+++ b/libMBIN-DLL/libMBIN-DLL.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>libMBIN</AssemblyName>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
     <Configurations>Release;Debug;Release-XML</Configurations>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
Update the pipeline script to build, test and release artefacts for linux and windows, and for dotnet 6 and 7.
This should also ensure that the SDK used to build the binaries is the earliest so that we have maximum compatibility.
Finally, this should have plenty of flexibility so that when we want to add MacOS builds we should be able to do so relatively easily.