### PR TITLE
Changes to Quaternion (de)serialization

### DIFF
--- a/Tools/auto_extract/templates/default/static_templates/TkAnimNodeFrameData.cs
+++ b/Tools/auto_extract/templates/default/static_templates/TkAnimNodeFrameData.cs
@@ -17,7 +17,6 @@ namespace libMBIN.NMS.Toolkit
         [NMS(Index = 1)]
         /* 0x20 */ public List<Vector4f> Translations;
 
-
         public override object CustomDeserialize(BinaryReader reader, Type field, NMSAttribute settings, FieldInfo fieldInfo) {
             var fieldName = fieldInfo.Name;
 
@@ -40,9 +39,10 @@ namespace libMBIN.NMS.Toolkit
                     // worker values
                     UInt16 c_x, c_y, c_z;
                     UInt16 i_x, i_y;
-                    // a few normalisation/scaling values
-                    float norm = 1.0f / 0x3FFF;
-                    float scale = 1.0f / (float)Math.Sqrt(2.0f);
+                    // The scaling factor. This is slightly different to the one in the exe.
+                    // The value in the exe is 0.000030518509 times some other factors,
+                    // however using this decimal value results in decompiled values which are much more messy.
+                    double scale = 1.0f / (0x3FFF * Math.Sqrt(2.0f));
                     // now, iterate over the input data.
                     // We will read in the data in chunks of 6 bytes
                     for (int i = 0; i < numEntries; i++)
@@ -53,49 +53,42 @@ namespace libMBIN.NMS.Toolkit
                         c_z = reader.ReadUInt16();
 
                         // determine most significant bit (0 or 1)
-                        i_x = (UInt16)(c_x >> 0xF);
+                        i_x = (UInt16)(c_x >> 0xE);
                         i_y = (UInt16)(c_y >> 0xF);
-                        //i_z = (UInt16)(c_z >> 0xF);
 
                         /* dropcomponent indicates which component of the quaternion has been dropped
                         3 -> x
                         2 -> y
                         1 -> z
                         0 -> w */
-                        ushort dropcomponent = (ushort)(i_x << 1 | i_y);
+                        ushort dropcomponent = (ushort)(i_y | i_x & 2);
 
                         //Mask Values (strip most significant bit)
-                        c_x = (UInt16)(c_x & 0x7FFF);
-                        c_y = (UInt16)(c_y & 0x7FFF);
-                        c_z = (UInt16)(c_z & 0x7FFF);
-
-                        Quaternion q = new Quaternion(
-                            (float)((c_x - 0x3FFF) * norm * scale),
-                            (float)((c_y - 0x3FFF) * norm * scale),
-                            (float)((c_z - 0x3FFF) * norm * scale),
-                            0.0f);
+                        double qx = scale * ((c_x & 0x7FFF) - 0x3FFF);
+                        double qy = scale * ((c_y & 0x7FFF) - 0x3FFF);
+                        double qz = scale * (c_z - 0x3FFF);
 
                         //I assume that W is positive by default
-                        q.w = (float)Math.Sqrt(Math.Max(1.0f - q.x * q.x - q.y * q.y - q.z * q.z, 0.0));
+                        double qw = Math.Sqrt(Math.Max(Math.Min(1.0f - qx * qx - qy * qy - qz * qz, 1.0), 0.0));
                         // output Quaternion
                         Quaternion qo;
 
                         switch (dropcomponent)
                             {
                             case 3:     // qx was dropped
-                                qo = new Quaternion(q.w, q.x, q.y, q.z);
+                                qo = new Quaternion(qw, qx, qy, qz, 3 - dropcomponent);
                                 break;
                             case 2:     // qy was dropped
-                                qo = new Quaternion(q.x, q.w, q.y, q.z);
+                                qo = new Quaternion(qx, qw, qy, qz, 3 - dropcomponent);
                                 break;
                             case 1:     // qz was dropped
-                                qo = new Quaternion(q.x, q.y, q.w, q.z);
+                                qo = new Quaternion(qx, qy, qw, qz, 3 - dropcomponent);
                                 break;
                             case 0:     // qw was dropped
-                                qo = new Quaternion(q.x, q.y, q.z, q.w);
+                                qo = new Quaternion(qx, qy, qz, qw, 3 - dropcomponent);
                                 break;
                             default:
-                                qo = new Quaternion(0.0f, 0.0f, 0.0f, 0.0f);        // shouldn't ever get here
+                                qo = new Quaternion(0.0f, 0.0f, 0.0f, 0.0f, 0);        // shouldn't ever get here
                                 break;
                         }
                         data.Add(qo);
@@ -134,12 +127,17 @@ namespace libMBIN.NMS.Toolkit
                     foreach (Quaternion q in data)
                         {
                         List<UInt16> convertedQ = new List<UInt16>
-                        {ConvertQuat(q.x),
-                         ConvertQuat(q.y),
-                         ConvertQuat(q.z),
-                         ConvertQuat(q.w)};
+                        {
+                            ConvertQuat(q.x),
+                            ConvertQuat(q.y),
+                            ConvertQuat(q.z),
+                            ConvertQuat(q.w),
+                        };
 
-                        int dropcomponent = (int)DetermineDropComponent(convertedQ);
+                        // Get the drop component from the value stored in the exml.
+                        // For more details see the comment above the DetermineDropComponent method.
+                        int dropcomponent = q.dropComponent;
+                        // int dropcomponent = DetermineDropComponent(convertedQ);
 
                         // remove the element we wish to discard
                         convertedQ.RemoveAt(dropcomponent);
@@ -165,6 +163,14 @@ namespace libMBIN.NMS.Toolkit
             return false;
         }
 
+        // Note: This function doesn't quite work. There are a few edge cases that it doesn't quite handle.
+        // To get around this we'll just store the dropped component, but if these edge cases can be fixed,
+        // then we can stop storing the drop component and just determine it from the data.
+        // Some bytes which cannot have their drop component determined correctly (little endian):
+        // e475 b01b 601f
+        // ee80 deca 107f
+        // f4e6 388d c672
+        // f3e6 398d c572
         private UInt16 DetermineDropComponent(List<UInt16> arr)
             {
             UInt16 max_loc = 0;        // x by default
@@ -202,7 +208,7 @@ namespace libMBIN.NMS.Toolkit
             return max_loc;
         }
 
-        private UInt16 ConvertQuat(float qi)
+        private UInt16 ConvertQuat(double qi)
             {
             return (UInt16)Math.Round(0x3FFF * (Math.Sqrt(2) * qi + 1));
         }

--- a/libMBIN/Source/NMS/BaseTypes/Quaternion.cs
+++ b/libMBIN/Source/NMS/BaseTypes/Quaternion.cs
@@ -1,22 +1,28 @@
-﻿using libMBIN.NMS.Toolkit;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+
+using libMBIN.NMS.Toolkit;
 using libMBIN.NMS.GameComponents;
 
 namespace libMBIN.NMS
 {
-    [NMS(Size = 0x10, Alignment = 0x2)]
     public class Quaternion : NMSTemplate
     {
-        public float x;
-        public float y;
-        public float z;
-        public float w;
+        public double x;
+        public double y;
+        public double z;
+        public double w;
+        public int dropComponent;
 
-        public Quaternion(float x, float y, float z, float w)
+        public Quaternion(double x, double y, double z, double w, int dropComponent)
         {
             this.x = x;
             this.y = y;
             this.z = z;
             this.w = w;
+            this.dropComponent = dropComponent;
         }
 
         public Quaternion() { }
@@ -29,6 +35,21 @@ namespace libMBIN.NMS
         public override string ToString()
         {
             return $"({this.x}, {this.y}, {this.z}, {this.w})";
+        }
+
+        public override bool CustomSerialize(BinaryWriter writer, Type field, object fieldData, NMSAttribute settings, FieldInfo fieldInfo, ref List<Tuple<long, object>> additionalData, ref int addtDataIndex)
+            {
+            if (field == null || fieldInfo == null)
+                return false;
+
+            switch (fieldInfo.Name)
+                {
+                case nameof(dropComponent):
+                    // Do nothing...
+                    return true;
+            }
+
+            return false;
         }
     }
 }

--- a/libMBIN/Source/NMS/Toolkit/TkAnimNodeFrameData.cs
+++ b/libMBIN/Source/NMS/Toolkit/TkAnimNodeFrameData.cs
@@ -17,7 +17,6 @@ namespace libMBIN.NMS.Toolkit
         [NMS(Index = 1)]
         /* 0x20 */ public List<Vector4f> Translations;
 
-
         public override object CustomDeserialize(BinaryReader reader, Type field, NMSAttribute settings, FieldInfo fieldInfo) {
             var fieldName = fieldInfo.Name;
 
@@ -40,9 +39,10 @@ namespace libMBIN.NMS.Toolkit
                     // worker values
                     UInt16 c_x, c_y, c_z;
                     UInt16 i_x, i_y;
-                    // a few normalisation/scaling values
-                    float norm = 1.0f / 0x3FFF;
-                    float scale = 1.0f / (float)Math.Sqrt(2.0f);
+                    // The scaling factor. This is slightly different to the one in the exe.
+                    // The value in the exe is 0.000030518509 times some other factors,
+                    // however using this decimal value results in decompiled values which are much more messy.
+                    double scale = 1.0f / (0x3FFF * Math.Sqrt(2.0f));
                     // now, iterate over the input data.
                     // We will read in the data in chunks of 6 bytes
                     for (int i = 0; i < numEntries; i++)
@@ -53,49 +53,42 @@ namespace libMBIN.NMS.Toolkit
                         c_z = reader.ReadUInt16();
 
                         // determine most significant bit (0 or 1)
-                        i_x = (UInt16)(c_x >> 0xF);
+                        i_x = (UInt16)(c_x >> 0xE);
                         i_y = (UInt16)(c_y >> 0xF);
-                        //i_z = (UInt16)(c_z >> 0xF);
 
                         /* dropcomponent indicates which component of the quaternion has been dropped
                         3 -> x
                         2 -> y
                         1 -> z
                         0 -> w */
-                        ushort dropcomponent = (ushort)(i_x << 1 | i_y);
+                        ushort dropcomponent = (ushort)(i_y | i_x & 2);
 
                         //Mask Values (strip most significant bit)
-                        c_x = (UInt16)(c_x & 0x7FFF);
-                        c_y = (UInt16)(c_y & 0x7FFF);
-                        c_z = (UInt16)(c_z & 0x7FFF);
-
-                        Quaternion q = new Quaternion(
-                            (float)((c_x - 0x3FFF) * norm * scale),
-                            (float)((c_y - 0x3FFF) * norm * scale),
-                            (float)((c_z - 0x3FFF) * norm * scale),
-                            0.0f);
+                        double qx = scale * ((c_x & 0x7FFF) - 0x3FFF);
+                        double qy = scale * ((c_y & 0x7FFF) - 0x3FFF);
+                        double qz = scale * (c_z - 0x3FFF);
 
                         //I assume that W is positive by default
-                        q.w = (float)Math.Sqrt(Math.Max(1.0f - q.x * q.x - q.y * q.y - q.z * q.z, 0.0));
+                        double qw = Math.Sqrt(Math.Max(Math.Min(1.0f - qx * qx - qy * qy - qz * qz, 1.0), 0.0));
                         // output Quaternion
                         Quaternion qo;
 
                         switch (dropcomponent)
                             {
                             case 3:     // qx was dropped
-                                qo = new Quaternion(q.w, q.x, q.y, q.z);
+                                qo = new Quaternion(qw, qx, qy, qz, 3 - dropcomponent);
                                 break;
                             case 2:     // qy was dropped
-                                qo = new Quaternion(q.x, q.w, q.y, q.z);
+                                qo = new Quaternion(qx, qw, qy, qz, 3 - dropcomponent);
                                 break;
                             case 1:     // qz was dropped
-                                qo = new Quaternion(q.x, q.y, q.w, q.z);
+                                qo = new Quaternion(qx, qy, qw, qz, 3 - dropcomponent);
                                 break;
                             case 0:     // qw was dropped
-                                qo = new Quaternion(q.x, q.y, q.z, q.w);
+                                qo = new Quaternion(qx, qy, qz, qw, 3 - dropcomponent);
                                 break;
                             default:
-                                qo = new Quaternion(0.0f, 0.0f, 0.0f, 0.0f);        // shouldn't ever get here
+                                qo = new Quaternion(0.0f, 0.0f, 0.0f, 0.0f, 0);        // shouldn't ever get here
                                 break;
                         }
                         data.Add(qo);
@@ -134,12 +127,17 @@ namespace libMBIN.NMS.Toolkit
                     foreach (Quaternion q in data)
                         {
                         List<UInt16> convertedQ = new List<UInt16>
-                        {ConvertQuat(q.x),
-                         ConvertQuat(q.y),
-                         ConvertQuat(q.z),
-                         ConvertQuat(q.w)};
+                        {
+                            ConvertQuat(q.x),
+                            ConvertQuat(q.y),
+                            ConvertQuat(q.z),
+                            ConvertQuat(q.w),
+                        };
 
-                        int dropcomponent = (int)DetermineDropComponent(convertedQ);
+                        // Get the drop component from the value stored in the exml.
+                        // For more details see the comment above the DetermineDropComponent method.
+                        int dropcomponent = q.dropComponent;
+                        // int dropcomponent = DetermineDropComponent(convertedQ);
 
                         // remove the element we wish to discard
                         convertedQ.RemoveAt(dropcomponent);
@@ -165,6 +163,14 @@ namespace libMBIN.NMS.Toolkit
             return false;
         }
 
+        // Note: This function doesn't quite work. There are a few edge cases that it doesn't quite handle.
+        // To get around this we'll just store the dropped component, but if these edge cases can be fixed,
+        // then we can stop storing the drop component and just determine it from the data.
+        // Some bytes which cannot have their drop component determined correctly (little endian):
+        // e475 b01b 601f
+        // ee80 deca 107f
+        // f4e6 388d c672
+        // f3e6 398d c572
         private UInt16 DetermineDropComponent(List<UInt16> arr)
             {
             UInt16 max_loc = 0;        // x by default
@@ -202,7 +208,7 @@ namespace libMBIN.NMS.Toolkit
             return max_loc;
         }
 
-        private UInt16 ConvertQuat(float qi)
+        private UInt16 ConvertQuat(double qi)
             {
             return (UInt16)Math.Round(0x3FFF * (Math.Sqrt(2) * qi + 1));
         }

--- a/libMBIN/Source/Template/NMSTemplate.cs
+++ b/libMBIN/Source/Template/NMSTemplate.cs
@@ -1270,6 +1270,8 @@ namespace libMBIN
                     return xmlProperty.Value;
                 case "Single":
                     return float.Parse(xmlProperty.Value);
+                case "Double":
+                    return double.Parse(xmlProperty.Value);
                 case "Boolean":
                     return bool.Parse(xmlProperty.Value);
                 case "Byte":


### PR DESCRIPTION
This (finally) makes anim files deserialize and reserialize 1:1!!!
The changes don't look too drastic, mostly it was changing `float`'s to `double`'s (after all that!)
I also couldn't figure out the improvements to the `DetermineDropComponent` method so that it would cover all the edge cases, so now the drop component is actually written to the exml file. For any downstream users of this data (of which there should be essentially none), this can be ignored.

One main downside of this is that if you want to add new values or modify the existing ones the drop component won't be known, so for the time being, it is still not really recommended that you modify anim files other than to potentially remove values (or use existing `Quaternion` values)