### PR TITLE
Restore pre experimental field order when serialising to exml

### DIFF
--- a/Tools/auto_extract/extractor.py
+++ b/Tools/auto_extract/extractor.py
@@ -241,6 +241,7 @@ class Field(ABC):
         self.data = data
         self.raw_field_type = 0x00
         self.field_size = 0x0
+        self.field_index = 0x0
 
         # properties which are overwritten by subclasses which need to specify
         # them.
@@ -660,6 +661,7 @@ def extract(nms_mem: pymem.Pymem, address: int, field_count: int) -> tuple[list[
     for i in range(field_count):
         data = nms_mem.read_bytes(address + i * 0x60, 0x60)
         field = Field.instantiate(data, nms_mem)
+        field.field_index = i
         # As we add fields, determine if the field is an array with an
         # associated enum. If it is then set a flag.
         if (not has_enum_arrays

--- a/Tools/auto_extract/templates/default/class_template.j2
+++ b/Tools/auto_extract/templates/default/class_template.j2
@@ -16,6 +16,7 @@
             {{ enum_val[1] }}{% if field.requires_values %} = {{enum_val[0] }}{% endif %},
 {%- endfor %}
         }
+        [NMS(Index = {{ field.field_index }})]
         /* {{ field.field_offset }} */ public {{ field.field_name }}Enum {{ field.field_name }};
 {%- elif field._is_array_field %}{# End of enum chunk, start of array chunk #}
 {%- if field.local_enum %}
@@ -26,11 +27,13 @@
 {%- endfor %}
         }
 {%- endif %}
-        [NMS(Size = {{ field.array_size }}{% if field.array_enum_type is not none %}, EnumType = typeof({{ field.array_enum_type }}){% endif %})]
+        [NMS(Index = {{ field.field_index }}, Size = {{ field.array_size }}{% if field.array_enum_type is not none %}, EnumType = typeof({{ field.array_enum_type }}){% endif %})]
         /* {{ field.field_offset }} */ public {{ field.field_type }}[] {{ field.field_name }};
 {%- elif field._is_list_field %}{# End of array chunk, start of list chunk #}
+        [NMS(Index = {{ field.field_index }})]
         /* {{ field.field_offset }} */ public List<{{ field.field_type }}> {{ field.field_name }};
 {%- else %}{# End of array chunk, start of normal field chunk #}
+        [NMS(Index = {{ field.field_index }})]
         /* {{ field.field_offset }} */ public {{ field.field_type }} {{ field.field_name }};
 {%- endif %}
 {%- endfor %}

--- a/libMBIN/Source/Template/NMSAttribute.cs
+++ b/libMBIN/Source/Template/NMSAttribute.cs
@@ -17,5 +17,6 @@ namespace libMBIN
         public ulong NameHash { get; set; }
         public bool Broken { get; set; }
         public bool IDField { get; set; } = false;
+        public int Index { get; set; }
     }
 }

--- a/libMBIN/Source/Template/NMSTemplate.cs
+++ b/libMBIN/Source/Template/NMSTemplate.cs
@@ -1224,7 +1224,7 @@ namespace libMBIN
                 xmlData = new EXmlData { Template = type.Name };
             }
 
-            var fields = type.GetFields().OrderBy(field => field.MetadataToken); // hack to get fields in order of declaration (todo: use something less hacky, this might break mono?)
+            var fields = type.GetFields().OrderBy(field => field.GetCustomAttribute<NMSAttribute>()?.Index ?? 0); // Order fields in declared order
 
             foreach ( var field in fields ) {
 


### PR DESCRIPTION
Take declared field order from the exe and use that to restore field order in exml

I only did some quick testing on this, but it seems to work as expected. The MBINs retain the new ordering