### PR TITLE
Flatten VariableSizeString

### DIFF
--- a/libMBIN/Source/NMS/BaseTypes/VariableSizeString.cs
+++ b/libMBIN/Source/NMS/BaseTypes/VariableSizeString.cs
@@ -4,9 +4,14 @@ using libMBIN.NMS.GameComponents;
 namespace libMBIN.NMS
 {
     [NMS(Size = 0x10, Alignment = 0x1)]
-    public class VariableSizeString : NMSTemplate
+    public class VariableSizeString : NMSTemplate, INMSString
     {
         public string Value;
+
+        public string StringValue()
+        {
+            return this.Value;
+        }
 
         /// <summary>
         /// Returns the value held by this string.
@@ -17,7 +22,14 @@ namespace libMBIN.NMS
             return this.Value;
         }
 
+        public VariableSizeString(string str)
+        {
+            this.Value = str;
+        }
+
+        public VariableSizeString() { }
+
         public static implicit operator VariableSizeString ( string str ) => new VariableSizeString { Value = str };
-		public static implicit operator string ( VariableSizeString str ) => str.Value;
-	}
+        public static implicit operator string ( VariableSizeString str ) => str.Value;
+    }
 }

--- a/libMBIN/Source/Version.cs
+++ b/libMBIN/Source/Version.cs
@@ -25,7 +25,7 @@
         //      the Prerelease version should be reset to 1
         // When the Release version is incremented:
         //      the Prerelease version should be reset to 0
-        internal const string VERSION_STRING = "4.70.0.1";
+        internal const string VERSION_STRING = "4.70.0.2";
 
         /// <summary>Shorthand for AssemblyVersion.Major</summary>
         public static int Major      => AssemblyVersion.Major;


### PR DESCRIPTION
This will flatten `VariableSizeString`'s in the exml so that they appear like regular strings.
This was called for since the scene files now contain many of them so existing lua scripts broke.
This should fix these scripts.

![image](https://github.com/monkeyman192/MBINCompiler/assets/8000597/f0225adb-dd36-427a-9338-a41bf041955b)
