### PR TITLE
Update for experimental - Add Colour32 and most _id and _index attributes

### DIFF
--- a/Tools/auto_extract/extractor.py
+++ b/Tools/auto_extract/extractor.py
@@ -159,7 +159,7 @@ EXTRA_ATTRIBUTES = {
 DONT_OVERRIDE = {
     'TkAnimNodeFrameData': 0xDD8A411B84D2D5DC,
     # 'TkAnimNodeFrameHalfData',
-    'TkGeometryData': 0xED9C2FCDA6D4B22F,
+    'TkGeometryData': 0xE2C133EF90E9F7A3,
     'TkMeshData': 0xA5E773D3424BA9FA,
 }
 
@@ -189,9 +189,9 @@ TYPE_MAPPING = {
     0x0C: 'VariableSizeString',  # Technically a "filename" -> GcFilename (?)
     0x0D: 'FLAGENUM',
     0x0E: 'float',
-    0x0F: 'NMSString0x10',
-    0x10: 'NMSString0x20A',  # There seems to be no difference in use between this
-    0x11: 'NMSString0x20A',  # and this...
+    0x0F: 'NMSString0x10',   # Id
+    0x10: 'NMSString0x20A',  # Id256
+    0x11: 'NMSString0x20A',  # LocId
     0x12: 'sbyte',
     0x13: 'short',
     0x14: 'int',
@@ -219,6 +219,7 @@ TYPE_MAPPING = {
     0x2A: 'halfVector3',
     0x2B: 'TkPhysRelVec3',
     0x2C: 'HashMap',
+    0x2D: 'Colour32',  # 4 channel colour with each channel packed as a byte
 }
 
 TYPE_MAPPING_REV = {value: key for key, value in TYPE_MAPPING.items()}

--- a/Tools/auto_extract/extractor.py
+++ b/Tools/auto_extract/extractor.py
@@ -232,22 +232,21 @@ PREFIX_MAPPING = {
 
 
 """
-Details on the format of the 0x60 bytes for each field (from cTkMetaDataMember definition):
+Details on the format of the 0x58 bytes for each field (from cTkMetaDataMember definition):
 
 0x00: char *mpacName;
 0x08: unsigned int miNameHash;
-0x10: char *mpacCategoryName;
-0x18: unsigned int miCategoryHash;
-0x1C: cTkMetaDataMember::eType mType;
-0x20: cTkMetaDataMember::eType mInnerType;
-0x24: int miSize;
-0x28: int miCount;
-0x2C: int miOffset;
-0x30: cTkMetaDataClass *mpClassMetadata;
-0x38: cTkMetaDataEnumLookup *mpEnumLookup;
-0x40: int miNumEnumMembers;
-0x44: FloatEditOptions mFloatEditOptions;
-0x50: FloatLimits mFloatLimits;
+0x0C: cTkMetaDataMember::eType mType;
+0x10: cTkMetaDataMember::eType mInnerType;
+0x14: int miSize;
+0x18: int miCount;
+0x1C: int miOffset;
+0x20: cTkMetaDataClass *mpClassMetadata;
+0x28: char *mpIdField;
+0x30: cTkMetaDataEnumLookup *mpEnumLookup;
+0x38: int miNumEnumMembers;
+0x3C: FloatEditOptions mFloatEditOptions;
+0x48: FloatLimits mFloatLimits;
 
 0x00: (uint64*) pointer to the name of the field. This is null-terminated.
 0x08: ???
@@ -311,9 +310,9 @@ class Field(ABC):
         # Some field names are annoyingly duplicated in the exe. c# doesn't
         # allow this, so we need to add something to the name to make it unique.
         self._field_name_is_duplicate = False
-        self.field_size = struct.unpack_from('<I', data, offset=0x24)[0]
-        self._array_size = struct.unpack_from('<I', data, offset=0x28)[0]
-        self._field_offset = int(struct.unpack_from('<I', data, offset=0x2C)[0])
+        self.field_size = struct.unpack_from('<I', data, offset=0x14)[0]
+        self._array_size = struct.unpack_from('<I', data, offset=0x18)[0]
+        self._field_offset = int(struct.unpack_from('<I', data, offset=0x1C)[0])
 
         # Sort out the requirements for this field.
         self.required_using: set = set()
@@ -361,7 +360,7 @@ class Field(ABC):
         This allows us to simplify the logic regarding deserialising the field
         by deferring it to the individual classes.
         """
-        raw_type = struct.unpack_from('<I', data, offset=0x1C)[0]
+        raw_type = struct.unpack_from('<I', data, offset=0xC)[0]
         if raw_type == TYPE_MAPPING_REV['ENUM'] or raw_type == TYPE_MAPPING_REV['FLAGENUM']:
             ef = EnumField(data, nms_mem)
             if raw_type == TYPE_MAPPING_REV['FLAGENUM']:
@@ -393,7 +392,7 @@ class CustomField(Field):
 
         # Get the pointer to the custom type name.
         ptr_custom_type = nms_mem.read_ulonglong(
-            struct.unpack_from('<Q', data, offset=0x30)[0]
+            struct.unpack_from('<Q', data, offset=0x20)[0]
         )
         # Now get the actual name.
         self._field_type = nms_mem.read_string(ptr_custom_type, byte=128)[1:]
@@ -423,11 +422,11 @@ class HashMapField(Field):
         self._is_hash_map_field = True
         self.local_enum = False
 
-        array_type_raw = struct.unpack_from('<I', data, offset=0x20)[0]
+        array_type_raw = struct.unpack_from('<I', data, offset=0x10)[0]
         # A custom array subtype.
         if array_type_raw == TYPE_MAPPING_REV['CUSTOM']:
             ptr_custom_type = nms_mem.read_ulonglong(
-                struct.unpack_from('<Q', data, offset=0x30)[0]
+                struct.unpack_from('<Q', data, offset=0x20)[0]
             )
             self._field_type = nms_mem.read_string(ptr_custom_type, byte=128)[1:]
             self.required_using.add(
@@ -439,7 +438,7 @@ class HashMapField(Field):
                 array_type_raw, f'unknown {array_type_raw:X}'
             )
         # Determine the associated EnumType
-        self.ptr_enum = struct.unpack_from('<Q', data, offset=0x38)[0]
+        self.ptr_enum = struct.unpack_from('<Q', data, offset=0x30)[0]
         # This may be a nullptr, in which case we end as we have no enum to get.
         if self.ptr_enum == 0:
             return
@@ -456,6 +455,12 @@ class HashMapField(Field):
             if name in RESTRICTED_NAMES:
                 name = name.capitalize()
             self.array_enum.append(name)
+
+        # Check to see if we have an IdField defined
+        idField_ptr = struct.unpack_from('<Q', data, offset=0x28)[0]
+        if idField_ptr != 0:
+            idField: str = nms_mem.read_string(ptr_enum_name, byte=128)
+            print(f"{self.field_name} has an ID field: {idField}")
 
     @property
     def field_type(self):
@@ -474,11 +479,11 @@ class ArrayField(Field):
         self._is_array_field = True
         self.local_enum = False
 
-        array_type_raw = struct.unpack_from('<I', data, offset=0x20)[0]
+        array_type_raw = struct.unpack_from('<I', data, offset=0x10)[0]
         # A custom array subtype.
         if array_type_raw == TYPE_MAPPING_REV['CUSTOM']:
             ptr_custom_type = nms_mem.read_ulonglong(
-                struct.unpack_from('<Q', data, offset=0x30)[0]
+                struct.unpack_from('<Q', data, offset=0x20)[0]
             )
             self._field_type = nms_mem.read_string(ptr_custom_type, byte=128)[1:]
             self.required_using.add(
@@ -490,7 +495,7 @@ class ArrayField(Field):
                 array_type_raw, f'unknown {array_type_raw:X}'
             )
         # Determine the associated EnumType
-        self.ptr_enum = struct.unpack_from('<Q', data, offset=0x38)[0]
+        self.ptr_enum = struct.unpack_from('<Q', data, offset=0x30)[0]
         # This may be a nullptr, in which case we end as we have no enum to get.
         if self.ptr_enum == 0:
             return
@@ -521,11 +526,15 @@ class ListField(Field):
         self.required_using.add('System.Collections.Generic')
         self._is_list_field = True
 
-        array_type_raw = struct.unpack_from('<I', data, offset=0x20)[0]
+        array_type_raw = struct.unpack_from('<I', data, offset=0x10)[0]
         if array_type_raw == 0x03:
-            ptr_custom_type = nms_mem.read_ulonglong(
-                struct.unpack_from('<Q', data, offset=0x30)[0]
-            )
+            try:
+                ptr_custom_type = nms_mem.read_ulonglong(
+                    struct.unpack_from('<Q', data, offset=0x20)[0]
+                )
+            except:
+                print(self.field_name)
+                raise
             self._field_type = nms_mem.read_string(ptr_custom_type, byte=128)[1:]
             self.required_using.add(
                 constants.USING_MAPPING.get(self._field_type[:2].lower(),
@@ -549,8 +558,8 @@ class EnumField(Field):
         self.requires_values = False
         self._is_enum_field = True
 
-        enum_count = struct.unpack_from('<I', data, offset=0x40)[0]
-        self.ptr_enum = struct.unpack_from('<Q', data, offset=0x38)[0]
+        enum_count = struct.unpack_from('<I', data, offset=0x38)[0]
+        self.ptr_enum = struct.unpack_from('<Q', data, offset=0x30)[0]
         self.enum_data = []
         # For each enum value, read the index, and a pointer to the name.
         for i in range(enum_count):
@@ -769,11 +778,11 @@ def read_class(
 
 
 def extract(nms_mem: pymem.Pymem, address: int, field_count: int) -> tuple[list[Field], bool]:
-    # Take the 0x60 bytes and process them.
+    # Take the 0x58 bytes and process them.
     fields = []
     has_enum_arrays = False
     for i in range(field_count):
-        data = nms_mem.read_bytes(address + i * 0x60, 0x60)
+        data = nms_mem.read_bytes(address + i * 0x58, 0x58)
         field = Field.instantiate(data, nms_mem)
         field.field_index = i
         # As we add fields, determine if the field is an array with an

--- a/Tools/auto_extract/templates/default/libMBIN-Shared.projitems.j2
+++ b/Tools/auto_extract/templates/default/libMBIN-Shared.projitems.j2
@@ -28,6 +28,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Source\MBIN\MBINFile.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Source\MBIN\MBINHeader.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Source\NMS\BaseTypes\Colour.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Source\NMS\BaseTypes\Colour32.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Source\NMS\BaseTypes\OptionalVariableSizeString.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Source\NMS\BaseTypes\HashMap.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Source\NMS\BaseTypes\halfVector3.cs" />

--- a/Tools/auto_extract/templates/default/static_templates/TkGeometryData.cs
+++ b/Tools/auto_extract/templates/default/static_templates/TkGeometryData.cs
@@ -6,7 +6,7 @@ using System.Reflection;
 
 namespace libMBIN.NMS.Toolkit
 {
-    [NMS(GUID = 0xED9C2FCDA6D4B22F, NameHash = 0x819C3220)]
+    [NMS(GUID = 0xE2C133EF90E9F7A3, NameHash = 0x819C3220)]
     public class TkGeometryData : NMSTemplate
     {
         [NMS(Index = 20)]

--- a/libMBIN/Source/MXML/MXmlProperty.cs
+++ b/libMBIN/Source/MXML/MXmlProperty.cs
@@ -9,10 +9,10 @@ namespace libMBIN
         public string Value { get; set; }
         [XmlAttribute("linked")]
         public string Linked { get; set; }
-        [XmlAttribute("_index")]
-        public string Index { get; set; }
         [XmlAttribute("_id")]
         public string ID { get; set; }
+        [XmlAttribute("_index")]
+        public string Index { get; set; }
 
         public override string ToString()
         {

--- a/libMBIN/Source/MXML/MXmlProperty.cs
+++ b/libMBIN/Source/MXML/MXmlProperty.cs
@@ -8,7 +8,11 @@ namespace libMBIN
         [XmlAttribute("value")]
         public string Value { get; set; }
         [XmlAttribute("linked")]
-        public string Linked {get; set; }
+        public string Linked { get; set; }
+        [XmlAttribute("_index")]
+        public string Index { get; set; }
+        [XmlAttribute("_id")]
+        public string ID { get; set; }
 
         public override string ToString()
         {

--- a/libMBIN/Source/NMS/BaseTypes/Colour32.cs
+++ b/libMBIN/Source/NMS/BaseTypes/Colour32.cs
@@ -1,0 +1,69 @@
+﻿using libMBIN.Source.Common;
+using System;
+
+namespace libMBIN.NMS
+{
+    /// <summary>
+    /// This class is a simple colour one. The values of each field must be between 0 and 1.
+    /// To convert from the usual representation of a value between 0 and 255, you just need to divide the value
+    /// by 255 to get the floating point representation used by the game.
+    /// </summary>
+    [NMS(Alignment = 0x4, Size = 0x4)]
+    public class Colour32 : NMSTemplate
+    {
+        /// <summary>
+        /// The Red component of the colour.
+        /// </summary>
+        public float R;
+
+        /// <summary>
+        /// The Green component of the colour.
+        /// </summary>
+        public float G;
+
+        /// <summary>
+        /// The Blue component of the colour.
+        /// </summary>
+        public float B;
+
+        /// <summary>
+        /// The Alpha component of the colour.
+        /// </summary>
+        public float A;
+
+
+        /// <summary>
+        /// Creates a Colour while providing it with float RGB values.
+        /// <br/>Values must be between 0 - 1.
+        /// </summary>
+        /// <param name="R">Red component of the colour. Value can be anything between 0 and 1.</param>
+        /// <param name="G">Green component of the colour. Value can be anything between 0 and 1.</param>
+        /// <param name="B">Blue component of the colour. Value can be anything between 0 and 1.</param>
+        /// <param name="A">Alpha component of the colour. Value can be anything between 0 and 1.</param>
+        public Colour32(float R, float G, float B, float A = 1f)
+        {
+            this.R = R;
+            this.G = G;
+            this.B = B;
+            this.A = A;
+        }
+
+        /// <summary>
+        /// Creates a Colour while providing it with standard RGB values.
+        /// <br/>Values must be whole numbers between 0 - 255.
+        /// </summary>
+        /// <param name="R">Red component of the colour. Value can be any whole number between 0 and 255.</param>
+        /// <param name="G">Green component of the colour. Value can be any whole number between 0 and 255.</param>
+        /// <param name="B">Blue component of the colour. Value can be any whole number between 0 and 255.</param>
+        /// <param name="A">Alpha component of the colour. Value can be any whole number between 0 and 255.</param>
+        public Colour32(byte R, byte G, byte B, byte A = 255)
+        {
+            this.R = R / 255f;
+            this.G = G / 255f;
+            this.B = B / 255f;
+            this.A = A / 255f;
+        }
+
+        public Colour32() { }
+    }
+}

--- a/libMBIN/Source/NMS/GameComponents/GcCameraFollowSettings.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcCameraFollowSettings.cs
@@ -1,15 +1,15 @@
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0xC75CC88ABAB0A7E, NameHash = 0x932D2ED5)]
+    [NMS(GUID = 0x84058ACCFDF28B8B, NameHash = 0x932D2ED5)]
     public class GcCameraFollowSettings : NMSTemplate
     {
         [NMS(Index = 0)]
         /* 0x00 */ public NMSString0x10 Name;
-        [NMS(Index = 55)]
-        /* 0x10 */ public float AvoidCollisionLRSpeed;
-        [NMS(Index = 57)]
-        /* 0x14 */ public float AvoidCollisionPushSpeed;
         [NMS(Index = 56)]
+        /* 0x10 */ public float AvoidCollisionLRSpeed;
+        [NMS(Index = 58)]
+        /* 0x14 */ public float AvoidCollisionPushSpeed;
+        [NMS(Index = 57)]
         /* 0x18 */ public float AvoidCollisionUDSpeed;
         [NMS(Index = 9)]
         /* 0x1C */ public float BackMaxDistance;
@@ -29,7 +29,7 @@ namespace libMBIN.NMS.GameComponents
         /* 0x38 */ public float CenterStartSpeed;
         [NMS(Index = 36)]
         /* 0x3C */ public float CenterStartTime;
-        [NMS(Index = 62)]
+        [NMS(Index = 63)]
         /* 0x40 */ public float CustomBlendTime;
         [NMS(Index = 31)]
         /* 0x44 */ public float DistSpeed;
@@ -43,91 +43,93 @@ namespace libMBIN.NMS.GameComponents
         /* 0x54 */ public float LeftMaxDistance;
         [NMS(Index = 17)]
         /* 0x58 */ public float LeftMinDistance;
-        [NMS(Index = 44)]
-        /* 0x5C */ public float LookStickLimitAngle;
-        [NMS(Index = 48)]
-        /* 0x60 */ public float LRProbesRadius;
-        [NMS(Index = 47)]
-        /* 0x64 */ public float LRProbesRange;
-        [NMS(Index = 1)]
-        /* 0x68 */ public float MinSpeed;
-        [NMS(Index = 46)]
-        /* 0x6C */ public int NumLRProbes;
-        [NMS(Index = 49)]
-        /* 0x70 */ public int NumUDProbes;
-        [NMS(Index = 3)]
-        /* 0x74 */ public float OffsetX;
-        [NMS(Index = 4)]
-        /* 0x78 */ public float OffsetY;
-        [NMS(Index = 5)]
-        /* 0x7C */ public float OffsetYAlt;
-        [NMS(Index = 19)]
-        /* 0x80 */ public float OffsetYExtraMaxDistance;
-        [NMS(Index = 6)]
-        /* 0x84 */ public float OffsetYSlopeExtra;
-        [NMS(Index = 7)]
-        /* 0x88 */ public float OffsetZFlat;
-        [NMS(Index = 21)]
-        /* 0x8C */ public float PanFar;
-        [NMS(Index = 20)]
-        /* 0x90 */ public float PanNear;
-        [NMS(Index = 51)]
-        /* 0x94 */ public float ProbeCenterX;
-        [NMS(Index = 52)]
-        /* 0x98 */ public float ProbeCenterY;
-        [NMS(Index = 53)]
-        /* 0x9C */ public float PushForwardDropoffLR;
-        [NMS(Index = 54)]
-        /* 0xA0 */ public float PushForwardDropoffUD;
-        [NMS(Index = 2)]
-        /* 0xA4 */ public float SpeedRange;
-        [NMS(Index = 34)]
-        /* 0xA8 */ public float SpringSpeed;
-        [NMS(Index = 50)]
-        /* 0xAC */ public float UDProbesRange;
-        [NMS(Index = 22)]
-        /* 0xB0 */ public float UpGamma;
-        [NMS(Index = 13)]
-        /* 0xB4 */ public float UpMaxDistance;
-        [NMS(Index = 12)]
-        /* 0xB8 */ public float UpMinDistance;
-        [NMS(Index = 14)]
-        /* 0xBC */ public float UpSlopeAdjust;
-        [NMS(Index = 15)]
-        /* 0xC0 */ public float UpWaveAdjust;
-        [NMS(Index = 16)]
-        /* 0xC4 */ public float UpWaveAdjustMaxHeight;
-        [NMS(Index = 40)]
-        /* 0xC8 */ public float VelocityAnticipate;
-        [NMS(Index = 41)]
-        /* 0xCC */ public float VelocityAnticipateSpringSpeed;
-        [NMS(Index = 42)]
-        /* 0xD0 */ public float VertMaxSpring;
-        [NMS(Index = 26)]
-        /* 0xD4 */ public float VertRotationMax;
-        [NMS(Index = 25)]
-        /* 0xD8 */ public float VertRotationMin;
-        [NMS(Index = 27)]
-        /* 0xDC */ public float VertRotationOffset;
-        [NMS(Index = 29)]
-        /* 0xE0 */ public float VertRotationOffsetMaxAngle;
-        [NMS(Index = 28)]
-        /* 0xE4 */ public float VertRotationOffsetMinAngle;
-        [NMS(Index = 24)]
-        /* 0xE8 */ public float VertRotationSpeed;
-        [NMS(Index = 59)]
-        /* 0xEC */ public bool AvoidCollisionLRUseStickDelay;
-        [NMS(Index = 58)]
-        /* 0xED */ public bool AvoidCollisionUDUseStickDelay;
         [NMS(Index = 45)]
-        /* 0xEE */ public bool EnableCollisionDetection;
-        [NMS(Index = 35)]
-        /* 0xEF */ public bool LockToObjectOnIdle;
-        [NMS(Index = 61)]
-        /* 0xF0 */ public bool UseCustomBlendTime;
+        /* 0x5C */ public float LookStickLimitAngle;
+        [NMS(Index = 49)]
+        /* 0x60 */ public float LRProbesRadius;
+        [NMS(Index = 48)]
+        /* 0x64 */ public float LRProbesRange;
+        [NMS(Index = 44)]
+        /* 0x68 */ public float MinMoveVelToTriggerSpring;
+        [NMS(Index = 1)]
+        /* 0x6C */ public float MinSpeed;
+        [NMS(Index = 47)]
+        /* 0x70 */ public int NumLRProbes;
+        [NMS(Index = 50)]
+        /* 0x74 */ public int NumUDProbes;
+        [NMS(Index = 3)]
+        /* 0x78 */ public float OffsetX;
+        [NMS(Index = 4)]
+        /* 0x7C */ public float OffsetY;
+        [NMS(Index = 5)]
+        /* 0x80 */ public float OffsetYAlt;
+        [NMS(Index = 19)]
+        /* 0x84 */ public float OffsetYExtraMaxDistance;
+        [NMS(Index = 6)]
+        /* 0x88 */ public float OffsetYSlopeExtra;
+        [NMS(Index = 7)]
+        /* 0x8C */ public float OffsetZFlat;
+        [NMS(Index = 21)]
+        /* 0x90 */ public float PanFar;
+        [NMS(Index = 20)]
+        /* 0x94 */ public float PanNear;
+        [NMS(Index = 52)]
+        /* 0x98 */ public float ProbeCenterX;
+        [NMS(Index = 53)]
+        /* 0x9C */ public float ProbeCenterY;
+        [NMS(Index = 54)]
+        /* 0xA0 */ public float PushForwardDropoffLR;
+        [NMS(Index = 55)]
+        /* 0xA4 */ public float PushForwardDropoffUD;
+        [NMS(Index = 2)]
+        /* 0xA8 */ public float SpeedRange;
+        [NMS(Index = 34)]
+        /* 0xAC */ public float SpringSpeed;
+        [NMS(Index = 51)]
+        /* 0xB0 */ public float UDProbesRange;
+        [NMS(Index = 22)]
+        /* 0xB4 */ public float UpGamma;
+        [NMS(Index = 13)]
+        /* 0xB8 */ public float UpMaxDistance;
+        [NMS(Index = 12)]
+        /* 0xBC */ public float UpMinDistance;
+        [NMS(Index = 14)]
+        /* 0xC0 */ public float UpSlopeAdjust;
+        [NMS(Index = 15)]
+        /* 0xC4 */ public float UpWaveAdjust;
+        [NMS(Index = 16)]
+        /* 0xC8 */ public float UpWaveAdjustMaxHeight;
+        [NMS(Index = 40)]
+        /* 0xCC */ public float VelocityAnticipate;
+        [NMS(Index = 41)]
+        /* 0xD0 */ public float VelocityAnticipateSpringSpeed;
+        [NMS(Index = 42)]
+        /* 0xD4 */ public float VertMaxSpring;
+        [NMS(Index = 26)]
+        /* 0xD8 */ public float VertRotationMax;
+        [NMS(Index = 25)]
+        /* 0xDC */ public float VertRotationMin;
+        [NMS(Index = 27)]
+        /* 0xE0 */ public float VertRotationOffset;
+        [NMS(Index = 29)]
+        /* 0xE4 */ public float VertRotationOffsetMaxAngle;
+        [NMS(Index = 28)]
+        /* 0xE8 */ public float VertRotationOffsetMinAngle;
+        [NMS(Index = 24)]
+        /* 0xEC */ public float VertRotationSpeed;
         [NMS(Index = 60)]
-        /* 0xF1 */ public bool UseSpeedBasedSpring;
+        /* 0xF0 */ public bool AvoidCollisionLRUseStickDelay;
+        [NMS(Index = 59)]
+        /* 0xF1 */ public bool AvoidCollisionUDUseStickDelay;
+        [NMS(Index = 46)]
+        /* 0xF2 */ public bool EnableCollisionDetection;
+        [NMS(Index = 35)]
+        /* 0xF3 */ public bool LockToObjectOnIdle;
+        [NMS(Index = 62)]
+        /* 0xF4 */ public bool UseCustomBlendTime;
+        [NMS(Index = 61)]
+        /* 0xF5 */ public bool UseSpeedBasedSpring;
         [NMS(Index = 30)]
-        /* 0xF2 */ public bool VertStartLookingDown;
+        /* 0xF6 */ public bool VertStartLookingDown;
     }
 }

--- a/libMBIN/Source/NMS/GameComponents/GcCollisionTable.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcCollisionTable.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0x528D5131F27A4192, NameHash = 0x36E3583)]
+    [NMS(GUID = 0x84F2728DF073D73A, NameHash = 0x36E3583)]
     public class GcCollisionTable : NMSTemplate
     {
         [NMS(Index = 0)]

--- a/libMBIN/Source/NMS/GameComponents/GcCreatureRoleData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcCreatureRoleData.cs
@@ -2,7 +2,7 @@ using libMBIN.NMS.GameComponents;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0xA31ED3B06AB5F107, NameHash = 0x58E509FD)]
+    [NMS(GUID = 0xF9E3BF5F8C3A03FB, NameHash = 0x58E509FD)]
     public class GcCreatureRoleData : NMSTemplate
     {
         [NMS(Index = 4)]

--- a/libMBIN/Source/NMS/GameComponents/GcCreatureRoleDataTable.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcCreatureRoleDataTable.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0xEC6AE5A26824F07E, NameHash = 0xF744FEF1)]
+    [NMS(GUID = 0xFDF6B5348B67912D, NameHash = 0xF744FEF1)]
     public class GcCreatureRoleDataTable : NMSTemplate
     {
         [NMS(Index = 0)]

--- a/libMBIN/Source/NMS/GameComponents/GcCreatureRoleDescription.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcCreatureRoleDescription.cs
@@ -2,7 +2,7 @@ using libMBIN.NMS.GameComponents;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0x4E3B462272631D3D, NameHash = 0x4DA14594)]
+    [NMS(GUID = 0x4F9C1A9868351C48, NameHash = 0x4DA14594)]
     public class GcCreatureRoleDescription : NMSTemplate
     {
         [NMS(Index = 12)]

--- a/libMBIN/Source/NMS/GameComponents/GcCreatureRoleDescriptionTable.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcCreatureRoleDescriptionTable.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0x31658E9C354D1733, NameHash = 0xFEAF8B28)]
+    [NMS(GUID = 0x44FA048F72B7FA57, NameHash = 0xFEAF8B28)]
     public class GcCreatureRoleDescriptionTable : NMSTemplate
     {
         [NMS(Index = 0)]

--- a/libMBIN/Source/NMS/GameComponents/GcDebugScene.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcDebugScene.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0x2EBD8D1BB86ADBD, NameHash = 0xF6B8782)]
+    [NMS(GUID = 0xFD3C9DDA11C3BC86, NameHash = 0xF6B8782)]
     public class GcDebugScene : NMSTemplate
     {
         [NMS(Index = 75, Size = 0x6)]

--- a/libMBIN/Source/NMS/GameComponents/GcDefaultSaveData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcDefaultSaveData.cs
@@ -2,7 +2,7 @@ using libMBIN.NMS.GameComponents;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0xCEAA0293F88FFA98, NameHash = 0xF989045F)]
+    [NMS(GUID = 0x9AE481751BAD9F6C, NameHash = 0xF989045F)]
     public class GcDefaultSaveData : NMSTemplate
     {
         [NMS(Index = 0)]

--- a/libMBIN/Source/NMS/GameComponents/GcEnvironmentSpawnData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcEnvironmentSpawnData.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0x7FF38F5E9493B6ED, NameHash = 0x9776A7F7)]
+    [NMS(GUID = 0x613A9AFECEEB63AB, NameHash = 0x9776A7F7)]
     public class GcEnvironmentSpawnData : NMSTemplate
     {
         [NMS(Index = 0)]

--- a/libMBIN/Source/NMS/GameComponents/GcExternalObjectList.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcExternalObjectList.cs
@@ -2,7 +2,7 @@ using libMBIN.NMS.GameComponents;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0x5D0765F292AAFB, NameHash = 0xA5E5246F)]
+    [NMS(GUID = 0xE264E9CF58569C75, NameHash = 0xA5E5246F)]
     public class GcExternalObjectList : NMSTemplate
     {
         [NMS(Index = 0)]

--- a/libMBIN/Source/NMS/GameComponents/GcMissionTable.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcMissionTable.cs
@@ -1,12 +1,11 @@
 using libMBIN.NMS.GameComponents;
-using System.Collections.Generic;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0xC0F37F4F313F0B8D, NameHash = 0x4E2556EB)]
+    [NMS(GUID = 0x156C71F266F647C6, NameHash = 0x4E2556EB)]
     public class GcMissionTable : NMSTemplate
     {
         [NMS(Index = 0)]
-        /* 0x0 */ public List<GcGenericMissionSequence> Missions;
+        /* 0x0 */ public HashMap<GcGenericMissionSequence> Missions;
     }
 }

--- a/libMBIN/Source/NMS/GameComponents/GcModBasePart.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcModBasePart.cs
@@ -2,7 +2,7 @@ using libMBIN.NMS.GameComponents;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0xFF85091DB7CB8869, NameHash = 0xEE9DB27A)]
+    [NMS(GUID = 0xE73F919B68A05A84, NameHash = 0xEE9DB27A)]
     public class GcModBasePart : NMSTemplate
     {
         [NMS(Index = 1)]

--- a/libMBIN/Source/NMS/GameComponents/GcModelViewCollection.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcModelViewCollection.cs
@@ -3,10 +3,10 @@ using libMBIN.NMS.GameComponents;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0x711A0264DD1002D6, NameHash = 0xA5C6254C)]
+    [NMS(GUID = 0x557F9F1CF91A2D2F, NameHash = 0xA5C6254C)]
     public class GcModelViewCollection : NMSTemplate
     {
-        [NMS(Index = 0, Size = 0x30, EnumType = typeof(GcModelViews.ModelViewsEnum))]
+        [NMS(Index = 0, Size = 0x31, EnumType = typeof(GcModelViews.ModelViewsEnum))]
         /* 0x0 */ public TkModelRendererData[] ModelViewData;
     }
 }

--- a/libMBIN/Source/NMS/GameComponents/GcModelViews.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcModelViews.cs
@@ -1,11 +1,12 @@
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0x94F827A6B17429F2, NameHash = 0x69104096)]
+    [NMS(GUID = 0xD33BED5F7DEAE49C, NameHash = 0x69104096)]
     public class GcModelViews : NMSTemplate
     {
-        // size: 0x30
+        // size: 0x31
         public enum ModelViewsEnum : uint {
             Suit,
+            SplitSuit,
             SuitWithCape,
             Weapon,
             Ship,

--- a/libMBIN/Source/NMS/GameComponents/GcNGuiGraphicData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcNGuiGraphicData.cs
@@ -3,16 +3,16 @@ using libMBIN.NMS.GameComponents;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0x7A68031D4DE8C733, NameHash = 0xB38C6150)]
+    [NMS(GUID = 0x445168033EDC9651, NameHash = 0xB38C6150)]
     public class GcNGuiGraphicData : NMSTemplate
     {
-        [NMS(Index = 1)]
-        /* 0x000 */ public TkNGuiGraphicStyle Style;
         [NMS(Index = 0, MxmlName = "Element Data")]
-        /* 0x240 */ public GcNGuiElementData ElementData;
+        /* 0x000 */ public GcNGuiElementData ElementData;
         [NMS(Index = 2)]
-        /* 0x2A8 */ public VariableSizeString Image;
+        /* 0x068 */ public VariableSizeString Image;
+        [NMS(Index = 1)]
+        /* 0x078 */ public TkNGuiGraphicStyle Style;
         [NMS(Index = 3)]
-        /* 0x2B8 */ public float Angle;
+        /* 0x1F8 */ public float Angle;
     }
 }

--- a/libMBIN/Source/NMS/GameComponents/GcNGuiLayerData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcNGuiLayerData.cs
@@ -4,19 +4,19 @@ using System.Collections.Generic;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0x39E3571F52A35BD6, NameHash = 0xA151C99F)]
+    [NMS(GUID = 0x1741B0AD04B60F1D, NameHash = 0xA151C99F)]
     public class GcNGuiLayerData : NMSTemplate
     {
-        [NMS(Index = 1)]
-        /* 0x000 */ public TkNGuiGraphicStyle Style;
         [NMS(Index = 0, MxmlName = "Element Data")]
-        /* 0x240 */ public GcNGuiElementData ElementData;
+        /* 0x000 */ public GcNGuiElementData ElementData;
         [NMS(Index = 3)]
-        /* 0x2A8 */ public List<NMSTemplate> Children;
+        /* 0x068 */ public List<NMSTemplate> Children;
         [NMS(Index = 4)]
-        /* 0x2B8 */ public VariableSizeString DataFilename;
+        /* 0x078 */ public VariableSizeString DataFilename;
         [NMS(Index = 2)]
-        /* 0x2C8 */ public VariableSizeString Image;
+        /* 0x088 */ public VariableSizeString Image;
+        [NMS(Index = 1)]
+        /* 0x098 */ public TkNGuiGraphicStyle Style;
         // size: 0x5
         public enum AltModeEnum : uint {
             None,
@@ -26,6 +26,6 @@ namespace libMBIN.NMS.GameComponents
             OnlyOnTouch,
         }
         [NMS(Index = 5)]
-        /* 0x2D8 */ public AltModeEnum AltMode;
+        /* 0x218 */ public AltModeEnum AltMode;
     }
 }

--- a/libMBIN/Source/NMS/GameComponents/GcNGuiPreset.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcNGuiPreset.cs
@@ -2,18 +2,18 @@ using libMBIN.NMS.GameComponents;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0xB04E6E9B4E13858B, NameHash = 0x1EF39842)]
+    [NMS(GUID = 0x7454F79847C74C2E, NameHash = 0x1EF39842)]
     public class GcNGuiPreset : NMSTemplate
     {
         [NMS(Index = 3, Size = 0xA)]
         /* 0x0000 */ public GcNGuiPresetText[] Text;
         [NMS(Index = 2, Size = 0xA)]
-        /* 0x2620 */ public GcNGuiPresetGraphic[] Graphic;
+        /* 0x1950 */ public GcNGuiPresetGraphic[] Graphic;
         [NMS(Index = 1, Size = 0xA)]
-        /* 0x4100 */ public GcNGuiPresetGraphic[] Layer;
+        /* 0x2C60 */ public GcNGuiPresetGraphic[] Layer;
         [NMS(Index = 4, MxmlName = "Spacing Layout")]
-        /* 0x5BE0 */ public GcNGuiLayoutData SpacingLayout;
+        /* 0x3F70 */ public GcNGuiLayoutData SpacingLayout;
         [NMS(Index = 0)]
-        /* 0x5C28 */ public VariableSizeString Font;
+        /* 0x3FB8 */ public VariableSizeString Font;
     }
 }

--- a/libMBIN/Source/NMS/GameComponents/GcNGuiPresetGraphic.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcNGuiPresetGraphic.cs
@@ -3,16 +3,16 @@ using libMBIN.NMS.GameComponents;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0x14A9D3CA83B277C4, NameHash = 0xA40EDAE)]
+    [NMS(GUID = 0x3432E398D287A64D, NameHash = 0xA40EDAE)]
     public class GcNGuiPresetGraphic : NMSTemplate
     {
-        [NMS(Index = 2)]
-        /* 0x000 */ public TkNGuiGraphicStyle Style;
         [NMS(Index = 1)]
-        /* 0x240 */ public GcNGuiLayoutData Layout;
+        /* 0x00 */ public GcNGuiLayoutData Layout;
         [NMS(Index = 3)]
-        /* 0x288 */ public VariableSizeString Image;
+        /* 0x48 */ public VariableSizeString Image;
         [NMS(Index = 0)]
-        /* 0x298 */ public NMSString0x10 PresetID;
+        /* 0x58 */ public NMSString0x10 PresetID;
+        [NMS(Index = 2)]
+        /* 0x68 */ public TkNGuiGraphicStyle Style;
     }
 }

--- a/libMBIN/Source/NMS/GameComponents/GcNGuiPresetText.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcNGuiPresetText.cs
@@ -3,18 +3,18 @@ using libMBIN.NMS.GameComponents;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0x49350F77FBF25252, NameHash = 0x1D0BA017)]
+    [NMS(GUID = 0x9CBAC4C68AC118E4, NameHash = 0x1D0BA017)]
     public class GcNGuiPresetText : NMSTemplate
     {
-        [NMS(Index = 3, MxmlName = "Graphic Style")]
-        /* 0x000 */ public TkNGuiGraphicStyle GraphicStyle;
-        [NMS(Index = 2)]
-        /* 0x240 */ public TkNGuiTextStyle Style;
         [NMS(Index = 1)]
-        /* 0x360 */ public GcNGuiLayoutData Layout;
+        /* 0x000 */ public GcNGuiLayoutData Layout;
         [NMS(Index = 4)]
-        /* 0x3A8 */ public VariableSizeString Image;
+        /* 0x048 */ public VariableSizeString Image;
         [NMS(Index = 0)]
-        /* 0x3B8 */ public NMSString0x10 PresetID;
+        /* 0x058 */ public NMSString0x10 PresetID;
+        [NMS(Index = 3, MxmlName = "Graphic Style")]
+        /* 0x068 */ public TkNGuiGraphicStyle GraphicStyle;
+        [NMS(Index = 2)]
+        /* 0x1E8 */ public TkNGuiTextStyle Style;
     }
 }

--- a/libMBIN/Source/NMS/GameComponents/GcNGuiTextData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcNGuiTextData.cs
@@ -4,30 +4,30 @@ using System.Collections.Generic;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0xB73332A2242F834D, NameHash = 0xD5C1D227)]
+    [NMS(GUID = 0xDE64309606070537, NameHash = 0xD5C1D227)]
     public class GcNGuiTextData : NMSTemplate
     {
-        [NMS(Index = 2, MxmlName = "Graphic Style")]
-        /* 0x000 */ public TkNGuiGraphicStyle GraphicStyle;
-        [NMS(Index = 1)]
-        /* 0x240 */ public TkNGuiTextStyle Style;
         [NMS(Index = 0, MxmlName = "Element Data")]
-        /* 0x360 */ public GcNGuiElementData ElementData;
+        /* 0x000 */ public GcNGuiElementData ElementData;
         [NMS(Index = 7)]
-        /* 0x3C8 */ public List<GcAccessibleOverride_Text> AccessibleOverrides;
+        /* 0x068 */ public List<GcAccessibleOverride_Text> AccessibleOverrides;
         [NMS(Index = 4)]
-        /* 0x3D8 */ public VariableSizeString Image;
+        /* 0x078 */ public VariableSizeString Image;
         [NMS(Index = 3)]
-        /* 0x3E8 */ public VariableSizeString Text;
+        /* 0x088 */ public VariableSizeString Text;
         [NMS(Index = 6)]
-        /* 0x3F8 */ public List<GcVROverride_Text> VROverrides;
+        /* 0x098 */ public List<GcVROverride_Text> VROverrides;
+        [NMS(Index = 2, MxmlName = "Graphic Style")]
+        /* 0x0A8 */ public TkNGuiGraphicStyle GraphicStyle;
+        [NMS(Index = 1)]
+        /* 0x228 */ public TkNGuiTextStyle Style;
         [NMS(Index = 5)]
-        /* 0x408 */ public float ForcedOffset;
+        /* 0x2C4 */ public float ForcedOffset;
         [NMS(Index = 10)]
-        /* 0x40C */ public bool BlockSpecialStyles;
+        /* 0x2C8 */ public bool BlockSpecialStyles;
         [NMS(Index = 9)]
-        /* 0x40D */ public bool ForcedAllowScroll;
+        /* 0x2C9 */ public bool ForcedAllowScroll;
         [NMS(Index = 8)]
-        /* 0x40E */ public bool Special;
+        /* 0x2CA */ public bool Special;
     }
 }

--- a/libMBIN/Source/NMS/GameComponents/GcObjectSpawnData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcObjectSpawnData.cs
@@ -3,20 +3,20 @@ using System.Collections.Generic;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0x4E30D514A8E6E836, NameHash = 0x9858A3C5)]
+    [NMS(GUID = 0x81C11302C70F6AD4, NameHash = 0x9858A3C5)]
     public class GcObjectSpawnData : NMSTemplate
     {
-        [NMS(Index = 44)]
+        [NMS(Index = 45)]
         /* 0x000 */ public GcObjectSpawnDataVariant QualityVariantData;
         [NMS(Index = 0)]
         /* 0x048 */ public GcResourceElement Resource;
-        [NMS(Index = 42)]
+        [NMS(Index = 43)]
         /* 0x090 */ public List<GcResourceElement> AltResources;
         [NMS(Index = 1)]
         /* 0x0A0 */ public NMSString0x10 DebugName;
-        [NMS(Index = 41)]
+        [NMS(Index = 42)]
         /* 0x0B0 */ public NMSString0x10 DestroyedByVehicleEffect;
-        [NMS(Index = 43)]
+        [NMS(Index = 44)]
         /* 0x0C0 */ public List<GcTerrainTileType> ExtraTileTypes;
         [NMS(Index = 4)]
         /* 0x0D0 */ public NMSString0x10 Placement;
@@ -117,17 +117,19 @@ namespace libMBIN.NMS.GameComponents
         /* 0x15B */ public bool DestroyedByTerrainEdit;
         [NMS(Index = 36)]
         /* 0x15C */ public bool InvisibleToCamera;
-        [NMS(Index = 40)]
+        [NMS(Index = 41)]
         /* 0x15D */ public bool IsFloatingIsland;
         [NMS(Index = 26)]
         /* 0x15E */ public bool MatchGroundColour;
+        [NMS(Index = 40)]
+        /* 0x15F */ public bool MoveToGroundOnUpgrade;
         [NMS(Index = 25)]
-        /* 0x15F */ public bool RelativeToSeaLevel;
+        /* 0x160 */ public bool RelativeToSeaLevel;
         [NMS(Index = 39)]
-        /* 0x160 */ public bool SupportsScanToReveal;
+        /* 0x161 */ public bool SupportsScanToReveal;
         [NMS(Index = 29)]
-        /* 0x161 */ public bool SwapPrimaryForRandomColour;
+        /* 0x162 */ public bool SwapPrimaryForRandomColour;
         [NMS(Index = 28)]
-        /* 0x162 */ public bool SwapPrimaryForSecondaryColour;
+        /* 0x163 */ public bool SwapPrimaryForSecondaryColour;
     }
 }

--- a/libMBIN/Source/NMS/GameComponents/GcObjectSpawnDataArray.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcObjectSpawnDataArray.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0xECE5BEF774CF6E90, NameHash = 0x3500C026)]
+    [NMS(GUID = 0x3FFF52574AF06403, NameHash = 0x3500C026)]
     public class GcObjectSpawnDataArray : NMSTemplate
     {
         [NMS(Index = 2)]

--- a/libMBIN/Source/NMS/GameComponents/GcPhysicsCollisionGroupCollidesWith.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcPhysicsCollisionGroupCollidesWith.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0x2BCC41461652122B, NameHash = 0xB0C9B25F)]
+    [NMS(GUID = 0x935CDF2D8ACA2EB9, NameHash = 0xB0C9B25F)]
     public class GcPhysicsCollisionGroupCollidesWith : NMSTemplate
     {
         [NMS(Index = 1)]

--- a/libMBIN/Source/NMS/GameComponents/GcPhysicsCollisionGroups.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcPhysicsCollisionGroups.cs
@@ -2,10 +2,10 @@ using System;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0xFCD45809E9408C91, NameHash = 0x6A2D4F5A)]
+    [NMS(GUID = 0xA06D547501556B30, NameHash = 0x6A2D4F5A)]
     public class GcPhysicsCollisionGroups : NMSTemplate
     {
-        // size: 0x41
+        // size: 0x46
         [Flags]
         public enum CollisionGroupEnum : uint {
             Normal,
@@ -68,6 +68,11 @@ namespace libMBIN.NMS.GameComponents
             Raycast_AiShipTravel,
             Raycast_ObstructionQuery,
             Raycast_GeometryProbe,
+            Raycast_DroneTargetSensing_Friendly,
+            Raycast_DroneTargetSensing_Unfriendly,
+            Raycast_DroneTargetSensing_Friendly_NoShield,
+            Raycast_DroneTargetSensing_Unfriendly_NoShield,
+            Raycast_ObjectPlacementAddObject,
             Raycast_CatchCreatures,
             Raycast_CatchNormal,
             Raycast_CatchTerrain,

--- a/libMBIN/Source/NMS/GameComponents/GcPhysicsCollisionTable.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcPhysicsCollisionTable.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0x6D2296A4050D4540, NameHash = 0xF5EE5140)]
+    [NMS(GUID = 0x6EAF559AC8677719, NameHash = 0xF5EE5140)]
     public class GcPhysicsCollisionTable : NMSTemplate
     {
         [NMS(Index = 0)]

--- a/libMBIN/Source/NMS/GameComponents/GcPlanetData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcPlanetData.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0xDD7ABFC9C9F9BF53, NameHash = 0x17A032B6)]
+    [NMS(GUID = 0x125DF0A3AB98DE8F, NameHash = 0x17A032B6)]
     public class GcPlanetData : NMSTemplate
     {
         [NMS(Index = 10)]

--- a/libMBIN/Source/NMS/GameComponents/GcPlanetGenerationIntermediateData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcPlanetGenerationIntermediateData.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0xBA496E71C66785C1, NameHash = 0x9BD23889)]
+    [NMS(GUID = 0xF37A9F6F0CBBECFF, NameHash = 0x9BD23889)]
     public class GcPlanetGenerationIntermediateData : NMSTemplate
     {
         [NMS(Index = 5)]

--- a/libMBIN/Source/NMS/GameComponents/GcPlayerCommonStateData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcPlayerCommonStateData.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0x4A21B3B24D86A472, NameHash = 0xC7D918F3)]
+    [NMS(GUID = 0x471DE97AD47A14EA, NameHash = 0xC7D918F3)]
     public class GcPlayerCommonStateData : NMSTemplate
     {
         [NMS(Index = 5)]

--- a/libMBIN/Source/NMS/GameComponents/GcPlayerSpawnStateData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcPlayerSpawnStateData.cs
@@ -1,6 +1,6 @@
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0x55FD426A97A3832F, NameHash = 0xE1F664A6)]
+    [NMS(GUID = 0x758F78C58D4C358A, NameHash = 0xE1F664A6)]
     public class GcPlayerSpawnStateData : NMSTemplate
     {
         [NMS(Index = 10)]
@@ -27,7 +27,7 @@ namespace libMBIN.NMS.GameComponents
         /* 0xA0 */ public Vector4f ShipPositionInSystem;
         [NMS(Index = 5)]
         /* 0xB0 */ public Vector4f ShipTransformAt;
-        // size: 0x7
+        // size: 0x8
         public enum LastKnownPlayerStateEnum : uint {
             OnFoot,
             InShip,
@@ -36,6 +36,7 @@ namespace libMBIN.NMS.GameComponents
             InNexus,
             AbandonedFreighter,
             InShipLanded,
+            InVehicle,
         }
         [NMS(Index = 6)]
         /* 0xC0 */ public LastKnownPlayerStateEnum LastKnownPlayerState;

--- a/libMBIN/Source/NMS/GameComponents/GcPlayerStateData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcPlayerStateData.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0x91CE237B7B18FFCB, NameHash = 0x5E49C3E9)]
+    [NMS(GUID = 0x7586DA17B211CE85, NameHash = 0x5E49C3E9)]
     public class GcPlayerStateData : NMSTemplate
     {
         [NMS(Index = 120)]

--- a/libMBIN/Source/NMS/GameComponents/GcProceduralProductData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcProceduralProductData.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0xAF6B812BAA9A5A1D, NameHash = 0xE5910A2D)]
+    [NMS(GUID = 0xA842C11E0FC6541B, NameHash = 0xE5910A2D)]
     public class GcProceduralProductData : NMSTemplate
     {
         [NMS(Index = 3)]

--- a/libMBIN/Source/NMS/GameComponents/GcProceduralProductTable.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcProceduralProductTable.cs
@@ -2,7 +2,7 @@ using libMBIN.NMS.GameComponents;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0xEF4E264E7D012231, NameHash = 0xB792767A)]
+    [NMS(GUID = 0xB8E02353C37BD477, NameHash = 0xB792767A)]
     public class GcProceduralProductTable : NMSTemplate
     {
         [NMS(Index = 0, Size = 0x1C, EnumType = typeof(GcProceduralProductCategory.ProceduralProductCategoryEnum))]

--- a/libMBIN/Source/NMS/GameComponents/GcProductData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcProductData.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0xFBDECDAD6B9DFB9B, NameHash = 0x5C7DD06F)]
+    [NMS(GUID = 0xD363C790BF9509BE, NameHash = 0x5C7DD06F)]
     public class GcProductData : NMSTemplate
     {
         [NMS(Index = 12)]

--- a/libMBIN/Source/NMS/GameComponents/GcProductTable.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcProductTable.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0x45EB9A41B9557013, NameHash = 0x6EDC332)]
+    [NMS(GUID = 0x1522CAB1861470B, NameHash = 0x6EDC332)]
     public class GcProductTable : NMSTemplate
     {
         [NMS(Index = 0)]

--- a/libMBIN/Source/NMS/GameComponents/GcRealitySubstanceData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcRealitySubstanceData.cs
@@ -3,7 +3,7 @@ using libMBIN.NMS.GameComponents;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0x378EE1DD2E5A9BF8, NameHash = 0x77C00C01)]
+    [NMS(GUID = 0x1139CE3DC3FC0576, NameHash = 0x77C00C01)]
     public class GcRealitySubstanceData : NMSTemplate
     {
         [NMS(Index = 8)]

--- a/libMBIN/Source/NMS/GameComponents/GcRewardSpecificShip.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcRewardSpecificShip.cs
@@ -2,7 +2,7 @@ using libMBIN.NMS.GameComponents;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0x2BF9188BA607BAA1, NameHash = 0x8A37C4A2)]
+    [NMS(GUID = 0x788E0994C6C269F3, NameHash = 0x8A37C4A2)]
     public class GcRewardSpecificShip : NMSTemplate
     {
         [NMS(Index = 3)]

--- a/libMBIN/Source/NMS/GameComponents/GcScannableComponentData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcScannableComponentData.cs
@@ -2,7 +2,7 @@ using libMBIN.NMS.GameComponents;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0xF56B753DE5BC8DA9, NameHash = 0x4E404FB0)]
+    [NMS(GUID = 0x2CA730CAF21804B1, NameHash = 0x4E404FB0)]
     public class GcScannableComponentData : NMSTemplate
     {
         [NMS(Index = 16)]

--- a/libMBIN/Source/NMS/GameComponents/GcScannerIconTypes.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcScannerIconTypes.cs
@@ -1,9 +1,9 @@
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0x9147857D3041EE52, NameHash = 0x1BEA2B30)]
+    [NMS(GUID = 0x71882E8812EE6F3A, NameHash = 0x1BEA2B30)]
     public class GcScannerIconTypes : NMSTemplate
     {
-        // size: 0x47
+        // size: 0x48
         public enum ScanIconTypeEnum : uint {
             None,
             Health,
@@ -76,6 +76,7 @@ namespace libMBIN.NMS.GameComponents
             FishPot,
             RuinBeacon,
             SeaGlass,
+            LocalWeatherHazard,
         }
         [NMS(Index = 0)]
         /* 0x0 */ public ScanIconTypeEnum ScanIconType;

--- a/libMBIN/Source/NMS/GameComponents/GcScannerIcons.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcScannerIcons.cs
@@ -3,176 +3,176 @@ using libMBIN.NMS.GameComponents;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0xB87F941E7DBE5FB6, NameHash = 0xF873D7AD)]
+    [NMS(GUID = 0x6323E6522323CA74, NameHash = 0xF873D7AD)]
     public class GcScannerIcons : NMSTemplate
     {
-        [NMS(Index = 37, Size = 0x47, EnumType = typeof(GcScannerIconTypes.ScanIconTypeEnum))]
+        [NMS(Index = 37, Size = 0x48, EnumType = typeof(GcScannerIconTypes.ScanIconTypeEnum))]
         /* 0x0000 */ public Colour[] ScannableColours;
         [NMS(Index = 59, Size = 0x4)]
-        /* 0x0470 */ public Colour[] NetworkFSPlayerColours;
+        /* 0x0480 */ public Colour[] NetworkFSPlayerColours;
         [NMS(Index = 38)]
-        /* 0x04B0 */ public Colour BuildingColour;
+        /* 0x04C0 */ public Colour BuildingColour;
         [NMS(Index = 39)]
-        /* 0x04C0 */ public Colour GenericColour;
+        /* 0x04D0 */ public Colour GenericColour;
         [NMS(Index = 40)]
-        /* 0x04D0 */ public Colour RelicColour;
+        /* 0x04E0 */ public Colour RelicColour;
         [NMS(Index = 41)]
-        /* 0x04E0 */ public Colour SignalColour;
+        /* 0x04F0 */ public Colour SignalColour;
         [NMS(Index = 42)]
-        /* 0x04F0 */ public Colour UnknownColour;
-        [NMS(Index = 35, Size = 0x47, EnumType = typeof(GcScannerIconTypes.ScanIconTypeEnum))]
-        /* 0x0500 */ public GcScannerIcon[] ScannableIcons;
-        [NMS(Index = 36, Size = 0x47, EnumType = typeof(GcScannerIconTypes.ScanIconTypeEnum))]
-        /* 0x1488 */ public GcScannerIcon[] ScannableIconsBinocs;
+        /* 0x0500 */ public Colour UnknownColour;
+        [NMS(Index = 35, Size = 0x48, EnumType = typeof(GcScannerIconTypes.ScanIconTypeEnum))]
+        /* 0x0510 */ public GcScannerIcon[] ScannableIcons;
+        [NMS(Index = 36, Size = 0x48, EnumType = typeof(GcScannerIconTypes.ScanIconTypeEnum))]
+        /* 0x14D0 */ public GcScannerIcon[] ScannableIconsBinocs;
         [NMS(Index = 32, Size = 0x23, EnumType = typeof(GcScannerBuildingIconTypes.ScanBuildingIconTypeEnum))]
-        /* 0x2410 */ public GcScannerIcon[] BuildingIcons;
+        /* 0x2490 */ public GcScannerIcon[] BuildingIcons;
         [NMS(Index = 33, Size = 0x23, EnumType = typeof(GcScannerBuildingIconTypes.ScanBuildingIconTypeEnum))]
-        /* 0x2BB8 */ public GcScannerIcon[] BuildingIconsBinocs;
+        /* 0x2C38 */ public GcScannerIcon[] BuildingIconsBinocs;
         [NMS(Index = 34, Size = 0x23, EnumType = typeof(GcScannerBuildingIconTypes.ScanBuildingIconTypeEnum))]
-        /* 0x3360 */ public GcScannerIcon[] BuildingIconsHuge;
+        /* 0x33E0 */ public GcScannerIcon[] BuildingIconsHuge;
         [NMS(Index = 3, Size = 0x7, EnumType = typeof(GcVehicleType.VehicleTypeEnum))]
-        /* 0x3B08 */ public GcScannerIcon[] Vehicles;
+        /* 0x3B88 */ public GcScannerIcon[] Vehicles;
         [NMS(Index = 31, Size = 0x6, EnumType = typeof(GcGenericIconTypes.GenericIconTypeEnum))]
-        /* 0x3C90 */ public GcScannerIcon[] GenericIcons;
+        /* 0x3D10 */ public GcScannerIcon[] GenericIcons;
         [NMS(Index = 57, Size = 0x4)]
-        /* 0x3DE0 */ public GcScannerIcon[] NetworkFSPlayerMarkers;
+        /* 0x3E60 */ public GcScannerIcon[] NetworkFSPlayerMarkers;
         [NMS(Index = 58, Size = 0x4)]
-        /* 0x3EC0 */ public GcScannerIcon[] NetworkFSPlayerMarkersShip;
+        /* 0x3F40 */ public GcScannerIcon[] NetworkFSPlayerMarkersShip;
         [NMS(Index = 60, Size = 0x4)]
-        /* 0x3FA0 */ public GcScannerIcon[] NetworkPlayerFreighter;
+        /* 0x4020 */ public GcScannerIcon[] NetworkPlayerFreighter;
         [NMS(Index = 69, Size = 0x5, EnumType = typeof(GcScannerIconHighlightTypes.ScannerIconHighlightTypeEnum))]
-        /* 0x4080 */ public TkTextureResource[] HighlightIcons;
+        /* 0x4100 */ public TkTextureResource[] HighlightIcons;
         [NMS(Index = 30)]
-        /* 0x40F8 */ public GcScannerIcon ArrowLarge;
+        /* 0x4178 */ public GcScannerIcon ArrowLarge;
         [NMS(Index = 29)]
-        /* 0x4130 */ public GcScannerIcon ArrowSmall;
+        /* 0x41B0 */ public GcScannerIcon ArrowSmall;
         [NMS(Index = 48)]
-        /* 0x4168 */ public GcScannerIcon BaseBuildingMarker;
+        /* 0x41E8 */ public GcScannerIcon BaseBuildingMarker;
         [NMS(Index = 16)]
-        /* 0x41A0 */ public GcScannerIcon Battle;
+        /* 0x4220 */ public GcScannerIcon Battle;
         [NMS(Index = 20)]
-        /* 0x41D8 */ public GcScannerIcon BattleSmall;
+        /* 0x4258 */ public GcScannerIcon BattleSmall;
         [NMS(Index = 62)]
-        /* 0x4210 */ public GcScannerIcon BlackHole;
+        /* 0x4290 */ public GcScannerIcon BlackHole;
         [NMS(Index = 13)]
-        /* 0x4248 */ public GcScannerIcon Bounty1;
+        /* 0x42C8 */ public GcScannerIcon Bounty1;
         [NMS(Index = 14)]
-        /* 0x4280 */ public GcScannerIcon Bounty2;
+        /* 0x4300 */ public GcScannerIcon Bounty2;
         [NMS(Index = 15)]
-        /* 0x42B8 */ public GcScannerIcon Bounty3;
+        /* 0x4338 */ public GcScannerIcon Bounty3;
         [NMS(Index = 19)]
-        /* 0x42F0 */ public GcScannerIcon BountySmall;
+        /* 0x4370 */ public GcScannerIcon BountySmall;
         [NMS(Index = 22)]
-        /* 0x4328 */ public GcScannerIcon Checkpoint;
+        /* 0x43A8 */ public GcScannerIcon Checkpoint;
         [NMS(Index = 26)]
-        /* 0x4360 */ public GcScannerIcon CircleAnimation;
+        /* 0x43E0 */ public GcScannerIcon CircleAnimation;
         [NMS(Index = 64)]
-        /* 0x4398 */ public GcScannerIcon CreatureAction;
+        /* 0x4418 */ public GcScannerIcon CreatureAction;
         [NMS(Index = 63)]
-        /* 0x43D0 */ public GcScannerIcon CreatureCurious;
+        /* 0x4450 */ public GcScannerIcon CreatureCurious;
         [NMS(Index = 66)]
-        /* 0x4408 */ public GcScannerIcon CreatureDanger;
+        /* 0x4488 */ public GcScannerIcon CreatureDanger;
         [NMS(Index = 43)]
-        /* 0x4440 */ public GcScannerIcon CreatureDiscovered;
+        /* 0x44C0 */ public GcScannerIcon CreatureDiscovered;
         [NMS(Index = 67)]
-        /* 0x4478 */ public GcScannerIcon CreatureFiend;
+        /* 0x44F8 */ public GcScannerIcon CreatureFiend;
         [NMS(Index = 75)]
-        /* 0x44B0 */ public GcScannerIcon CreatureInteraction;
+        /* 0x4530 */ public GcScannerIcon CreatureInteraction;
         [NMS(Index = 68)]
-        /* 0x44E8 */ public GcScannerIcon CreatureMilk;
+        /* 0x4568 */ public GcScannerIcon CreatureMilk;
         [NMS(Index = 65)]
-        /* 0x4520 */ public GcScannerIcon CreatureTame;
+        /* 0x45A0 */ public GcScannerIcon CreatureTame;
         [NMS(Index = 44)]
-        /* 0x4558 */ public GcScannerIcon CreatureUndiscovered;
+        /* 0x45D8 */ public GcScannerIcon CreatureUndiscovered;
         [NMS(Index = 45)]
-        /* 0x4590 */ public GcScannerIcon CreatureUnknown;
+        /* 0x4610 */ public GcScannerIcon CreatureUnknown;
         [NMS(Index = 7)]
-        /* 0x45C8 */ public GcScannerIcon DamagedFrigate;
+        /* 0x4648 */ public GcScannerIcon DamagedFrigate;
         [NMS(Index = 12)]
-        /* 0x4600 */ public GcScannerIcon Death;
+        /* 0x4680 */ public GcScannerIcon Death;
         [NMS(Index = 18)]
-        /* 0x4638 */ public GcScannerIcon DeathSmall;
+        /* 0x46B8 */ public GcScannerIcon DeathSmall;
         [NMS(Index = 28)]
-        /* 0x4670 */ public GcScannerIcon DiamondAnimation;
+        /* 0x46F0 */ public GcScannerIcon DiamondAnimation;
         [NMS(Index = 11)]
-        /* 0x46A8 */ public GcScannerIcon EditingBase;
+        /* 0x4728 */ public GcScannerIcon EditingBase;
         [NMS(Index = 9)]
-        /* 0x46E0 */ public GcScannerIcon Expedition;
+        /* 0x4760 */ public GcScannerIcon Expedition;
         [NMS(Index = 4)]
-        /* 0x4718 */ public GcScannerIcon Freighter;
+        /* 0x4798 */ public GcScannerIcon Freighter;
         [NMS(Index = 5)]
-        /* 0x4750 */ public GcScannerIcon FreighterBase;
+        /* 0x47D0 */ public GcScannerIcon FreighterBase;
         [NMS(Index = 82)]
-        /* 0x4788 */ public GcScannerIcon FriendlyDrone;
+        /* 0x4808 */ public GcScannerIcon FriendlyDrone;
         [NMS(Index = 23)]
-        /* 0x47C0 */ public GcScannerIcon Garage;
+        /* 0x4840 */ public GcScannerIcon Garage;
         [NMS(Index = 27)]
-        /* 0x47F8 */ public GcScannerIcon HexAnimation;
+        /* 0x4878 */ public GcScannerIcon HexAnimation;
         [NMS(Index = 46)]
-        /* 0x4830 */ public GcScannerIcon MessageBeacon;
+        /* 0x48B0 */ public GcScannerIcon MessageBeacon;
         [NMS(Index = 47)]
-        /* 0x4868 */ public GcScannerIcon MessageBeaconSmall;
+        /* 0x48E8 */ public GcScannerIcon MessageBeaconSmall;
         [NMS(Index = 74)]
-        /* 0x48A0 */ public GcScannerIcon MissionAbandonedFreighter;
+        /* 0x4920 */ public GcScannerIcon MissionAbandonedFreighter;
         [NMS(Index = 71)]
-        /* 0x48D8 */ public GcScannerIcon MissionEnterBuilding;
+        /* 0x4958 */ public GcScannerIcon MissionEnterBuilding;
         [NMS(Index = 73)]
-        /* 0x4910 */ public GcScannerIcon MissionEnterFreighter;
+        /* 0x4990 */ public GcScannerIcon MissionEnterFreighter;
         [NMS(Index = 70)]
-        /* 0x4948 */ public GcScannerIcon MissionEnterOrbit;
+        /* 0x49C8 */ public GcScannerIcon MissionEnterOrbit;
         [NMS(Index = 72)]
-        /* 0x4980 */ public GcScannerIcon MissionEnterStation;
+        /* 0x4A00 */ public GcScannerIcon MissionEnterStation;
         [NMS(Index = 53)]
-        /* 0x49B8 */ public GcScannerIcon MonumentMarker;
+        /* 0x4A38 */ public GcScannerIcon MonumentMarker;
         [NMS(Index = 54)]
-        /* 0x49F0 */ public GcScannerIcon NetworkPlayerMarker;
+        /* 0x4A70 */ public GcScannerIcon NetworkPlayerMarker;
         [NMS(Index = 55)]
-        /* 0x4A28 */ public GcScannerIcon NetworkPlayerMarkerShip;
+        /* 0x4AA8 */ public GcScannerIcon NetworkPlayerMarkerShip;
         [NMS(Index = 56)]
-        /* 0x4A60 */ public GcScannerIcon NetworkPlayerMarkerVehicle;
+        /* 0x4AE0 */ public GcScannerIcon NetworkPlayerMarkerVehicle;
         [NMS(Index = 24)]
-        /* 0x4A98 */ public GcScannerIcon NPC;
+        /* 0x4B18 */ public GcScannerIcon NPC;
         [NMS(Index = 81)]
-        /* 0x4AD0 */ public GcScannerIcon OtherPlayerSettlement;
+        /* 0x4B50 */ public GcScannerIcon OtherPlayerSettlement;
         [NMS(Index = 77)]
-        /* 0x4B08 */ public GcScannerIcon Pet;
+        /* 0x4B88 */ public GcScannerIcon Pet;
         [NMS(Index = 79)]
-        /* 0x4B40 */ public GcScannerIcon PetActivity;
+        /* 0x4BC0 */ public GcScannerIcon PetActivity;
         [NMS(Index = 76)]
-        /* 0x4B78 */ public GcScannerIcon PetInteraction;
+        /* 0x4BF8 */ public GcScannerIcon PetInteraction;
         [NMS(Index = 78)]
-        /* 0x4BB0 */ public GcScannerIcon PetSad;
+        /* 0x4C30 */ public GcScannerIcon PetSad;
         [NMS(Index = 83)]
-        /* 0x4BE8 */ public GcScannerIcon PirateRaid;
+        /* 0x4C68 */ public GcScannerIcon PirateRaid;
         [NMS(Index = 51)]
-        /* 0x4C20 */ public GcScannerIcon PlanetPoleEast;
+        /* 0x4CA0 */ public GcScannerIcon PlanetPoleEast;
         [NMS(Index = 49)]
-        /* 0x4C58 */ public GcScannerIcon PlanetPoleNorth;
+        /* 0x4CD8 */ public GcScannerIcon PlanetPoleNorth;
         [NMS(Index = 50)]
-        /* 0x4C90 */ public GcScannerIcon PlanetPoleSouth;
+        /* 0x4D10 */ public GcScannerIcon PlanetPoleSouth;
         [NMS(Index = 52)]
-        /* 0x4CC8 */ public GcScannerIcon PlanetPoleWest;
+        /* 0x4D48 */ public GcScannerIcon PlanetPoleWest;
         [NMS(Index = 10)]
-        /* 0x4D00 */ public GcScannerIcon PlayerBase;
+        /* 0x4D80 */ public GcScannerIcon PlayerBase;
         [NMS(Index = 6)]
-        /* 0x4D38 */ public GcScannerIcon PlayerFreighter;
+        /* 0x4DB8 */ public GcScannerIcon PlayerFreighter;
         [NMS(Index = 80)]
-        /* 0x4D70 */ public GcScannerIcon PlayerSettlement;
+        /* 0x4DF0 */ public GcScannerIcon PlayerSettlement;
         [NMS(Index = 61)]
-        /* 0x4DA8 */ public GcScannerIcon PortalMarker;
+        /* 0x4E28 */ public GcScannerIcon PortalMarker;
         [NMS(Index = 8)]
-        /* 0x4DE0 */ public GcScannerIcon PurchasableFrigate;
+        /* 0x4E60 */ public GcScannerIcon PurchasableFrigate;
         [NMS(Index = 25)]
-        /* 0x4E18 */ public GcScannerIcon SettlementNPC;
+        /* 0x4E98 */ public GcScannerIcon SettlementNPC;
         [NMS(Index = 1)]
-        /* 0x4E50 */ public GcScannerIcon Ship;
+        /* 0x4ED0 */ public GcScannerIcon Ship;
         [NMS(Index = 17)]
-        /* 0x4E88 */ public GcScannerIcon ShipSmall;
+        /* 0x4F08 */ public GcScannerIcon ShipSmall;
         [NMS(Index = 0)]
-        /* 0x4EC0 */ public GcScannerIcon TaggedBuilding;
+        /* 0x4F40 */ public GcScannerIcon TaggedBuilding;
         [NMS(Index = 21)]
-        /* 0x4EF8 */ public GcScannerIcon TimedEvent;
+        /* 0x4F78 */ public GcScannerIcon TimedEvent;
         [NMS(Index = 2)]
-        /* 0x4F30 */ public GcScannerIcon VehicleGeneric;
+        /* 0x4FB0 */ public GcScannerIcon VehicleGeneric;
     }
 }

--- a/libMBIN/Source/NMS/GameComponents/GcSceneSettings.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcSceneSettings.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0xDAA78DC54B5BD720, NameHash = 0x5180E7C9)]
+    [NMS(GUID = 0xFA5F32BDBDC8E6B9, NameHash = 0x5180E7C9)]
     public class GcSceneSettings : NMSTemplate
     {
         [NMS(Index = 8)]

--- a/libMBIN/Source/NMS/GameComponents/GcSeasonalGameModeData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcSeasonalGameModeData.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0x1DEF18D503CD2A6D, NameHash = 0xC2909BE6)]
+    [NMS(GUID = 0x3F419080679EEB75, NameHash = 0xC2909BE6)]
     public class GcSeasonalGameModeData : NMSTemplate
     {
         [NMS(Index = 72, Size = 0x12)]

--- a/libMBIN/Source/NMS/GameComponents/GcSubstanceTable.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcSubstanceTable.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0xC047EDE35767235D, NameHash = 0x7A9FBCC1)]
+    [NMS(GUID = 0x7B5117BDE1C9FB83, NameHash = 0x7A9FBCC1)]
     public class GcSubstanceTable : NMSTemplate
     {
         [NMS(Index = 1)]

--- a/libMBIN/Source/NMS/GameComponents/GcVehicleData.cs
+++ b/libMBIN/Source/NMS/GameComponents/GcVehicleData.cs
@@ -1,9 +1,9 @@
 namespace libMBIN.NMS.GameComponents
 {
-    [NMS(GUID = 0x96BEE63E4537305C, NameHash = 0x357DD91E)]
+    [NMS(GUID = 0x5434BDC00ECBFF65, NameHash = 0x357DD91E)]
     public class GcVehicleData : NMSTemplate
     {
-        [NMS(Index = 139, Size = 0xA)]
+        [NMS(Index = 143, Size = 0xA)]
         /* 0x0000 */ public Vector3f[] WheelGrassPushers;
         [NMS(Index = 21, Size = 0xA)]
         /* 0x00A0 */ public Vector3f[] WheelLocs;
@@ -31,267 +31,275 @@ namespace libMBIN.NMS.GameComponents
         /* 0x0270 */ public NMSString0x10 Name;
         [NMS(Index = 85)]
         /* 0x0280 */ public NMSString0x10 SideSkidParticle;
-        [NMS(Index = 90)]
-        /* 0x0290 */ public NMSString0x10 WheelSpinParticle;
-        [NMS(Index = 25, Size = 0xA)]
-        /* 0x02A0 */ public float[] WheelRadiusMultiplier;
-        [NMS(Index = 24, Size = 0xA)]
-        /* 0x02C8 */ public float[] WheelRayFakeWidthFactor;
-        [NMS(Index = 119)]
-        /* 0x02F0 */ public float AudioImpactSpeedMul;
-        [NMS(Index = 118)]
-        /* 0x02F4 */ public float AudioImpactSpeedThreshold;
-        [NMS(Index = 32)]
-        /* 0x02F8 */ public float CollRadius;
-        [NMS(Index = 140)]
-        /* 0x02FC */ public float CreatureMassScale;
-        [NMS(Index = 47)]
-        /* 0x0300 */ public float HardStopSpeedThreshold;
-        [NMS(Index = 144)]
-        /* 0x0304 */ public float HeadlightIntensity;
-        [NMS(Index = 33)]
-        /* 0x0308 */ public float InertiaMul;
-        [NMS(Index = 135)]
-        /* 0x030C */ public int NumGrassPushers;
-        [NMS(Index = 2)]
-        /* 0x0310 */ public int NumWheels;
-        [NMS(Index = 87)]
-        /* 0x0314 */ public float SideSkidParticleMaxRate;
-        [NMS(Index = 89)]
-        /* 0x0318 */ public float SideSkidParticleMaxThresh;
-        [NMS(Index = 86)]
-        /* 0x031C */ public float SideSkidParticleMinRate;
-        [NMS(Index = 88)]
-        /* 0x0320 */ public float SideSkidParticleMinThresh;
-        [NMS(Index = 20)]
-        /* 0x0324 */ public float SteeringWheelPushRange;
-        [NMS(Index = 19)]
-        /* 0x0328 */ public float SteeringWheelSpringMultiplier;
-        [NMS(Index = 39)]
-        /* 0x032C */ public float TopSpeedForward;
-        [NMS(Index = 40)]
-        /* 0x0330 */ public float TopSpeedReverse;
-        [NMS(Index = 59)]
-        /* 0x0334 */ public float TurningWheelForce;
-        [NMS(Index = 60)]
-        /* 0x0338 */ public float TurningWheelForceDamperVR;
-        [NMS(Index = 63)]
-        /* 0x033C */ public float TurningWheelFrictionBraking;
-        [NMS(Index = 62)]
-        /* 0x0340 */ public float TurningWheelFrictionNonBraking;
-        [NMS(Index = 61)]
-        /* 0x0344 */ public float TurningWheelFrictionOmega;
-        [NMS(Index = 14)]
-        /* 0x0348 */ public float UnderwaterAlignDir;
-        [NMS(Index = 15)]
-        /* 0x034C */ public float UnderwaterAlignUp;
-        [NMS(Index = 12)]
-        /* 0x0350 */ public float UnderwaterEngineDirectionBrake;
-        [NMS(Index = 13)]
-        /* 0x0354 */ public float UnderwaterEngineDirectionBrakeVertical;
-        [NMS(Index = 11)]
-        /* 0x0358 */ public float UnderwaterEngineFalloff;
-        [NMS(Index = 9)]
-        /* 0x035C */ public float UnderwaterEngineMaxSpeed;
-        [NMS(Index = 10)]
-        /* 0x0360 */ public float UnderwaterEngineMaxSpeedVR;
-        [NMS(Index = 7)]
-        /* 0x0364 */ public float UnderwaterEnginePower;
-        [NMS(Index = 8)]
-        /* 0x0368 */ public float UnderwaterEnginePowerVR;
-        [NMS(Index = 106)]
-        /* 0x036C */ public float VehicleAngularDampingAerial;
-        [NMS(Index = 104)]
-        /* 0x0370 */ public float VehicleAngularDampingGround;
-        [NMS(Index = 108)]
-        /* 0x0374 */ public float VehicleAngularDampingWater;
-        [NMS(Index = 114)]
-        /* 0x0378 */ public float VehicleAudioSideSkidMul;
-        [NMS(Index = 115)]
-        /* 0x037C */ public float VehicleAudioSideSkidThreshold;
-        [NMS(Index = 112)]
-        /* 0x0380 */ public float VehicleAudioSpeedMul;
-        [NMS(Index = 116)]
-        /* 0x0384 */ public float VehicleAudioSpinSkidMul;
-        [NMS(Index = 117)]
-        /* 0x0388 */ public float VehicleAudioSpinSkidThreshold;
-        [NMS(Index = 134)]
-        /* 0x038C */ public float VehicleAudioSuspensionScale;
-        [NMS(Index = 133)]
-        /* 0x0390 */ public float VehicleAudioSuspensionThreshold;
-        [NMS(Index = 113)]
-        /* 0x0394 */ public float VehicleAudioTorqueMul;
-        [NMS(Index = 74)]
-        /* 0x0398 */ public float VehicleBoostExtraMaxSpeedAir;
-        [NMS(Index = 72)]
-        /* 0x039C */ public float VehicleBoostForce;
-        [NMS(Index = 73)]
-        /* 0x03A0 */ public float VehicleBoostMaxSpeed;
-        [NMS(Index = 77)]
-        /* 0x03A4 */ public float VehicleBoostRechargeTime;
-        [NMS(Index = 75)]
-        /* 0x03A8 */ public float VehicleBoostSpeedFalloff;
-        [NMS(Index = 76)]
-        /* 0x03AC */ public float VehicleBoostTime;
-        [NMS(Index = 111)]
-        /* 0x03B0 */ public float VehicleComCheat;
-        [NMS(Index = 68)]
-        /* 0x03B4 */ public float VehicleGravity;
-        [NMS(Index = 69)]
-        /* 0x03B8 */ public float VehicleGravityWater;
-        [NMS(Index = 71)]
-        /* 0x03BC */ public float VehicleJumpAirControlForce;
-        [NMS(Index = 82)]
-        /* 0x03C0 */ public float VehicleJumpAirMaxTorque;
-        [NMS(Index = 81)]
-        /* 0x03C4 */ public float VehicleJumpAirRotateTimeMax;
-        [NMS(Index = 80)]
-        /* 0x03C8 */ public float VehicleJumpAirRotateTimeMin;
-        [NMS(Index = 78)]
-        /* 0x03CC */ public float VehicleJumpAirRotateXAmount;
-        [NMS(Index = 79)]
-        /* 0x03D0 */ public float VehicleJumpAirRotateZAmount;
-        [NMS(Index = 70)]
-        /* 0x03D4 */ public float VehicleJumpForce;
-        [NMS(Index = 105)]
-        /* 0x03D8 */ public float VehicleLinearDampingAerial;
-        [NMS(Index = 103)]
-        /* 0x03DC */ public float VehicleLinearDampingGround;
-        [NMS(Index = 107)]
-        /* 0x03E0 */ public float VehicleLinearDampingWater;
-        [NMS(Index = 132)]
-        /* 0x03E4 */ public float VehicleUnderwaterRotateTime;
-        [NMS(Index = 18)]
-        /* 0x03E8 */ public float VisualPitchAmount;
-        [NMS(Index = 16)]
-        /* 0x03EC */ public float VisualRollAmount;
-        [NMS(Index = 17)]
-        /* 0x03F0 */ public float VisualRollOffsetY;
-        [NMS(Index = 46)]
-        /* 0x03F4 */ public float WheelDragginess;
-        [NMS(Index = 110)]
-        /* 0x03F8 */ public float WheelEndHeight;
-        [NMS(Index = 49)]
-        /* 0x03FC */ public float WheelFrontFrictionDynamic;
-        [NMS(Index = 50)]
-        /* 0x0400 */ public float WheelFrontFrictionDynamicThreshold;
-        [NMS(Index = 48)]
-        /* 0x0404 */ public float WheelFrontFrictionOmega;
-        [NMS(Index = 51)]
-        /* 0x0408 */ public float WheelFrontFrictionStatic;
-        [NMS(Index = 52)]
-        /* 0x040C */ public float WheelFrontFrictionStaticThreshold;
-        [NMS(Index = 138)]
-        /* 0x0410 */ public float WheelGrassPusherFrequency;
-        [NMS(Index = 136)]
-        /* 0x0414 */ public float WheelGrassPusherStrength;
-        [NMS(Index = 137)]
-        /* 0x0418 */ public float WheelGrassPusherWobble;
-        [NMS(Index = 6)]
-        /* 0x041C */ public float WheelGuardAdjustUpwards;
-        [NMS(Index = 5)]
-        /* 0x0420 */ public float WheelGuardExtraHeight;
-        [NMS(Index = 4)]
-        /* 0x0424 */ public float WheelGuardExtraRadius;
-        [NMS(Index = 101)]
-        /* 0x0428 */ public float WheelGuardMassScaleMax;
-        [NMS(Index = 100)]
-        /* 0x042C */ public float WheelGuardMassScaleMin;
-        [NMS(Index = 102)]
-        /* 0x0430 */ public float WheelGuardMassScaleMinClamp;
-        [NMS(Index = 98)]
-        /* 0x0434 */ public float WheelGuardPenetrationScaleMax;
-        [NMS(Index = 97)]
-        /* 0x0438 */ public float WheelGuardPenetrationScaleMin;
-        [NMS(Index = 99)]
-        /* 0x043C */ public float WheelGuardPenetrationScaleMinClamp;
         [NMS(Index = 96)]
-        /* 0x0440 */ public float WheelGuardVerticalResponseMax;
+        /* 0x0290 */ public NMSString0x10 SubSplashParticle;
+        [NMS(Index = 90)]
+        /* 0x02A0 */ public NMSString0x10 WheelSpinParticle;
         [NMS(Index = 95)]
-        /* 0x0444 */ public float WheelGuardVerticalResponseMin;
-        [NMS(Index = 41)]
-        /* 0x0448 */ public float WheelMaxAccelForceForward;
-        [NMS(Index = 42)]
-        /* 0x044C */ public float WheelMaxAccelForceReverse;
-        [NMS(Index = 44)]
-        /* 0x0450 */ public float WheelMaxDecelForceBraking;
-        [NMS(Index = 43)]
-        /* 0x0454 */ public float WheelMaxDecelForceNonBraking;
-        [NMS(Index = 3)]
-        /* 0x0458 */ public float WheelRadius;
-        [NMS(Index = 54)]
-        /* 0x045C */ public float WheelSideFrictionDynamic;
-        [NMS(Index = 55)]
-        /* 0x0460 */ public float WheelSideFrictionDynamicThreshold;
-        [NMS(Index = 53)]
-        /* 0x0464 */ public float WheelSideFrictionOmega;
-        [NMS(Index = 56)]
-        /* 0x0468 */ public float WheelSideFrictionStatic;
-        [NMS(Index = 57)]
-        /* 0x046C */ public float WheelSideFrictionStaticThreshold;
-        [NMS(Index = 45)]
-        /* 0x0470 */ public float WheelSpinniness;
-        [NMS(Index = 92)]
-        /* 0x0474 */ public float WheelSpinParticleMaxRate;
-        [NMS(Index = 94)]
-        /* 0x0478 */ public float WheelSpinParticleMaxThresh;
-        [NMS(Index = 91)]
-        /* 0x047C */ public float WheelSpinParticleMinRate;
-        [NMS(Index = 93)]
-        /* 0x0480 */ public float WheelSpinParticleMinThresh;
-        [NMS(Index = 109)]
-        /* 0x0484 */ public float WheelStartHeight;
-        [NMS(Index = 38)]
-        /* 0x0488 */ public float WheelSuspensionAnimMax;
-        [NMS(Index = 37)]
-        /* 0x048C */ public float WheelSuspensionAnimMin;
-        [NMS(Index = 36)]
-        /* 0x0490 */ public float WheelSuspensionDamping;
-        [NMS(Index = 35)]
-        /* 0x0494 */ public float WheelSuspensionForce;
-        [NMS(Index = 34)]
-        /* 0x0498 */ public float WheelSuspensionlength;
-        [NMS(Index = 143, Size = 0x2)]
-        /* 0x049C */ public NMSString0x100[] CockpitHeadlightNames;
-        [NMS(Index = 141, Size = 0x2)]
-        /* 0x069C */ public NMSString0x100[] HeadlightNames;
-        [NMS(Index = 142, Size = 0x2)]
-        /* 0x089C */ public NMSString0x100[] VolumetricHeadlightNames;
-        [NMS(Index = 22, Size = 0xA)]
-        /* 0x0A9C */ public NMSString0x20[] WheelNames;
-        [NMS(Index = 23, Size = 0xA)]
-        /* 0x0BDC */ public NMSString0x20[] WheelSuspensionNames;
-        [NMS(Index = 121)]
-        /* 0x0D1C */ public NMSString0x80 AudioBoostStart;
-        [NMS(Index = 122)]
-        /* 0x0D9C */ public NMSString0x80 AudioBoostStop;
+        /* 0x02B0 */ public NMSString0x10 WheelSplashParticle;
+        [NMS(Index = 25, Size = 0xA)]
+        /* 0x02C0 */ public float[] WheelRadiusMultiplier;
+        [NMS(Index = 24, Size = 0xA)]
+        /* 0x02E8 */ public float[] WheelRayFakeWidthFactor;
         [NMS(Index = 123)]
-        /* 0x0E1C */ public NMSString0x80 AudioHornStart;
-        [NMS(Index = 124)]
-        /* 0x0E9C */ public NMSString0x80 AudioHornStop;
-        [NMS(Index = 125)]
-        /* 0x0F1C */ public NMSString0x80 AudioIdleExterior;
-        [NMS(Index = 126)]
-        /* 0x0F9C */ public NMSString0x80 AudioImpacts;
-        [NMS(Index = 130)]
-        /* 0x101C */ public NMSString0x80 AudioJump;
-        [NMS(Index = 127)]
-        /* 0x109C */ public NMSString0x80 AudioStart;
-        [NMS(Index = 128)]
-        /* 0x111C */ public NMSString0x80 AudioStop;
-        [NMS(Index = 129)]
-        /* 0x119C */ public NMSString0x80 AudioSuspension;
-        [NMS(Index = 27)]
-        /* 0x121C */ public bool CustomCollision;
-        [NMS(Index = 131)]
-        /* 0x121D */ public bool DriveOnTopOfWater;
-        [NMS(Index = 58)]
-        /* 0x121E */ public bool LockVehicleAxis;
-        [NMS(Index = 83)]
-        /* 0x121F */ public bool UseBuggySuspensionHack;
-        [NMS(Index = 84)]
-        /* 0x1220 */ public bool UseRoverWheelHack;
+        /* 0x0310 */ public float AudioImpactSpeedMul;
+        [NMS(Index = 122)]
+        /* 0x0314 */ public float AudioImpactSpeedThreshold;
+        [NMS(Index = 32)]
+        /* 0x0318 */ public float CollRadius;
+        [NMS(Index = 144)]
+        /* 0x031C */ public float CreatureMassScale;
+        [NMS(Index = 47)]
+        /* 0x0320 */ public float HardStopSpeedThreshold;
+        [NMS(Index = 148)]
+        /* 0x0324 */ public float HeadlightIntensity;
+        [NMS(Index = 33)]
+        /* 0x0328 */ public float InertiaMul;
+        [NMS(Index = 139)]
+        /* 0x032C */ public int NumGrassPushers;
+        [NMS(Index = 2)]
+        /* 0x0330 */ public int NumWheels;
+        [NMS(Index = 87)]
+        /* 0x0334 */ public float SideSkidParticleMaxRate;
+        [NMS(Index = 89)]
+        /* 0x0338 */ public float SideSkidParticleMaxThresh;
+        [NMS(Index = 86)]
+        /* 0x033C */ public float SideSkidParticleMinRate;
+        [NMS(Index = 88)]
+        /* 0x0340 */ public float SideSkidParticleMinThresh;
+        [NMS(Index = 20)]
+        /* 0x0344 */ public float SteeringWheelPushRange;
+        [NMS(Index = 19)]
+        /* 0x0348 */ public float SteeringWheelSpringMultiplier;
+        [NMS(Index = 98)]
+        /* 0x034C */ public float SubSplashParticleMaxThresh;
+        [NMS(Index = 97)]
+        /* 0x0350 */ public float SubSplashParticleMinThresh;
+        [NMS(Index = 39)]
+        /* 0x0354 */ public float TopSpeedForward;
+        [NMS(Index = 40)]
+        /* 0x0358 */ public float TopSpeedReverse;
+        [NMS(Index = 59)]
+        /* 0x035C */ public float TurningWheelForce;
+        [NMS(Index = 60)]
+        /* 0x0360 */ public float TurningWheelForceDamperVR;
+        [NMS(Index = 63)]
+        /* 0x0364 */ public float TurningWheelFrictionBraking;
+        [NMS(Index = 62)]
+        /* 0x0368 */ public float TurningWheelFrictionNonBraking;
+        [NMS(Index = 61)]
+        /* 0x036C */ public float TurningWheelFrictionOmega;
+        [NMS(Index = 14)]
+        /* 0x0370 */ public float UnderwaterAlignDir;
+        [NMS(Index = 15)]
+        /* 0x0374 */ public float UnderwaterAlignUp;
+        [NMS(Index = 12)]
+        /* 0x0378 */ public float UnderwaterEngineDirectionBrake;
+        [NMS(Index = 13)]
+        /* 0x037C */ public float UnderwaterEngineDirectionBrakeVertical;
+        [NMS(Index = 11)]
+        /* 0x0380 */ public float UnderwaterEngineFalloff;
+        [NMS(Index = 9)]
+        /* 0x0384 */ public float UnderwaterEngineMaxSpeed;
+        [NMS(Index = 10)]
+        /* 0x0388 */ public float UnderwaterEngineMaxSpeedVR;
+        [NMS(Index = 7)]
+        /* 0x038C */ public float UnderwaterEnginePower;
+        [NMS(Index = 8)]
+        /* 0x0390 */ public float UnderwaterEnginePowerVR;
+        [NMS(Index = 110)]
+        /* 0x0394 */ public float VehicleAngularDampingAerial;
+        [NMS(Index = 108)]
+        /* 0x0398 */ public float VehicleAngularDampingGround;
+        [NMS(Index = 112)]
+        /* 0x039C */ public float VehicleAngularDampingWater;
+        [NMS(Index = 118)]
+        /* 0x03A0 */ public float VehicleAudioSideSkidMul;
+        [NMS(Index = 119)]
+        /* 0x03A4 */ public float VehicleAudioSideSkidThreshold;
+        [NMS(Index = 116)]
+        /* 0x03A8 */ public float VehicleAudioSpeedMul;
         [NMS(Index = 120)]
-        /* 0x1221 */ public bool VehicleAudioSwapSkidAndSpeed;
+        /* 0x03AC */ public float VehicleAudioSpinSkidMul;
+        [NMS(Index = 121)]
+        /* 0x03B0 */ public float VehicleAudioSpinSkidThreshold;
+        [NMS(Index = 138)]
+        /* 0x03B4 */ public float VehicleAudioSuspensionScale;
+        [NMS(Index = 137)]
+        /* 0x03B8 */ public float VehicleAudioSuspensionThreshold;
+        [NMS(Index = 117)]
+        /* 0x03BC */ public float VehicleAudioTorqueMul;
+        [NMS(Index = 74)]
+        /* 0x03C0 */ public float VehicleBoostExtraMaxSpeedAir;
+        [NMS(Index = 72)]
+        /* 0x03C4 */ public float VehicleBoostForce;
+        [NMS(Index = 73)]
+        /* 0x03C8 */ public float VehicleBoostMaxSpeed;
+        [NMS(Index = 77)]
+        /* 0x03CC */ public float VehicleBoostRechargeTime;
+        [NMS(Index = 75)]
+        /* 0x03D0 */ public float VehicleBoostSpeedFalloff;
+        [NMS(Index = 76)]
+        /* 0x03D4 */ public float VehicleBoostTime;
+        [NMS(Index = 115)]
+        /* 0x03D8 */ public float VehicleComCheat;
+        [NMS(Index = 68)]
+        /* 0x03DC */ public float VehicleGravity;
+        [NMS(Index = 69)]
+        /* 0x03E0 */ public float VehicleGravityWater;
+        [NMS(Index = 71)]
+        /* 0x03E4 */ public float VehicleJumpAirControlForce;
+        [NMS(Index = 82)]
+        /* 0x03E8 */ public float VehicleJumpAirMaxTorque;
+        [NMS(Index = 81)]
+        /* 0x03EC */ public float VehicleJumpAirRotateTimeMax;
+        [NMS(Index = 80)]
+        /* 0x03F0 */ public float VehicleJumpAirRotateTimeMin;
+        [NMS(Index = 78)]
+        /* 0x03F4 */ public float VehicleJumpAirRotateXAmount;
+        [NMS(Index = 79)]
+        /* 0x03F8 */ public float VehicleJumpAirRotateZAmount;
+        [NMS(Index = 70)]
+        /* 0x03FC */ public float VehicleJumpForce;
+        [NMS(Index = 109)]
+        /* 0x0400 */ public float VehicleLinearDampingAerial;
+        [NMS(Index = 107)]
+        /* 0x0404 */ public float VehicleLinearDampingGround;
+        [NMS(Index = 111)]
+        /* 0x0408 */ public float VehicleLinearDampingWater;
+        [NMS(Index = 136)]
+        /* 0x040C */ public float VehicleUnderwaterRotateTime;
+        [NMS(Index = 18)]
+        /* 0x0410 */ public float VisualPitchAmount;
+        [NMS(Index = 16)]
+        /* 0x0414 */ public float VisualRollAmount;
+        [NMS(Index = 17)]
+        /* 0x0418 */ public float VisualRollOffsetY;
+        [NMS(Index = 46)]
+        /* 0x041C */ public float WheelDragginess;
+        [NMS(Index = 114)]
+        /* 0x0420 */ public float WheelEndHeight;
+        [NMS(Index = 49)]
+        /* 0x0424 */ public float WheelFrontFrictionDynamic;
+        [NMS(Index = 50)]
+        /* 0x0428 */ public float WheelFrontFrictionDynamicThreshold;
+        [NMS(Index = 48)]
+        /* 0x042C */ public float WheelFrontFrictionOmega;
+        [NMS(Index = 51)]
+        /* 0x0430 */ public float WheelFrontFrictionStatic;
+        [NMS(Index = 52)]
+        /* 0x0434 */ public float WheelFrontFrictionStaticThreshold;
+        [NMS(Index = 142)]
+        /* 0x0438 */ public float WheelGrassPusherFrequency;
+        [NMS(Index = 140)]
+        /* 0x043C */ public float WheelGrassPusherStrength;
+        [NMS(Index = 141)]
+        /* 0x0440 */ public float WheelGrassPusherWobble;
+        [NMS(Index = 6)]
+        /* 0x0444 */ public float WheelGuardAdjustUpwards;
+        [NMS(Index = 5)]
+        /* 0x0448 */ public float WheelGuardExtraHeight;
+        [NMS(Index = 4)]
+        /* 0x044C */ public float WheelGuardExtraRadius;
+        [NMS(Index = 105)]
+        /* 0x0450 */ public float WheelGuardMassScaleMax;
+        [NMS(Index = 104)]
+        /* 0x0454 */ public float WheelGuardMassScaleMin;
+        [NMS(Index = 106)]
+        /* 0x0458 */ public float WheelGuardMassScaleMinClamp;
+        [NMS(Index = 102)]
+        /* 0x045C */ public float WheelGuardPenetrationScaleMax;
+        [NMS(Index = 101)]
+        /* 0x0460 */ public float WheelGuardPenetrationScaleMin;
+        [NMS(Index = 103)]
+        /* 0x0464 */ public float WheelGuardPenetrationScaleMinClamp;
+        [NMS(Index = 100)]
+        /* 0x0468 */ public float WheelGuardVerticalResponseMax;
+        [NMS(Index = 99)]
+        /* 0x046C */ public float WheelGuardVerticalResponseMin;
+        [NMS(Index = 41)]
+        /* 0x0470 */ public float WheelMaxAccelForceForward;
+        [NMS(Index = 42)]
+        /* 0x0474 */ public float WheelMaxAccelForceReverse;
+        [NMS(Index = 44)]
+        /* 0x0478 */ public float WheelMaxDecelForceBraking;
+        [NMS(Index = 43)]
+        /* 0x047C */ public float WheelMaxDecelForceNonBraking;
+        [NMS(Index = 3)]
+        /* 0x0480 */ public float WheelRadius;
+        [NMS(Index = 54)]
+        /* 0x0484 */ public float WheelSideFrictionDynamic;
+        [NMS(Index = 55)]
+        /* 0x0488 */ public float WheelSideFrictionDynamicThreshold;
+        [NMS(Index = 53)]
+        /* 0x048C */ public float WheelSideFrictionOmega;
+        [NMS(Index = 56)]
+        /* 0x0490 */ public float WheelSideFrictionStatic;
+        [NMS(Index = 57)]
+        /* 0x0494 */ public float WheelSideFrictionStaticThreshold;
+        [NMS(Index = 45)]
+        /* 0x0498 */ public float WheelSpinniness;
+        [NMS(Index = 92)]
+        /* 0x049C */ public float WheelSpinParticleMaxRate;
+        [NMS(Index = 94)]
+        /* 0x04A0 */ public float WheelSpinParticleMaxThresh;
+        [NMS(Index = 91)]
+        /* 0x04A4 */ public float WheelSpinParticleMinRate;
+        [NMS(Index = 93)]
+        /* 0x04A8 */ public float WheelSpinParticleMinThresh;
+        [NMS(Index = 113)]
+        /* 0x04AC */ public float WheelStartHeight;
+        [NMS(Index = 38)]
+        /* 0x04B0 */ public float WheelSuspensionAnimMax;
+        [NMS(Index = 37)]
+        /* 0x04B4 */ public float WheelSuspensionAnimMin;
+        [NMS(Index = 36)]
+        /* 0x04B8 */ public float WheelSuspensionDamping;
+        [NMS(Index = 35)]
+        /* 0x04BC */ public float WheelSuspensionForce;
+        [NMS(Index = 34)]
+        /* 0x04C0 */ public float WheelSuspensionlength;
+        [NMS(Index = 147, Size = 0x2)]
+        /* 0x04C4 */ public NMSString0x100[] CockpitHeadlightNames;
+        [NMS(Index = 145, Size = 0x2)]
+        /* 0x06C4 */ public NMSString0x100[] HeadlightNames;
+        [NMS(Index = 146, Size = 0x2)]
+        /* 0x08C4 */ public NMSString0x100[] VolumetricHeadlightNames;
+        [NMS(Index = 22, Size = 0xA)]
+        /* 0x0AC4 */ public NMSString0x20[] WheelNames;
+        [NMS(Index = 23, Size = 0xA)]
+        /* 0x0C04 */ public NMSString0x20[] WheelSuspensionNames;
+        [NMS(Index = 125)]
+        /* 0x0D44 */ public NMSString0x80 AudioBoostStart;
+        [NMS(Index = 126)]
+        /* 0x0DC4 */ public NMSString0x80 AudioBoostStop;
+        [NMS(Index = 127)]
+        /* 0x0E44 */ public NMSString0x80 AudioHornStart;
+        [NMS(Index = 128)]
+        /* 0x0EC4 */ public NMSString0x80 AudioHornStop;
+        [NMS(Index = 129)]
+        /* 0x0F44 */ public NMSString0x80 AudioIdleExterior;
+        [NMS(Index = 130)]
+        /* 0x0FC4 */ public NMSString0x80 AudioImpacts;
+        [NMS(Index = 134)]
+        /* 0x1044 */ public NMSString0x80 AudioJump;
+        [NMS(Index = 131)]
+        /* 0x10C4 */ public NMSString0x80 AudioStart;
+        [NMS(Index = 132)]
+        /* 0x1144 */ public NMSString0x80 AudioStop;
+        [NMS(Index = 133)]
+        /* 0x11C4 */ public NMSString0x80 AudioSuspension;
+        [NMS(Index = 27)]
+        /* 0x1244 */ public bool CustomCollision;
+        [NMS(Index = 135)]
+        /* 0x1245 */ public bool DriveOnTopOfWater;
+        [NMS(Index = 58)]
+        /* 0x1246 */ public bool LockVehicleAxis;
+        [NMS(Index = 83)]
+        /* 0x1247 */ public bool UseBuggySuspensionHack;
+        [NMS(Index = 84)]
+        /* 0x1248 */ public bool UseRoverWheelHack;
+        [NMS(Index = 124)]
+        /* 0x1249 */ public bool VehicleAudioSwapSkidAndSpeed;
     }
 }

--- a/libMBIN/Source/NMS/Globals/GcAudioGlobals.cs
+++ b/libMBIN/Source/NMS/Globals/GcAudioGlobals.cs
@@ -3,24 +3,24 @@ using System.Collections.Generic;
 
 namespace libMBIN.NMS.Globals
 {
-    [NMS(GUID = 0xDA685A34DECD7A9A, NameHash = 0x2BDD54A8)]
+    [NMS(GUID = 0x7EBE352EF356930B, NameHash = 0x2BDD54A8)]
     public class GcAudioGlobals : NMSTemplate
     {
-        [NMS(Index = 35)]
+        [NMS(Index = 36)]
         /* 0x000 */ public List<float> ByteBeatScaleDegreeProbability;
         [NMS(Index = 0)]
         /* 0x010 */ public GcAudioNPCDoppler NPCEngines;
         [NMS(Index = 1)]
         /* 0x064 */ public GcAudio3PointDopplerData DroneDoppler;
-        [NMS(Index = 37)]
-        /* 0x070 */ public Vector2f ByteBeatSpeakerMaxAmplitude;
-        [NMS(Index = 39)]
-        /* 0x078 */ public Vector2f ByteBeatSpeakerMaxFrequency;
         [NMS(Index = 38)]
+        /* 0x070 */ public Vector2f ByteBeatSpeakerMaxAmplitude;
+        [NMS(Index = 40)]
+        /* 0x078 */ public Vector2f ByteBeatSpeakerMaxFrequency;
+        [NMS(Index = 39)]
         /* 0x080 */ public Vector2f ByteBeatSpeakerMinFrequency;
-        [NMS(Index = 63)]
-        /* 0x088 */ public Vector2f CommsChatterFalloffFreighers;
         [NMS(Index = 64)]
+        /* 0x088 */ public Vector2f CommsChatterFalloffFreighers;
+        [NMS(Index = 65)]
         /* 0x090 */ public Vector2f CommsChatterFalloffShips;
         [NMS(Index = 12)]
         /* 0x098 */ public Vector2f ShorelineSenseRadius;
@@ -28,55 +28,55 @@ namespace libMBIN.NMS.Globals
         /* 0x0A0 */ public Vector2f ShorelineSenseUJitter;
         [NMS(Index = 11)]
         /* 0x0A8 */ public Vector2f ShorelineSenseVJitter;
-        [NMS(Index = 60)]
-        /* 0x0B0 */ public float ArmFoleySpeedMultiplier;
         [NMS(Index = 61)]
+        /* 0x0B0 */ public float ArmFoleySpeedMultiplier;
+        [NMS(Index = 62)]
         /* 0x0B4 */ public float ArmWhooshFoleyValueTrigger;
-        [NMS(Index = 46)]
+        [NMS(Index = 47)]
         /* 0x0B8 */ public float AtlasStationActiveDistance;
         [NMS(Index = 2)]
         /* 0x0BC */ public float AuxSendCaveRampDistance;
         [NMS(Index = 3)]
         /* 0x0C0 */ public float AuxSendOutdoorsRampDistance;
-        [NMS(Index = 32)]
-        /* 0x0C4 */ public float ByteBeatBeginAtTonicProbability;
         [NMS(Index = 33)]
-        /* 0x0C8 */ public float ByteBeatChangeNoteProbability;
-        [NMS(Index = 23)]
-        /* 0x0CC */ public float ByteBeatCrossfadeTime;
-        [NMS(Index = 43)]
-        /* 0x0D0 */ public float ByteBeatDrumMixHigh;
-        [NMS(Index = 42)]
-        /* 0x0D4 */ public float ByteBeatDrumMixLow;
-        [NMS(Index = 22)]
-        /* 0x0D8 */ public int ByteBeatMaxGeneratingAudio;
-        [NMS(Index = 28)]
-        /* 0x0DC */ public int ByteBeatNonSilentAttempts;
-        [NMS(Index = 30)]
-        /* 0x0E0 */ public float ByteBeatNonSilentAvgInterpSpeed;
-        [NMS(Index = 31)]
-        /* 0x0E4 */ public float ByteBeatNonSilentSDCutoff;
-        [NMS(Index = 29)]
-        /* 0x0E8 */ public float ByteBeatNonSilentTime;
-        [NMS(Index = 41)]
-        /* 0x0EC */ public float ByteBeatPlayerFadeOut;
-        [NMS(Index = 40)]
-        /* 0x0F0 */ public int ByteBeatPlayerNumLoops;
+        /* 0x0C4 */ public float ByteBeatBeginAtTonicProbability;
         [NMS(Index = 34)]
-        /* 0x0F4 */ public float ByteBeatSkipNoteProbability;
-        [NMS(Index = 36)]
-        /* 0x0F8 */ public float ByteBeatSpeakerVolumeInterSpeed;
-        [NMS(Index = 45)]
-        /* 0x0FC */ public float ByteBeatSynthMixHigh;
-        [NMS(Index = 44)]
-        /* 0x100 */ public float ByteBeatSynthMixLow;
-        [NMS(Index = 27)]
-        /* 0x104 */ public int ByteBeatVisualisationMiniPixelStep;
-        [NMS(Index = 25)]
-        /* 0x108 */ public int ByteBeatVisualisationMode;
-        [NMS(Index = 26)]
-        /* 0x10C */ public int ByteBeatVisualisationPixelStep;
+        /* 0x0C8 */ public float ByteBeatChangeNoteProbability;
         [NMS(Index = 24)]
+        /* 0x0CC */ public float ByteBeatCrossfadeTime;
+        [NMS(Index = 44)]
+        /* 0x0D0 */ public float ByteBeatDrumMixHigh;
+        [NMS(Index = 43)]
+        /* 0x0D4 */ public float ByteBeatDrumMixLow;
+        [NMS(Index = 23)]
+        /* 0x0D8 */ public int ByteBeatMaxGeneratingAudio;
+        [NMS(Index = 29)]
+        /* 0x0DC */ public int ByteBeatNonSilentAttempts;
+        [NMS(Index = 31)]
+        /* 0x0E0 */ public float ByteBeatNonSilentAvgInterpSpeed;
+        [NMS(Index = 32)]
+        /* 0x0E4 */ public float ByteBeatNonSilentSDCutoff;
+        [NMS(Index = 30)]
+        /* 0x0E8 */ public float ByteBeatNonSilentTime;
+        [NMS(Index = 42)]
+        /* 0x0EC */ public float ByteBeatPlayerFadeOut;
+        [NMS(Index = 41)]
+        /* 0x0F0 */ public int ByteBeatPlayerNumLoops;
+        [NMS(Index = 35)]
+        /* 0x0F4 */ public float ByteBeatSkipNoteProbability;
+        [NMS(Index = 37)]
+        /* 0x0F8 */ public float ByteBeatSpeakerVolumeInterSpeed;
+        [NMS(Index = 46)]
+        /* 0x0FC */ public float ByteBeatSynthMixHigh;
+        [NMS(Index = 45)]
+        /* 0x100 */ public float ByteBeatSynthMixLow;
+        [NMS(Index = 28)]
+        /* 0x104 */ public int ByteBeatVisualisationMiniPixelStep;
+        [NMS(Index = 26)]
+        /* 0x108 */ public int ByteBeatVisualisationMode;
+        [NMS(Index = 27)]
+        /* 0x10C */ public int ByteBeatVisualisationPixelStep;
+        [NMS(Index = 25)]
         /* 0x110 */ public float ByteBeatVisualisationTime;
         [NMS(Index = 19)]
         /* 0x114 */ public float DistanceReportMax;
@@ -88,27 +88,27 @@ namespace libMBIN.NMS.Globals
         /* 0x120 */ public float DistanceSquishScaleToListener;
         [NMS(Index = 17)]
         /* 0x124 */ public float DroneDopplerExtentsFactor;
-        [NMS(Index = 56)]
-        /* 0x128 */ public float FishingMusicRampInTime;
         [NMS(Index = 57)]
+        /* 0x128 */ public float FishingMusicRampInTime;
+        [NMS(Index = 58)]
         /* 0x12C */ public float FishingMusicRampOutTime;
         [NMS(Index = 4)]
         /* 0x130 */ public float LadderStepDistance;
-        [NMS(Index = 47)]
-        /* 0x134 */ public float MiniStationActiveDistance;
-        [NMS(Index = 62)]
-        /* 0x138 */ public float MinSecondsBetweenArmWhooshes;
-        [NMS(Index = 54)]
-        /* 0x13C */ public float ObstructionAuxControlWhenHidden;
-        [NMS(Index = 53)]
-        /* 0x140 */ public float ObstructionAuxControlWhenVisible;
-        [NMS(Index = 51)]
-        /* 0x144 */ public float ObstructionSmoothTime;
-        [NMS(Index = 52)]
-        /* 0x148 */ public float ObstructionValueMax;
         [NMS(Index = 48)]
-        /* 0x14C */ public float PlayerDepthUnderwaterMax;
+        /* 0x134 */ public float MiniStationActiveDistance;
+        [NMS(Index = 63)]
+        /* 0x138 */ public float MinSecondsBetweenArmWhooshes;
+        [NMS(Index = 55)]
+        /* 0x13C */ public float ObstructionAuxControlWhenHidden;
+        [NMS(Index = 54)]
+        /* 0x140 */ public float ObstructionAuxControlWhenVisible;
+        [NMS(Index = 52)]
+        /* 0x144 */ public float ObstructionSmoothTime;
+        [NMS(Index = 53)]
+        /* 0x148 */ public float ObstructionValueMax;
         [NMS(Index = 49)]
+        /* 0x14C */ public float PlayerDepthUnderwaterMax;
+        [NMS(Index = 50)]
         /* 0x150 */ public float PlayerLowerOffsetEmitterMul;
         [NMS(Index = 16)]
         /* 0x154 */ public float ShorelineObstructionMul;
@@ -124,17 +124,19 @@ namespace libMBIN.NMS.Globals
         /* 0x168 */ public float ShorelineSenseStartUp;
         [NMS(Index = 13)]
         /* 0x16C */ public float ShorelineValidityRate;
+        [NMS(Index = 22)]
+        /* 0x170 */ public float ThirdPersonPushTowardsPlayer;
         [NMS(Index = 14)]
-        /* 0x170 */ public float WaveintensityRTPCSmoothRate;
+        /* 0x174 */ public float WaveintensityRTPCSmoothRate;
+        [NMS(Index = 60)]
+        /* 0x178 */ public bool EnableVRSpecificAudio;
         [NMS(Index = 59)]
-        /* 0x174 */ public bool EnableVRSpecificAudio;
-        [NMS(Index = 58)]
-        /* 0x175 */ public bool LockListenerMatrix;
-        [NMS(Index = 50)]
-        /* 0x176 */ public bool ObstructionEnabled;
-        [NMS(Index = 55)]
-        /* 0x177 */ public bool PulseMusicEnabled;
+        /* 0x179 */ public bool LockListenerMatrix;
+        [NMS(Index = 51)]
+        /* 0x17A */ public bool ObstructionEnabled;
+        [NMS(Index = 56)]
+        /* 0x17B */ public bool PulseMusicEnabled;
         [NMS(Index = 5)]
-        /* 0x178 */ public bool UseShorelineAudioInOpenWater;
+        /* 0x17C */ public bool UseShorelineAudioInOpenWater;
     }
 }

--- a/libMBIN/Source/NMS/Globals/GcCameraGlobals.cs
+++ b/libMBIN/Source/NMS/Globals/GcCameraGlobals.cs
@@ -4,86 +4,86 @@ using System.Collections.Generic;
 
 namespace libMBIN.NMS.Globals
 {
-    [NMS(GUID = 0xAE6DBAA77A717E18, NameHash = 0xFE7187F)]
+    [NMS(GUID = 0xFDD97CD587CC7318, NameHash = 0xFE7187F)]
     public class GcCameraGlobals : NMSTemplate
     {
-        [NMS(Index = 364)]
+        [NMS(Index = 365)]
         /* 0x0000 */ public TkModelRendererData CameraCreatureCustomiseBack;
-        [NMS(Index = 360)]
-        /* 0x00B0 */ public TkModelRendererData CameraCreatureCustomiseDefault;
-        [NMS(Index = 363)]
-        /* 0x0160 */ public TkModelRendererData CameraCreatureCustomiseFront;
         [NMS(Index = 361)]
-        /* 0x0210 */ public TkModelRendererData CameraCreatureCustomiseLeft;
+        /* 0x00B0 */ public TkModelRendererData CameraCreatureCustomiseDefault;
+        [NMS(Index = 364)]
+        /* 0x0160 */ public TkModelRendererData CameraCreatureCustomiseFront;
         [NMS(Index = 362)]
+        /* 0x0210 */ public TkModelRendererData CameraCreatureCustomiseLeft;
+        [NMS(Index = 363)]
         /* 0x02C0 */ public TkModelRendererData CameraCreatureCustomiseRight;
-        [NMS(Index = 358)]
-        /* 0x0370 */ public TkModelRendererData CameraNPCShipInteraction;
         [NMS(Index = 359)]
+        /* 0x0370 */ public TkModelRendererData CameraNPCShipInteraction;
+        [NMS(Index = 360)]
         /* 0x0420 */ public TkModelRendererData CameraNPCShopInteraction;
         [NMS(Index = 13)]
         /* 0x04D0 */ public TkModelRendererData FreighterCustomisationStandardCamera;
         [NMS(Index = 14)]
         /* 0x0580 */ public TkModelRendererData FreighterCustomisationStandardCameraAlt;
-        [NMS(Index = 307, Size = 0x9, EnumType = typeof(GcAlienRace.AlienRaceEnum))]
+        [NMS(Index = 308, Size = 0x9, EnumType = typeof(GcAlienRace.AlienRaceEnum))]
         /* 0x0630 */ public Vector3f[] FirstPersonCamOffset;
-        [NMS(Index = 205)]
+        [NMS(Index = 206)]
         /* 0x06C0 */ public Vector3f BuildingModeInitialOffset;
-        [NMS(Index = 308)]
+        [NMS(Index = 309)]
         /* 0x06D0 */ public Vector3f FirstPersonInShipCamOffset;
-        [NMS(Index = 151)]
-        /* 0x06E0 */ public Vector3f InteractionHailingFocusOffset;
-        [NMS(Index = 141)]
-        /* 0x06F0 */ public Vector3f InteractionOffset;
-        [NMS(Index = 149)]
-        /* 0x0700 */ public Vector3f InteractionOffsetCronus;
-        [NMS(Index = 146)]
-        /* 0x0710 */ public Vector3f InteractionOffsetDefault;
-        [NMS(Index = 142)]
-        /* 0x0720 */ public Vector3f InteractionOffsetExtraVR;
-        [NMS(Index = 143)]
-        /* 0x0730 */ public Vector3f InteractionOffsetExtraVRSeated;
-        [NMS(Index = 147)]
-        /* 0x0740 */ public Vector3f InteractionOffsetGek;
         [NMS(Index = 152)]
-        /* 0x0750 */ public Vector3f InteractionOffsetRecruitment;
-        [NMS(Index = 148)]
-        /* 0x0760 */ public Vector3f InteractionOffsetSpiderman;
+        /* 0x06E0 */ public Vector3f InteractionHailingFocusOffset;
+        [NMS(Index = 142)]
+        /* 0x06F0 */ public Vector3f InteractionOffset;
         [NMS(Index = 150)]
+        /* 0x0700 */ public Vector3f InteractionOffsetCronus;
+        [NMS(Index = 147)]
+        /* 0x0710 */ public Vector3f InteractionOffsetDefault;
+        [NMS(Index = 143)]
+        /* 0x0720 */ public Vector3f InteractionOffsetExtraVR;
+        [NMS(Index = 144)]
+        /* 0x0730 */ public Vector3f InteractionOffsetExtraVRSeated;
+        [NMS(Index = 148)]
+        /* 0x0740 */ public Vector3f InteractionOffsetGek;
+        [NMS(Index = 153)]
+        /* 0x0750 */ public Vector3f InteractionOffsetRecruitment;
+        [NMS(Index = 149)]
+        /* 0x0760 */ public Vector3f InteractionOffsetSpiderman;
+        [NMS(Index = 151)]
         /* 0x0770 */ public Vector3f InteractionShipFocusOffset;
         [NMS(Index = 36)]
         /* 0x0780 */ public Colour MiniportalFlashColour;
-        [NMS(Index = 139)]
+        [NMS(Index = 140)]
         /* 0x0790 */ public Vector3f ModelViewOffset;
-        [NMS(Index = 291)]
-        /* 0x07A0 */ public Vector3f OffsetCamOffset;
         [NMS(Index = 292)]
+        /* 0x07A0 */ public Vector3f OffsetCamOffset;
+        [NMS(Index = 293)]
         /* 0x07B0 */ public Vector3f OffsetCamRotation;
-        [NMS(Index = 174)]
-        /* 0x07C0 */ public Vector3f OffsetForFleetInteraction;
         [NMS(Index = 175)]
+        /* 0x07C0 */ public Vector3f OffsetForFleetInteraction;
+        [NMS(Index = 176)]
         /* 0x07D0 */ public Vector3f OffsetForFrigateInteraction;
-        [NMS(Index = 203)]
-        /* 0x07E0 */ public Vector3f PhotoModeShipOffset;
         [NMS(Index = 204)]
+        /* 0x07E0 */ public Vector3f PhotoModeShipOffset;
+        [NMS(Index = 205)]
         /* 0x07F0 */ public Vector3f PhotoModeVRFPOffset;
-        [NMS(Index = 144)]
-        /* 0x0800 */ public Vector3f ShopInteractionOffsetExtraVR;
         [NMS(Index = 145)]
+        /* 0x0800 */ public Vector3f ShopInteractionOffsetExtraVR;
+        [NMS(Index = 146)]
         /* 0x0810 */ public Vector3f ShopInteractionOffsetExtraVRSeated;
         [NMS(Index = 39)]
         /* 0x0820 */ public Colour VehicleExitFlashColour;
-        [NMS(Index = 132)]
+        [NMS(Index = 133)]
         /* 0x0830 */ public GcCameraFollowSettings AlienShipFollowCam;
-        [NMS(Index = 120)]
+        [NMS(Index = 121)]
         /* 0x0928 */ public GcCameraFollowSettings BikeFollowCam;
         [NMS(Index = 117)]
         /* 0x0A20 */ public GcCameraFollowSettings BuggyFollowCam;
-        [NMS(Index = 134)]
-        /* 0x0B18 */ public GcCameraFollowSettings BuildingIndoorsCam;
         [NMS(Index = 135)]
-        /* 0x0C10 */ public GcCameraFollowSettings BuildingOutdoorsCam;
+        /* 0x0B18 */ public GcCameraFollowSettings BuildingIndoorsCam;
         [NMS(Index = 136)]
+        /* 0x0C10 */ public GcCameraFollowSettings BuildingOutdoorsCam;
+        [NMS(Index = 137)]
         /* 0x0D08 */ public GcCameraFollowSettings BuildingUnderwaterCam;
         [NMS(Index = 94)]
         /* 0x0E00 */ public GcCameraFollowSettings CharacterAbandCam;
@@ -143,609 +143,611 @@ namespace libMBIN.NMS.Globals
         /* 0x2828 */ public GcCameraFollowSettings CharacterUnderwaterJetpackAscentCam;
         [NMS(Index = 107)]
         /* 0x2920 */ public GcCameraFollowSettings CharacterUnderwaterJetpackCam;
-        [NMS(Index = 127)]
+        [NMS(Index = 128)]
         /* 0x2A18 */ public GcCameraFollowSettings DropshipFollowCam;
         [NMS(Index = 118)]
         /* 0x2B10 */ public GcCameraFollowSettings HovercraftFollowCam;
-        [NMS(Index = 124)]
+        [NMS(Index = 125)]
         /* 0x2C08 */ public GcCameraFollowSettings MechCombatCam;
         [NMS(Index = 18)]
         /* 0x2D00 */ public GcCameraFollowSettings MechFirstPersonCam;
-        [NMS(Index = 123)]
+        [NMS(Index = 124)]
         /* 0x2DF8 */ public GcCameraFollowSettings MechFollowCam;
-        [NMS(Index = 125)]
-        /* 0x2EF0 */ public GcCameraFollowSettings MechJetpackCam;
-        [NMS(Index = 133)]
-        /* 0x2FE8 */ public GcCameraFollowSettings RobotShipFollowCam;
-        [NMS(Index = 129)]
-        /* 0x30E0 */ public GcCameraFollowSettings RoyalShipFollowCam;
-        [NMS(Index = 130)]
-        /* 0x31D8 */ public GcCameraFollowSettings SailShipFollowCam;
-        [NMS(Index = 131)]
-        /* 0x32D0 */ public GcCameraFollowSettings ScienceShipFollowCam;
-        [NMS(Index = 128)]
-        /* 0x33C8 */ public GcCameraFollowSettings ShuttleFollowCam;
         [NMS(Index = 126)]
+        /* 0x2EF0 */ public GcCameraFollowSettings MechJetpackCam;
+        [NMS(Index = 134)]
+        /* 0x2FE8 */ public GcCameraFollowSettings RobotShipFollowCam;
+        [NMS(Index = 130)]
+        /* 0x30E0 */ public GcCameraFollowSettings RoyalShipFollowCam;
+        [NMS(Index = 131)]
+        /* 0x31D8 */ public GcCameraFollowSettings SailShipFollowCam;
+        [NMS(Index = 132)]
+        /* 0x32D0 */ public GcCameraFollowSettings ScienceShipFollowCam;
+        [NMS(Index = 129)]
+        /* 0x33C8 */ public GcCameraFollowSettings ShuttleFollowCam;
+        [NMS(Index = 127)]
         /* 0x34C0 */ public GcCameraFollowSettings SpaceshipFollowCam;
         [NMS(Index = 119)]
         /* 0x35B8 */ public GcCameraFollowSettings SubmarineFollowCam;
-        [NMS(Index = 122)]
-        /* 0x36B0 */ public GcCameraFollowSettings TruckFollowCam;
+        [NMS(Index = 120)]
+        /* 0x36B0 */ public GcCameraFollowSettings SubmarineFollowCamSurface;
+        [NMS(Index = 123)]
+        /* 0x37A8 */ public GcCameraFollowSettings TruckFollowCam;
         [NMS(Index = 17)]
-        /* 0x37A8 */ public GcCameraFollowSettings VehicleCam;
+        /* 0x38A0 */ public GcCameraFollowSettings VehicleCam;
         [NMS(Index = 16)]
-        /* 0x38A0 */ public GcCameraFollowSettings VehicleCamHmd;
-        [NMS(Index = 121)]
-        /* 0x3998 */ public GcCameraFollowSettings WheeledBikeFollowCam;
-        [NMS(Index = 353)]
-        /* 0x3A90 */ public GcCameraAnimationData AmbientCameraAnimations;
+        /* 0x3998 */ public GcCameraFollowSettings VehicleCamHmd;
+        [NMS(Index = 122)]
+        /* 0x3A90 */ public GcCameraFollowSettings WheeledBikeFollowCam;
         [NMS(Index = 354)]
-        /* 0x3AB0 */ public TkModelResource AmbientDroneAnimations;
-        [NMS(Index = 9)]
-        /* 0x3AD0 */ public List<GcCameraAerialViewDataTableEntry> AerialViewDataTable;
+        /* 0x3B88 */ public GcCameraAnimationData AmbientCameraAnimations;
         [NMS(Index = 355)]
-        /* 0x3AE0 */ public VariableSizeString CameraAmbientAnimationsData;
-        [NMS(Index = 15)]
-        /* 0x3AF0 */ public List<GcCameraFollowSettings> Cameras;
-        [NMS(Index = 266)]
-        /* 0x3B00 */ public List<GcCameraShakeData> CameraShakeTable;
-        [NMS(Index = 366)]
-        /* 0x3B10 */ public List<Vector3f> SavedCameraFacing;
-        [NMS(Index = 365)]
-        /* 0x3B20 */ public List<TkPhysRelVectorData> SavedCameraPositions;
-        [NMS(Index = 368)]
-        /* 0x3B30 */ public GcCameraWarpSettings FreighterWarpSettings;
-        [NMS(Index = 369)]
-        /* 0x3B84 */ public GcCameraWarpSettings PirateFreighterWarpSettings;
-        [NMS(Index = 367)]
-        /* 0x3BD8 */ public GcCameraWarpSettings WarpSettings;
-        [NMS(Index = 6)]
-        /* 0x3C2C */ public GcCameraFocusBuildingControlSettings FocusBuildingModeDistanceControlSettings;
-        [NMS(Index = 4)]
-        /* 0x3C4C */ public GcCameraFocusBuildingControlSettings FocusBuildingModePitchControlSettings;
-        [NMS(Index = 7)]
-        /* 0x3C6C */ public GcCameraFocusBuildingControlSettings FocusBuildingModePlanarControlSettings;
-        [NMS(Index = 8)]
-        /* 0x3C8C */ public GcCameraFocusBuildingControlSettings FocusBuildingModeVerticalControlSettings;
-        [NMS(Index = 5)]
-        /* 0x3CAC */ public GcCameraFocusBuildingControlSettings FocusBuildingModeYawControlSettings;
-        [NMS(Index = 140)]
-        /* 0x3CCC */ public Vector2f ModelViewFocusOffset;
-        [NMS(Index = 179)]
-        /* 0x3CD4 */ public Vector2f PitchForFrigateInteraction;
-        [NMS(Index = 180)]
-        /* 0x3CDC */ public Vector2f RotationForFrigateInteraction;
-        [NMS(Index = 213)]
-        /* 0x3CE4 */ public float AerialViewBackTime;
-        [NMS(Index = 214)]
-        /* 0x3CE8 */ public float AerialViewBlendTime;
-        [NMS(Index = 210)]
-        /* 0x3CEC */ public float AerialViewDownDistance;
-        [NMS(Index = 211)]
-        /* 0x3CF0 */ public float AerialViewPause;
-        [NMS(Index = 212)]
-        /* 0x3CF4 */ public float AerialViewStartTime;
-        [NMS(Index = 57)]
-        /* 0x3CF8 */ public float BinocularFlashStrength;
-        [NMS(Index = 56)]
-        /* 0x3CFC */ public float BinocularFlashTime;
-        [NMS(Index = 269)]
-        /* 0x3D00 */ public float BobAmount;
-        [NMS(Index = 267)]
-        /* 0x3D04 */ public float BobAmountAbandFreighter;
-        [NMS(Index = 270)]
-        /* 0x3D08 */ public float BobFactor;
-        [NMS(Index = 268)]
-        /* 0x3D0C */ public float BobFactorAbandFreighter;
-        [NMS(Index = 271)]
-        /* 0x3D10 */ public float BobFocus;
-        [NMS(Index = 275)]
-        /* 0x3D14 */ public float BobFwdAmount;
-        [NMS(Index = 273)]
-        /* 0x3D18 */ public float BobRollAmount;
-        [NMS(Index = 272)]
-        /* 0x3D1C */ public float BobRollFactor;
-        [NMS(Index = 274)]
-        /* 0x3D20 */ public float BobRollOffset;
-        [NMS(Index = 206)]
-        /* 0x3D24 */ public float BuildingModeMaxDistance;
-        [NMS(Index = 357)]
-        /* 0x3D28 */ public float CameraAmbientAutoSwitchMaxTime;
+        /* 0x3BA8 */ public TkModelResource AmbientDroneAnimations;
+        [NMS(Index = 9)]
+        /* 0x3BC8 */ public List<GcCameraAerialViewDataTableEntry> AerialViewDataTable;
         [NMS(Index = 356)]
-        /* 0x3D2C */ public float CameraAmbientAutoSwitchMinTime;
-        [NMS(Index = 276)]
-        /* 0x3D30 */ public float CamSeed1;
-        [NMS(Index = 277)]
-        /* 0x3D34 */ public float CamSeed2;
-        [NMS(Index = 280)]
-        /* 0x3D38 */ public float CamWander1Amplitude;
-        [NMS(Index = 278)]
-        /* 0x3D3C */ public float CamWander1Phase;
-        [NMS(Index = 281)]
-        /* 0x3D40 */ public float CamWander2Amplitude;
-        [NMS(Index = 279)]
-        /* 0x3D44 */ public float CamWander2Phase;
-        [NMS(Index = 299)]
-        /* 0x3D48 */ public float CharCamAutoDirStartTime;
-        [NMS(Index = 302)]
-        /* 0x3D4C */ public float CharCamDeflectSpeed;
-        [NMS(Index = 294)]
-        /* 0x3D50 */ public float CharCamFocusHeight;
-        [NMS(Index = 297)]
-        /* 0x3D54 */ public float CharCamHeight;
-        [NMS(Index = 300)]
-        /* 0x3D58 */ public float CharCamLookOffset;
-        [NMS(Index = 301)]
-        /* 0x3D5C */ public float CharCamLookOffsetFactor;
-        [NMS(Index = 295)]
-        /* 0x3D60 */ public float CharCamMaxDistance;
-        [NMS(Index = 296)]
-        /* 0x3D64 */ public float CharCamMinDistance;
-        [NMS(Index = 303)]
-        /* 0x3D68 */ public float CharCamMinSpeed;
-        [NMS(Index = 298)]
-        /* 0x3D6C */ public float CharCamOffsetTime;
-        [NMS(Index = 304)]
-        /* 0x3D70 */ public float CharCamRightStickX;
-        [NMS(Index = 305)]
-        /* 0x3D74 */ public float CharCamRightStickY;
-        [NMS(Index = 309)]
-        /* 0x3D78 */ public float CloseFactorSpring;
-        [NMS(Index = 350)]
-        /* 0x3D7C */ public float CreatureInteractionCamSpring;
-        [NMS(Index = 337)]
-        /* 0x3D80 */ public float CreatureInteractionDistMulMax;
-        [NMS(Index = 336)]
-        /* 0x3D84 */ public float CreatureInteractionDistMulMin;
-        [NMS(Index = 344)]
-        /* 0x3D88 */ public float CreatureInteractionDownhillPitchTransfer;
-        [NMS(Index = 349)]
-        /* 0x3D8C */ public float CreatureInteractionFoVMax;
-        [NMS(Index = 348)]
-        /* 0x3D90 */ public float CreatureInteractionFoVMin;
-        [NMS(Index = 347)]
-        /* 0x3D94 */ public float CreatureInteractionFoVSplitSize;
-        [NMS(Index = 351)]
-        /* 0x3D98 */ public float CreatureInteractionHeadHeightSpring;
-        [NMS(Index = 343)]
-        /* 0x3D9C */ public float CreatureInteractionMaxDownhillPitchAroundPlayer;
-        [NMS(Index = 345)]
-        /* 0x3DA0 */ public float CreatureInteractionMaxUphillPitchAroundPlayer;
-        [NMS(Index = 333)]
-        /* 0x3DA4 */ public float CreatureInteractionMinDist;
-        [NMS(Index = 342)]
-        /* 0x3DA8 */ public float CreatureInteractionPitchMax;
-        [NMS(Index = 341)]
-        /* 0x3DAC */ public float CreatureInteractionPitchMin;
-        [NMS(Index = 340)]
-        /* 0x3DB0 */ public float CreatureInteractionPitchSplit;
-        [NMS(Index = 335)]
-        /* 0x3DB4 */ public float CreatureInteractionPushCameraDownAmount;
-        [NMS(Index = 334)]
-        /* 0x3DB8 */ public float CreatureInteractionPushCameraDownForCreatureBiggerThan;
-        [NMS(Index = 346)]
-        /* 0x3DBC */ public float CreatureInteractionUphillPitchTransfer;
-        [NMS(Index = 339)]
-        /* 0x3DC0 */ public float CreatureInteractionYawMax;
-        [NMS(Index = 338)]
-        /* 0x3DC4 */ public float CreatureInteractionYawMin;
-        [NMS(Index = 332)]
-        /* 0x3DC8 */ public float CreatureSizeMax;
-        [NMS(Index = 331)]
-        /* 0x3DCC */ public float CreatureSizeMin;
-        [NMS(Index = 258)]
-        /* 0x3DD0 */ public float DebugAICamAt;
-        [NMS(Index = 257)]
-        /* 0x3DD4 */ public float DebugAICamUp;
-        [NMS(Index = 284)]
-        /* 0x3DD8 */ public float DebugCameraFastFactor;
-        [NMS(Index = 286)]
-        /* 0x3DDC */ public float DebugCameraHeightForAccelerateBegin;
-        [NMS(Index = 288)]
-        /* 0x3DE0 */ public float DebugCameraHeightForAccelerateEnd;
-        [NMS(Index = 289)]
-        /* 0x3DE4 */ public float DebugCameraMaxSpeed;
-        [NMS(Index = 283)]
-        /* 0x3DE8 */ public float DebugCameraSlowFactor;
-        [NMS(Index = 285)]
-        /* 0x3DEC */ public float DebugCameraSpaceFastFactor;
-        [NMS(Index = 287)]
-        /* 0x3DF0 */ public float DebugCameraSpeedAtPlanetThreshold;
-        [NMS(Index = 255)]
-        /* 0x3DF4 */ public float DebugMoveCamHeight;
-        [NMS(Index = 254)]
-        /* 0x3DF8 */ public float DebugMoveCamSpeed;
-        [NMS(Index = 28)]
-        /* 0x3DFC */ public float DebugPlanetJumpFarHeight;
-        [NMS(Index = 27)]
-        /* 0x3E00 */ public float DebugPlanetJumpNearHeight;
-        [NMS(Index = 282)]
-        /* 0x3E04 */ public float DebugSpaceStationTeleportOffset;
-        [NMS(Index = 171)]
-        /* 0x3E08 */ public float DistanceForFleetInteraction;
-        [NMS(Index = 172)]
-        /* 0x3E0C */ public float DistanceForFrigateInteraction;
-        [NMS(Index = 173)]
-        /* 0x3E10 */ public float DistanceForFrigatePurchaseInteraction;
-        [NMS(Index = 306)]
-        /* 0x3E14 */ public float FirstPersonCamHeight;
-        [NMS(Index = 310)]
-        /* 0x3E18 */ public float FirstPersonFoV;
-        [NMS(Index = 264)]
-        /* 0x3E1C */ public float FirstPersonSlerpAway;
-        [NMS(Index = 265)]
-        /* 0x3E20 */ public float FirstPersonSlerpTowards;
-        [NMS(Index = 314)]
-        /* 0x3E24 */ public float FirstPersonZoom1FoV;
-        [NMS(Index = 315)]
-        /* 0x3E28 */ public float FirstPersonZoom2FoV;
-        [NMS(Index = 176)]
-        /* 0x3E2C */ public float FleetUIOrbitRate;
-        [NMS(Index = 178)]
-        /* 0x3E30 */ public float FleetUIVerticalMotionAmplitude;
-        [NMS(Index = 177)]
-        /* 0x3E34 */ public float FleetUIVerticalMotionDuration;
-        [NMS(Index = 55)]
-        /* 0x3E38 */ public float FlybyInVehicleDamper;
-        [NMS(Index = 51)]
-        /* 0x3E3C */ public float FlybyMinRange;
-        [NMS(Index = 53)]
-        /* 0x3E40 */ public float FlybyMinRelativeSpeed;
-        [NMS(Index = 52)]
-        /* 0x3E44 */ public float FlybyRange;
-        [NMS(Index = 54)]
-        /* 0x3E48 */ public float FlybyRelativeSpeedRange;
-        [NMS(Index = 3)]
-        /* 0x3E4C */ public float FocusBuildingModeMaxFOV;
-        [NMS(Index = 2)]
-        /* 0x3E50 */ public float FocusBuildingModeMinFOV;
-        [NMS(Index = 1)]
-        /* 0x3E54 */ public float FocusBuildingModeStartDistance;
-        [NMS(Index = 329)]
-        /* 0x3E58 */ public float FoVAdjust;
-        [NMS(Index = 326)]
-        /* 0x3E5C */ public float FoVSpring;
-        [NMS(Index = 327)]
-        /* 0x3E60 */ public float FoVSpringSights;
-        [NMS(Index = 328)]
-        /* 0x3E64 */ public float FoVSpringSightsPassive;
-        [NMS(Index = 165)]
-        /* 0x3E68 */ public float FrigateCaptainLateralShiftAmount;
-        [NMS(Index = 137)]
-        /* 0x3E6C */ public float FrontendModelCameraSpringTime;
-        [NMS(Index = 23)]
-        /* 0x3E70 */ public float HmdEyeExtraTurnAngle;
-        [NMS(Index = 25)]
-        /* 0x3E74 */ public float HmdEyeExtraTurnHeadAngleRange;
-        [NMS(Index = 24)]
-        /* 0x3E78 */ public float HmdEyeExtraTurnMinHeadAngle;
-        [NMS(Index = 22)]
-        /* 0x3E7C */ public float HmdEyeLookAngle;
-        [NMS(Index = 262)]
-        /* 0x3E80 */ public float IndoorCamShakeDamper;
-        [NMS(Index = 154)]
-        /* 0x3E84 */ public float InteractionHeadHeightCronus;
-        [NMS(Index = 153)]
-        /* 0x3E88 */ public float InteractionHeadHeightDefault;
-        [NMS(Index = 155)]
-        /* 0x3E8C */ public float InteractionHeadHeightGek;
-        [NMS(Index = 157)]
-        /* 0x3E90 */ public float InteractionHeadHeightSpiderman;
-        [NMS(Index = 156)]
-        /* 0x3E94 */ public float InteractionHeadHeightVykeen;
-        [NMS(Index = 161)]
-        /* 0x3E98 */ public float InteractionHeadPosHeightAdjust;
-        [NMS(Index = 164)]
-        /* 0x3E9C */ public float InteractionHeadPosHeightAdjustCronus;
-        [NMS(Index = 163)]
-        /* 0x3EA0 */ public float InteractionHeadPosHeightAdjustSpiderman;
-        [NMS(Index = 162)]
-        /* 0x3EA4 */ public float InteractionHeadPosHeightAdjustVykeen;
+        /* 0x3BD8 */ public VariableSizeString CameraAmbientAnimationsData;
+        [NMS(Index = 15)]
+        /* 0x3BE8 */ public List<GcCameraFollowSettings> Cameras;
+        [NMS(Index = 267)]
+        /* 0x3BF8 */ public List<GcCameraShakeData> CameraShakeTable;
+        [NMS(Index = 367)]
+        /* 0x3C08 */ public List<Vector3f> SavedCameraFacing;
+        [NMS(Index = 366)]
+        /* 0x3C18 */ public List<TkPhysRelVectorData> SavedCameraPositions;
+        [NMS(Index = 369)]
+        /* 0x3C28 */ public GcCameraWarpSettings FreighterWarpSettings;
+        [NMS(Index = 370)]
+        /* 0x3C7C */ public GcCameraWarpSettings PirateFreighterWarpSettings;
+        [NMS(Index = 368)]
+        /* 0x3CD0 */ public GcCameraWarpSettings WarpSettings;
+        [NMS(Index = 6)]
+        /* 0x3D24 */ public GcCameraFocusBuildingControlSettings FocusBuildingModeDistanceControlSettings;
+        [NMS(Index = 4)]
+        /* 0x3D44 */ public GcCameraFocusBuildingControlSettings FocusBuildingModePitchControlSettings;
+        [NMS(Index = 7)]
+        /* 0x3D64 */ public GcCameraFocusBuildingControlSettings FocusBuildingModePlanarControlSettings;
+        [NMS(Index = 8)]
+        /* 0x3D84 */ public GcCameraFocusBuildingControlSettings FocusBuildingModeVerticalControlSettings;
+        [NMS(Index = 5)]
+        /* 0x3DA4 */ public GcCameraFocusBuildingControlSettings FocusBuildingModeYawControlSettings;
+        [NMS(Index = 141)]
+        /* 0x3DC4 */ public Vector2f ModelViewFocusOffset;
+        [NMS(Index = 180)]
+        /* 0x3DCC */ public Vector2f PitchForFrigateInteraction;
         [NMS(Index = 181)]
-        /* 0x3EA8 */ public float InteractionModeBlendTime;
-        [NMS(Index = 182)]
-        /* 0x3EAC */ public float InteractionModeFocusCamBlend;
-        [NMS(Index = 183)]
-        /* 0x3EB0 */ public float InteractionModeFoV;
-        [NMS(Index = 160)]
-        /* 0x3EB4 */ public float InteractionPitchAdjustDeadZone;
-        [NMS(Index = 159)]
-        /* 0x3EB8 */ public float InteractionPitchAdjustStrength;
-        [NMS(Index = 158)]
-        /* 0x3EBC */ public float InteractionPitchAdjustTime;
-        [NMS(Index = 169)]
-        /* 0x3EC0 */ public float LocalMissionBoardLateralShiftAmount;
-        [NMS(Index = 60)]
-        /* 0x3EC4 */ public float MaxCreatureRidingYaw;
-        [NMS(Index = 59)]
-        /* 0x3EC8 */ public float MaxFirstPersonCameraPitch;
-        [NMS(Index = 84)]
-        /* 0x3ECC */ public float MechCameraArmShootOffsetY;
-        [NMS(Index = 85)]
-        /* 0x3ED0 */ public float MechCameraCombatFakeSpeed;
-        [NMS(Index = 83)]
-        /* 0x3ED4 */ public float MechCameraExtraYPostLandingBlendTime;
-        [NMS(Index = 82)]
-        /* 0x3ED8 */ public float MechCameraNoExtraYTimeAfterLand;
-        [NMS(Index = 224)]
-        /* 0x3EDC */ public float MechCamSpringStrengthMax;
-        [NMS(Index = 223)]
-        /* 0x3EE0 */ public float MechCamSpringStrengthMin;
-        [NMS(Index = 208)]
-        /* 0x3EE4 */ public float MeleeBoostedFoV;
-        [NMS(Index = 209)]
-        /* 0x3EE8 */ public float MeleeFoV;
-        [NMS(Index = 58)]
-        /* 0x3EEC */ public float MinFirstPersonCameraPitch;
-        [NMS(Index = 185)]
-        /* 0x3EF0 */ public float MinInteractFocusAngle;
-        [NMS(Index = 35)]
-        /* 0x3EF4 */ public float MiniportalFlashStrength;
-        [NMS(Index = 34)]
-        /* 0x3EF8 */ public float MiniportalFlashTime;
-        [NMS(Index = 251)]
-        /* 0x3EFC */ public float ModelViewDefaultPitch;
-        [NMS(Index = 252)]
-        /* 0x3F00 */ public float ModelViewDefaultYaw;
-        [NMS(Index = 248)]
-        /* 0x3F04 */ public float ModelViewDistSpeed;
-        [NMS(Index = 138)]
-        /* 0x3F08 */ public float ModelViewFlashTime;
-        [NMS(Index = 186)]
-        /* 0x3F0C */ public float ModelViewInterpTime;
-        [NMS(Index = 250)]
-        /* 0x3F10 */ public float ModelViewMaxDist;
-        [NMS(Index = 249)]
-        /* 0x3F14 */ public float ModelViewMinDist;
-        [NMS(Index = 247)]
-        /* 0x3F18 */ public float ModelViewMouseMoveSpeed;
-        [NMS(Index = 246)]
-        /* 0x3F1C */ public float ModelViewMouseRotateSnapStrength;
-        [NMS(Index = 245)]
-        /* 0x3F20 */ public float ModelViewMouseRotateSpeed;
-        [NMS(Index = 244)]
-        /* 0x3F24 */ public float ModelViewRotateSpeed;
-        [NMS(Index = 243)]
-        /* 0x3F28 */ public float MouseSensitivity;
-        [NMS(Index = 263)]
-        /* 0x3F2C */ public float NoControlCamShakeDamper;
-        [NMS(Index = 168)]
-        /* 0x3F30 */ public float NPCTradeLateralShiftAmount;
-        [NMS(Index = 170)]
-        /* 0x3F34 */ public float NPCTradeLateralShiftTime;
-        [NMS(Index = 293)]
-        /* 0x3F38 */ public float ObjectFocusTime;
-        [NMS(Index = 290)]
-        /* 0x3F3C */ public float OffsetCamFOV;
-        [NMS(Index = 12)]
-        /* 0x3F40 */ public float OffsetCombatCameraHorizontalAngle;
-        [NMS(Index = 260)]
-        /* 0x3F44 */ public float PainShakeTime;
-        [NMS(Index = 199)]
-        /* 0x3F48 */ public float PhotoModeCollisionRadius;
-        [NMS(Index = 201)]
-        /* 0x3F4C */ public float PhotoModeFlashDuration;
-        [NMS(Index = 202)]
-        /* 0x3F50 */ public float PhotoModeFlashIntensity;
-        [NMS(Index = 195)]
-        /* 0x3F54 */ public float PhotoModeMaxDistance;
-        [NMS(Index = 198)]
-        /* 0x3F58 */ public float PhotoModeMaxDistanceClampBuffer;
-        [NMS(Index = 197)]
-        /* 0x3F5C */ public float PhotoModeMaxDistanceClampForce;
-        [NMS(Index = 196)]
-        /* 0x3F60 */ public float PhotoModeMaxDistanceSpace;
-        [NMS(Index = 193)]
-        /* 0x3F64 */ public float PhotoModeMoveSpeed;
-        [NMS(Index = 200)]
-        /* 0x3F68 */ public float PhotoModeRollSpeed;
-        [NMS(Index = 194)]
-        /* 0x3F6C */ public float PhotoModeTurnSpeed;
-        [NMS(Index = 192)]
-        /* 0x3F70 */ public float PhotoModeVelocitySmoothTime;
-        [NMS(Index = 166)]
-        /* 0x3F74 */ public float PilotDetailsLateralShiftAmount;
-        [NMS(Index = 167)]
-        /* 0x3F78 */ public float RecruitmentLateralShiftAmount;
-        [NMS(Index = 19)]
-        /* 0x3F7C */ public float RevealedNPCHeadOffset;
-        [NMS(Index = 207)]
-        /* 0x3F80 */ public float RunningFoVAdjust;
-        [NMS(Index = 0)]
-        /* 0x3F84 */ public float ScanCameraLookAtTime;
-        [NMS(Index = 10)]
-        /* 0x3F88 */ public float SClassLandingShakeMultiplier;
-        [NMS(Index = 220)]
-        /* 0x3F8C */ public float ScreenshotBackDistance;
-        [NMS(Index = 218)]
-        /* 0x3F90 */ public float ScreenshotBendDownAmount;
-        [NMS(Index = 217)]
-        /* 0x3F94 */ public float ScreenshotHorizonFaceFactor;
-        [NMS(Index = 216)]
-        /* 0x3F98 */ public float ScreenshotHorizonHeight;
-        [NMS(Index = 221)]
-        /* 0x3F9C */ public float ScreenshotInTime;
-        [NMS(Index = 222)]
-        /* 0x3FA0 */ public float ScreenshotOutTime;
-        [NMS(Index = 219)]
-        /* 0x3FA4 */ public float ScreenshotRightDistance;
-        [NMS(Index = 184)]
-        /* 0x3FA8 */ public float ShipBuilderFoV;
-        [NMS(Index = 242)]
-        /* 0x3FAC */ public float ShipCamAimFOV;
-        [NMS(Index = 230)]
-        /* 0x3FB0 */ public float ShipCamLookInterp;
-        [NMS(Index = 231)]
-        /* 0x3FB4 */ public float ShipCamMinReturnTime;
-        [NMS(Index = 238)]
-        /* 0x3FB8 */ public float ShipCamMotionInterp;
-        [NMS(Index = 237)]
-        /* 0x3FBC */ public float ShipCamMotionMaxLagPitchAngle;
-        [NMS(Index = 236)]
-        /* 0x3FC0 */ public float ShipCamMotionMaxLagTurnAngle;
-        [NMS(Index = 234)]
-        /* 0x3FC4 */ public float ShipCamMotionPitch;
-        [NMS(Index = 235)]
-        /* 0x3FC8 */ public float ShipCamMotionPitchMod;
-        [NMS(Index = 233)]
-        /* 0x3FCC */ public float ShipCamMotionTurn;
-        [NMS(Index = 228)]
-        /* 0x3FD0 */ public float ShipCamPitch;
-        [NMS(Index = 229)]
-        /* 0x3FD4 */ public float ShipCamPitchMod;
-        [NMS(Index = 232)]
-        /* 0x3FD8 */ public float ShipCamReturnTime;
-        [NMS(Index = 240)]
-        /* 0x3FDC */ public float ShipCamRollAmountMax;
-        [NMS(Index = 239)]
-        /* 0x3FE0 */ public float ShipCamRollAmountMin;
-        [NMS(Index = 241)]
-        /* 0x3FE4 */ public float ShipCamRollSpeedScaler;
-        [NMS(Index = 226)]
-        /* 0x3FE8 */ public float ShipCamSpringStrengthMax;
-        [NMS(Index = 225)]
-        /* 0x3FEC */ public float ShipCamSpringStrengthMin;
-        [NMS(Index = 227)]
-        /* 0x3FF0 */ public float ShipCamTurn;
-        [NMS(Index = 48)]
-        /* 0x3FF4 */ public float ShipFirstPersonBlendOffset;
-        [NMS(Index = 47)]
-        /* 0x3FF8 */ public float ShipFirstPersonBlendTime;
-        [NMS(Index = 322)]
-        /* 0x3FFC */ public float ShipFoVBoost;
-        [NMS(Index = 318)]
-        /* 0x4000 */ public float ShipFoVMax;
-        [NMS(Index = 321)]
-        /* 0x4004 */ public float ShipFoVMax3rdPerson;
-        [NMS(Index = 316)]
-        /* 0x4008 */ public float ShipFoVMin;
-        [NMS(Index = 317)]
-        /* 0x400C */ public float ShipFoVMin2;
-        [NMS(Index = 320)]
-        /* 0x4010 */ public float ShipFoVMin3rdPerson;
-        [NMS(Index = 323)]
-        /* 0x4014 */ public float ShipFoVMiniJump;
-        [NMS(Index = 324)]
-        /* 0x4018 */ public float ShipFoVSpring;
-        [NMS(Index = 325)]
-        /* 0x401C */ public float ShipMiniJumpFoVSpring;
-        [NMS(Index = 261)]
-        /* 0x4020 */ public float ShipShakeDamper;
-        [NMS(Index = 44)]
-        /* 0x4024 */ public float ShipThirdPersonBlendOffset;
-        [NMS(Index = 46)]
-        /* 0x4028 */ public float ShipThirdPersonBlendOutOffset;
-        [NMS(Index = 45)]
-        /* 0x402C */ public float ShipThirdPersonBlendOutTime;
-        [NMS(Index = 42)]
-        /* 0x4030 */ public float ShipThirdPersonBlendTime;
-        [NMS(Index = 43)]
-        /* 0x4034 */ public float ShipThirdPersonBlendWithOffsetTime;
-        [NMS(Index = 50)]
-        /* 0x4038 */ public float ShipThirdPersonEnterBlendOffset;
-        [NMS(Index = 49)]
-        /* 0x403C */ public float ShipThirdPersonEnterBlendTime;
-        [NMS(Index = 319)]
-        /* 0x4040 */ public float ShipWarpFoV;
-        [NMS(Index = 20)]
-        /* 0x4044 */ public float SpecialVehicleMouseRecentreTime;
-        [NMS(Index = 21)]
-        /* 0x4048 */ public float SpecialVehicleMouseRecentreWeaponTime;
-        [NMS(Index = 32)]
-        /* 0x404C */ public float ThirdPersonAfterIntroCamBlendTime;
-        [NMS(Index = 187)]
-        /* 0x4050 */ public float ThirdPersonBlendInTime;
-        [NMS(Index = 188)]
-        /* 0x4054 */ public float ThirdPersonBlendOutTime;
-        [NMS(Index = 115)]
-        /* 0x4058 */ public float ThirdPersonCameraChangeBlendTime;
-        [NMS(Index = 116)]
-        /* 0x405C */ public float ThirdPersonCameraChangeMinimumBlend;
-        [NMS(Index = 63)]
-        /* 0x4060 */ public float ThirdPersonCloseDistance;
-        [NMS(Index = 64)]
-        /* 0x4064 */ public float ThirdPersonCloseDistanceX;
-        [NMS(Index = 62)]
-        /* 0x4068 */ public float ThirdPersonClosePitch;
-        [NMS(Index = 189)]
-        /* 0x406C */ public float ThirdPersonCollisionPushOffsetReducerStart;
-        [NMS(Index = 313)]
-        /* 0x4070 */ public float ThirdPersonCombatFoV;
-        [NMS(Index = 71)]
-        /* 0x4074 */ public float ThirdPersonDownhillAdjustMaxAngle;
-        [NMS(Index = 75)]
-        /* 0x4078 */ public float ThirdPersonDownhillAdjustMaxAnglePrime;
-        [NMS(Index = 70)]
-        /* 0x407C */ public float ThirdPersonDownhillAdjustMinAngle;
-        [NMS(Index = 74)]
-        /* 0x4080 */ public float ThirdPersonDownhillAdjustMinAnglePrime;
-        [NMS(Index = 69)]
-        /* 0x4084 */ public float ThirdPersonDownhillAdjustSpringTimeMax;
-        [NMS(Index = 68)]
-        /* 0x4088 */ public float ThirdPersonDownhillAdjustSpringTimeMin;
-        [NMS(Index = 311)]
-        /* 0x408C */ public float ThirdPersonFoV;
-        [NMS(Index = 190)]
-        /* 0x4090 */ public float ThirdPersonOffsetSpringTime;
-        [NMS(Index = 65)]
-        /* 0x4094 */ public float ThirdPersonRotationBackAdjustAngleMax;
-        [NMS(Index = 61)]
-        /* 0x4098 */ public float ThirdPersonRotationBackAdjustAngleMin;
-        [NMS(Index = 33)]
-        /* 0x409C */ public float ThirdPersonSkipIntroCamBlendTime;
-        [NMS(Index = 79)]
-        /* 0x40A0 */ public float ThirdPersonUphillAdjustCrossSlopeMaxAngle;
-        [NMS(Index = 78)]
-        /* 0x40A4 */ public float ThirdPersonUphillAdjustCrossSlopeMinAngle;
-        [NMS(Index = 73)]
-        /* 0x40A8 */ public float ThirdPersonUphillAdjustMaxAngle;
-        [NMS(Index = 77)]
-        /* 0x40AC */ public float ThirdPersonUphillAdjustMaxAnglePrime;
-        [NMS(Index = 72)]
-        /* 0x40B0 */ public float ThirdPersonUphillAdjustMinAngle;
-        [NMS(Index = 76)]
-        /* 0x40B4 */ public float ThirdPersonUphillAdjustMinAnglePrime;
-        [NMS(Index = 67)]
-        /* 0x40B8 */ public float ThirdPersonUphillAdjustSpringTimeMax;
-        [NMS(Index = 66)]
-        /* 0x40BC */ public float ThirdPersonUphillAdjustSpringTimeMin;
-        [NMS(Index = 29)]
-        /* 0x40C0 */ public float TogglePerspectiveBlendTime;
-        [NMS(Index = 31)]
-        /* 0x40C4 */ public float UnderwaterCameraExtraVertOffset;
-        [NMS(Index = 38)]
-        /* 0x40C8 */ public float VehicleExitFlashStrength;
-        [NMS(Index = 37)]
-        /* 0x40CC */ public float VehicleExitFlashTime;
-        [NMS(Index = 312)]
-        /* 0x40D0 */ public float VehicleFirstPersonFoV;
-        [NMS(Index = 40)]
-        /* 0x40D4 */ public float VehicleFirstToThirdExitOffsetY;
-        [NMS(Index = 41)]
-        /* 0x40D8 */ public float VehicleFirstToThirdExitOffsetZ;
-        [NMS(Index = 81)]
-        /* 0x40DC */ public float VehicleThirdPersonShootOffsetBlendOutTime;
-        [NMS(Index = 80)]
-        /* 0x40E0 */ public float VehicleThirdPersonShootOffsetReturnTime;
-        [NMS(Index = 259)]
-        /* 0x40E4 */ public float VRShakeMultiplier;
+        /* 0x3DD4 */ public Vector2f RotationForFrigateInteraction;
+        [NMS(Index = 214)]
+        /* 0x3DDC */ public float AerialViewBackTime;
         [NMS(Index = 215)]
-        /* 0x40E8 */ public TkCurveType AerialViewCurve;
-        [NMS(Index = 330)]
-        /* 0x40E9 */ public bool CreatureInteractionInterpolateDuringHold;
-        [NMS(Index = 256)]
-        /* 0x40EA */ public bool DebugAICam;
-        [NMS(Index = 253)]
-        /* 0x40EB */ public bool DebugMoveCam;
+        /* 0x3DE0 */ public float AerialViewBlendTime;
+        [NMS(Index = 211)]
+        /* 0x3DE4 */ public float AerialViewDownDistance;
+        [NMS(Index = 212)]
+        /* 0x3DE8 */ public float AerialViewPause;
+        [NMS(Index = 213)]
+        /* 0x3DEC */ public float AerialViewStartTime;
+        [NMS(Index = 57)]
+        /* 0x3DF0 */ public float BinocularFlashStrength;
+        [NMS(Index = 56)]
+        /* 0x3DF4 */ public float BinocularFlashTime;
+        [NMS(Index = 270)]
+        /* 0x3DF8 */ public float BobAmount;
+        [NMS(Index = 268)]
+        /* 0x3DFC */ public float BobAmountAbandFreighter;
+        [NMS(Index = 271)]
+        /* 0x3E00 */ public float BobFactor;
+        [NMS(Index = 269)]
+        /* 0x3E04 */ public float BobFactorAbandFreighter;
+        [NMS(Index = 272)]
+        /* 0x3E08 */ public float BobFocus;
+        [NMS(Index = 276)]
+        /* 0x3E0C */ public float BobFwdAmount;
+        [NMS(Index = 274)]
+        /* 0x3E10 */ public float BobRollAmount;
+        [NMS(Index = 273)]
+        /* 0x3E14 */ public float BobRollFactor;
+        [NMS(Index = 275)]
+        /* 0x3E18 */ public float BobRollOffset;
+        [NMS(Index = 207)]
+        /* 0x3E1C */ public float BuildingModeMaxDistance;
+        [NMS(Index = 358)]
+        /* 0x3E20 */ public float CameraAmbientAutoSwitchMaxTime;
+        [NMS(Index = 357)]
+        /* 0x3E24 */ public float CameraAmbientAutoSwitchMinTime;
+        [NMS(Index = 277)]
+        /* 0x3E28 */ public float CamSeed1;
+        [NMS(Index = 278)]
+        /* 0x3E2C */ public float CamSeed2;
+        [NMS(Index = 281)]
+        /* 0x3E30 */ public float CamWander1Amplitude;
+        [NMS(Index = 279)]
+        /* 0x3E34 */ public float CamWander1Phase;
+        [NMS(Index = 282)]
+        /* 0x3E38 */ public float CamWander2Amplitude;
+        [NMS(Index = 280)]
+        /* 0x3E3C */ public float CamWander2Phase;
+        [NMS(Index = 300)]
+        /* 0x3E40 */ public float CharCamAutoDirStartTime;
+        [NMS(Index = 303)]
+        /* 0x3E44 */ public float CharCamDeflectSpeed;
+        [NMS(Index = 295)]
+        /* 0x3E48 */ public float CharCamFocusHeight;
+        [NMS(Index = 298)]
+        /* 0x3E4C */ public float CharCamHeight;
+        [NMS(Index = 301)]
+        /* 0x3E50 */ public float CharCamLookOffset;
+        [NMS(Index = 302)]
+        /* 0x3E54 */ public float CharCamLookOffsetFactor;
+        [NMS(Index = 296)]
+        /* 0x3E58 */ public float CharCamMaxDistance;
+        [NMS(Index = 297)]
+        /* 0x3E5C */ public float CharCamMinDistance;
+        [NMS(Index = 304)]
+        /* 0x3E60 */ public float CharCamMinSpeed;
+        [NMS(Index = 299)]
+        /* 0x3E64 */ public float CharCamOffsetTime;
+        [NMS(Index = 305)]
+        /* 0x3E68 */ public float CharCamRightStickX;
+        [NMS(Index = 306)]
+        /* 0x3E6C */ public float CharCamRightStickY;
+        [NMS(Index = 310)]
+        /* 0x3E70 */ public float CloseFactorSpring;
+        [NMS(Index = 351)]
+        /* 0x3E74 */ public float CreatureInteractionCamSpring;
+        [NMS(Index = 338)]
+        /* 0x3E78 */ public float CreatureInteractionDistMulMax;
+        [NMS(Index = 337)]
+        /* 0x3E7C */ public float CreatureInteractionDistMulMin;
+        [NMS(Index = 345)]
+        /* 0x3E80 */ public float CreatureInteractionDownhillPitchTransfer;
+        [NMS(Index = 350)]
+        /* 0x3E84 */ public float CreatureInteractionFoVMax;
+        [NMS(Index = 349)]
+        /* 0x3E88 */ public float CreatureInteractionFoVMin;
+        [NMS(Index = 348)]
+        /* 0x3E8C */ public float CreatureInteractionFoVSplitSize;
         [NMS(Index = 352)]
-        /* 0x40EC */ public bool FollowDrawCamProbes;
-        [NMS(Index = 30)]
-        /* 0x40ED */ public bool LockFollowSpring;
+        /* 0x3E90 */ public float CreatureInteractionHeadHeightSpring;
+        [NMS(Index = 344)]
+        /* 0x3E94 */ public float CreatureInteractionMaxDownhillPitchAroundPlayer;
+        [NMS(Index = 346)]
+        /* 0x3E98 */ public float CreatureInteractionMaxUphillPitchAroundPlayer;
+        [NMS(Index = 334)]
+        /* 0x3E9C */ public float CreatureInteractionMinDist;
+        [NMS(Index = 343)]
+        /* 0x3EA0 */ public float CreatureInteractionPitchMax;
+        [NMS(Index = 342)]
+        /* 0x3EA4 */ public float CreatureInteractionPitchMin;
+        [NMS(Index = 341)]
+        /* 0x3EA8 */ public float CreatureInteractionPitchSplit;
+        [NMS(Index = 336)]
+        /* 0x3EAC */ public float CreatureInteractionPushCameraDownAmount;
+        [NMS(Index = 335)]
+        /* 0x3EB0 */ public float CreatureInteractionPushCameraDownForCreatureBiggerThan;
+        [NMS(Index = 347)]
+        /* 0x3EB4 */ public float CreatureInteractionUphillPitchTransfer;
+        [NMS(Index = 340)]
+        /* 0x3EB8 */ public float CreatureInteractionYawMax;
+        [NMS(Index = 339)]
+        /* 0x3EBC */ public float CreatureInteractionYawMin;
+        [NMS(Index = 333)]
+        /* 0x3EC0 */ public float CreatureSizeMax;
+        [NMS(Index = 332)]
+        /* 0x3EC4 */ public float CreatureSizeMin;
+        [NMS(Index = 259)]
+        /* 0x3EC8 */ public float DebugAICamAt;
+        [NMS(Index = 258)]
+        /* 0x3ECC */ public float DebugAICamUp;
+        [NMS(Index = 285)]
+        /* 0x3ED0 */ public float DebugCameraFastFactor;
+        [NMS(Index = 287)]
+        /* 0x3ED4 */ public float DebugCameraHeightForAccelerateBegin;
+        [NMS(Index = 289)]
+        /* 0x3ED8 */ public float DebugCameraHeightForAccelerateEnd;
+        [NMS(Index = 290)]
+        /* 0x3EDC */ public float DebugCameraMaxSpeed;
+        [NMS(Index = 284)]
+        /* 0x3EE0 */ public float DebugCameraSlowFactor;
+        [NMS(Index = 286)]
+        /* 0x3EE4 */ public float DebugCameraSpaceFastFactor;
+        [NMS(Index = 288)]
+        /* 0x3EE8 */ public float DebugCameraSpeedAtPlanetThreshold;
+        [NMS(Index = 256)]
+        /* 0x3EEC */ public float DebugMoveCamHeight;
+        [NMS(Index = 255)]
+        /* 0x3EF0 */ public float DebugMoveCamSpeed;
+        [NMS(Index = 28)]
+        /* 0x3EF4 */ public float DebugPlanetJumpFarHeight;
+        [NMS(Index = 27)]
+        /* 0x3EF8 */ public float DebugPlanetJumpNearHeight;
+        [NMS(Index = 283)]
+        /* 0x3EFC */ public float DebugSpaceStationTeleportOffset;
+        [NMS(Index = 172)]
+        /* 0x3F00 */ public float DistanceForFleetInteraction;
+        [NMS(Index = 173)]
+        /* 0x3F04 */ public float DistanceForFrigateInteraction;
+        [NMS(Index = 174)]
+        /* 0x3F08 */ public float DistanceForFrigatePurchaseInteraction;
+        [NMS(Index = 307)]
+        /* 0x3F0C */ public float FirstPersonCamHeight;
+        [NMS(Index = 311)]
+        /* 0x3F10 */ public float FirstPersonFoV;
+        [NMS(Index = 265)]
+        /* 0x3F14 */ public float FirstPersonSlerpAway;
+        [NMS(Index = 266)]
+        /* 0x3F18 */ public float FirstPersonSlerpTowards;
+        [NMS(Index = 315)]
+        /* 0x3F1C */ public float FirstPersonZoom1FoV;
+        [NMS(Index = 316)]
+        /* 0x3F20 */ public float FirstPersonZoom2FoV;
+        [NMS(Index = 177)]
+        /* 0x3F24 */ public float FleetUIOrbitRate;
+        [NMS(Index = 179)]
+        /* 0x3F28 */ public float FleetUIVerticalMotionAmplitude;
+        [NMS(Index = 178)]
+        /* 0x3F2C */ public float FleetUIVerticalMotionDuration;
+        [NMS(Index = 55)]
+        /* 0x3F30 */ public float FlybyInVehicleDamper;
+        [NMS(Index = 51)]
+        /* 0x3F34 */ public float FlybyMinRange;
+        [NMS(Index = 53)]
+        /* 0x3F38 */ public float FlybyMinRelativeSpeed;
+        [NMS(Index = 52)]
+        /* 0x3F3C */ public float FlybyRange;
+        [NMS(Index = 54)]
+        /* 0x3F40 */ public float FlybyRelativeSpeedRange;
+        [NMS(Index = 3)]
+        /* 0x3F44 */ public float FocusBuildingModeMaxFOV;
+        [NMS(Index = 2)]
+        /* 0x3F48 */ public float FocusBuildingModeMinFOV;
+        [NMS(Index = 1)]
+        /* 0x3F4C */ public float FocusBuildingModeStartDistance;
+        [NMS(Index = 330)]
+        /* 0x3F50 */ public float FoVAdjust;
+        [NMS(Index = 327)]
+        /* 0x3F54 */ public float FoVSpring;
+        [NMS(Index = 328)]
+        /* 0x3F58 */ public float FoVSpringSights;
+        [NMS(Index = 329)]
+        /* 0x3F5C */ public float FoVSpringSightsPassive;
+        [NMS(Index = 166)]
+        /* 0x3F60 */ public float FrigateCaptainLateralShiftAmount;
+        [NMS(Index = 138)]
+        /* 0x3F64 */ public float FrontendModelCameraSpringTime;
+        [NMS(Index = 23)]
+        /* 0x3F68 */ public float HmdEyeExtraTurnAngle;
+        [NMS(Index = 25)]
+        /* 0x3F6C */ public float HmdEyeExtraTurnHeadAngleRange;
+        [NMS(Index = 24)]
+        /* 0x3F70 */ public float HmdEyeExtraTurnMinHeadAngle;
+        [NMS(Index = 22)]
+        /* 0x3F74 */ public float HmdEyeLookAngle;
+        [NMS(Index = 263)]
+        /* 0x3F78 */ public float IndoorCamShakeDamper;
+        [NMS(Index = 155)]
+        /* 0x3F7C */ public float InteractionHeadHeightCronus;
+        [NMS(Index = 154)]
+        /* 0x3F80 */ public float InteractionHeadHeightDefault;
+        [NMS(Index = 156)]
+        /* 0x3F84 */ public float InteractionHeadHeightGek;
+        [NMS(Index = 158)]
+        /* 0x3F88 */ public float InteractionHeadHeightSpiderman;
+        [NMS(Index = 157)]
+        /* 0x3F8C */ public float InteractionHeadHeightVykeen;
+        [NMS(Index = 162)]
+        /* 0x3F90 */ public float InteractionHeadPosHeightAdjust;
+        [NMS(Index = 165)]
+        /* 0x3F94 */ public float InteractionHeadPosHeightAdjustCronus;
+        [NMS(Index = 164)]
+        /* 0x3F98 */ public float InteractionHeadPosHeightAdjustSpiderman;
+        [NMS(Index = 163)]
+        /* 0x3F9C */ public float InteractionHeadPosHeightAdjustVykeen;
+        [NMS(Index = 182)]
+        /* 0x3FA0 */ public float InteractionModeBlendTime;
+        [NMS(Index = 183)]
+        /* 0x3FA4 */ public float InteractionModeFocusCamBlend;
+        [NMS(Index = 184)]
+        /* 0x3FA8 */ public float InteractionModeFoV;
+        [NMS(Index = 161)]
+        /* 0x3FAC */ public float InteractionPitchAdjustDeadZone;
+        [NMS(Index = 160)]
+        /* 0x3FB0 */ public float InteractionPitchAdjustStrength;
+        [NMS(Index = 159)]
+        /* 0x3FB4 */ public float InteractionPitchAdjustTime;
+        [NMS(Index = 170)]
+        /* 0x3FB8 */ public float LocalMissionBoardLateralShiftAmount;
+        [NMS(Index = 60)]
+        /* 0x3FBC */ public float MaxCreatureRidingYaw;
+        [NMS(Index = 59)]
+        /* 0x3FC0 */ public float MaxFirstPersonCameraPitch;
+        [NMS(Index = 84)]
+        /* 0x3FC4 */ public float MechCameraArmShootOffsetY;
+        [NMS(Index = 85)]
+        /* 0x3FC8 */ public float MechCameraCombatFakeSpeed;
+        [NMS(Index = 83)]
+        /* 0x3FCC */ public float MechCameraExtraYPostLandingBlendTime;
+        [NMS(Index = 82)]
+        /* 0x3FD0 */ public float MechCameraNoExtraYTimeAfterLand;
+        [NMS(Index = 225)]
+        /* 0x3FD4 */ public float MechCamSpringStrengthMax;
+        [NMS(Index = 224)]
+        /* 0x3FD8 */ public float MechCamSpringStrengthMin;
+        [NMS(Index = 209)]
+        /* 0x3FDC */ public float MeleeBoostedFoV;
+        [NMS(Index = 210)]
+        /* 0x3FE0 */ public float MeleeFoV;
+        [NMS(Index = 58)]
+        /* 0x3FE4 */ public float MinFirstPersonCameraPitch;
+        [NMS(Index = 186)]
+        /* 0x3FE8 */ public float MinInteractFocusAngle;
+        [NMS(Index = 35)]
+        /* 0x3FEC */ public float MiniportalFlashStrength;
+        [NMS(Index = 34)]
+        /* 0x3FF0 */ public float MiniportalFlashTime;
+        [NMS(Index = 252)]
+        /* 0x3FF4 */ public float ModelViewDefaultPitch;
+        [NMS(Index = 253)]
+        /* 0x3FF8 */ public float ModelViewDefaultYaw;
+        [NMS(Index = 249)]
+        /* 0x3FFC */ public float ModelViewDistSpeed;
+        [NMS(Index = 139)]
+        /* 0x4000 */ public float ModelViewFlashTime;
+        [NMS(Index = 187)]
+        /* 0x4004 */ public float ModelViewInterpTime;
+        [NMS(Index = 251)]
+        /* 0x4008 */ public float ModelViewMaxDist;
+        [NMS(Index = 250)]
+        /* 0x400C */ public float ModelViewMinDist;
+        [NMS(Index = 248)]
+        /* 0x4010 */ public float ModelViewMouseMoveSpeed;
+        [NMS(Index = 247)]
+        /* 0x4014 */ public float ModelViewMouseRotateSnapStrength;
+        [NMS(Index = 246)]
+        /* 0x4018 */ public float ModelViewMouseRotateSpeed;
+        [NMS(Index = 245)]
+        /* 0x401C */ public float ModelViewRotateSpeed;
+        [NMS(Index = 244)]
+        /* 0x4020 */ public float MouseSensitivity;
+        [NMS(Index = 264)]
+        /* 0x4024 */ public float NoControlCamShakeDamper;
+        [NMS(Index = 169)]
+        /* 0x4028 */ public float NPCTradeLateralShiftAmount;
+        [NMS(Index = 171)]
+        /* 0x402C */ public float NPCTradeLateralShiftTime;
+        [NMS(Index = 294)]
+        /* 0x4030 */ public float ObjectFocusTime;
+        [NMS(Index = 291)]
+        /* 0x4034 */ public float OffsetCamFOV;
+        [NMS(Index = 12)]
+        /* 0x4038 */ public float OffsetCombatCameraHorizontalAngle;
+        [NMS(Index = 261)]
+        /* 0x403C */ public float PainShakeTime;
+        [NMS(Index = 200)]
+        /* 0x4040 */ public float PhotoModeCollisionRadius;
+        [NMS(Index = 202)]
+        /* 0x4044 */ public float PhotoModeFlashDuration;
+        [NMS(Index = 203)]
+        /* 0x4048 */ public float PhotoModeFlashIntensity;
+        [NMS(Index = 196)]
+        /* 0x404C */ public float PhotoModeMaxDistance;
+        [NMS(Index = 199)]
+        /* 0x4050 */ public float PhotoModeMaxDistanceClampBuffer;
+        [NMS(Index = 198)]
+        /* 0x4054 */ public float PhotoModeMaxDistanceClampForce;
+        [NMS(Index = 197)]
+        /* 0x4058 */ public float PhotoModeMaxDistanceSpace;
+        [NMS(Index = 194)]
+        /* 0x405C */ public float PhotoModeMoveSpeed;
+        [NMS(Index = 201)]
+        /* 0x4060 */ public float PhotoModeRollSpeed;
+        [NMS(Index = 195)]
+        /* 0x4064 */ public float PhotoModeTurnSpeed;
+        [NMS(Index = 193)]
+        /* 0x4068 */ public float PhotoModeVelocitySmoothTime;
+        [NMS(Index = 167)]
+        /* 0x406C */ public float PilotDetailsLateralShiftAmount;
+        [NMS(Index = 168)]
+        /* 0x4070 */ public float RecruitmentLateralShiftAmount;
+        [NMS(Index = 19)]
+        /* 0x4074 */ public float RevealedNPCHeadOffset;
+        [NMS(Index = 208)]
+        /* 0x4078 */ public float RunningFoVAdjust;
+        [NMS(Index = 0)]
+        /* 0x407C */ public float ScanCameraLookAtTime;
+        [NMS(Index = 10)]
+        /* 0x4080 */ public float SClassLandingShakeMultiplier;
+        [NMS(Index = 221)]
+        /* 0x4084 */ public float ScreenshotBackDistance;
+        [NMS(Index = 219)]
+        /* 0x4088 */ public float ScreenshotBendDownAmount;
+        [NMS(Index = 218)]
+        /* 0x408C */ public float ScreenshotHorizonFaceFactor;
+        [NMS(Index = 217)]
+        /* 0x4090 */ public float ScreenshotHorizonHeight;
+        [NMS(Index = 222)]
+        /* 0x4094 */ public float ScreenshotInTime;
+        [NMS(Index = 223)]
+        /* 0x4098 */ public float ScreenshotOutTime;
+        [NMS(Index = 220)]
+        /* 0x409C */ public float ScreenshotRightDistance;
+        [NMS(Index = 185)]
+        /* 0x40A0 */ public float ShipBuilderFoV;
+        [NMS(Index = 243)]
+        /* 0x40A4 */ public float ShipCamAimFOV;
+        [NMS(Index = 231)]
+        /* 0x40A8 */ public float ShipCamLookInterp;
+        [NMS(Index = 232)]
+        /* 0x40AC */ public float ShipCamMinReturnTime;
+        [NMS(Index = 239)]
+        /* 0x40B0 */ public float ShipCamMotionInterp;
+        [NMS(Index = 238)]
+        /* 0x40B4 */ public float ShipCamMotionMaxLagPitchAngle;
+        [NMS(Index = 237)]
+        /* 0x40B8 */ public float ShipCamMotionMaxLagTurnAngle;
+        [NMS(Index = 235)]
+        /* 0x40BC */ public float ShipCamMotionPitch;
+        [NMS(Index = 236)]
+        /* 0x40C0 */ public float ShipCamMotionPitchMod;
+        [NMS(Index = 234)]
+        /* 0x40C4 */ public float ShipCamMotionTurn;
+        [NMS(Index = 229)]
+        /* 0x40C8 */ public float ShipCamPitch;
+        [NMS(Index = 230)]
+        /* 0x40CC */ public float ShipCamPitchMod;
+        [NMS(Index = 233)]
+        /* 0x40D0 */ public float ShipCamReturnTime;
+        [NMS(Index = 241)]
+        /* 0x40D4 */ public float ShipCamRollAmountMax;
+        [NMS(Index = 240)]
+        /* 0x40D8 */ public float ShipCamRollAmountMin;
+        [NMS(Index = 242)]
+        /* 0x40DC */ public float ShipCamRollSpeedScaler;
+        [NMS(Index = 227)]
+        /* 0x40E0 */ public float ShipCamSpringStrengthMax;
+        [NMS(Index = 226)]
+        /* 0x40E4 */ public float ShipCamSpringStrengthMin;
+        [NMS(Index = 228)]
+        /* 0x40E8 */ public float ShipCamTurn;
+        [NMS(Index = 48)]
+        /* 0x40EC */ public float ShipFirstPersonBlendOffset;
+        [NMS(Index = 47)]
+        /* 0x40F0 */ public float ShipFirstPersonBlendTime;
+        [NMS(Index = 323)]
+        /* 0x40F4 */ public float ShipFoVBoost;
+        [NMS(Index = 319)]
+        /* 0x40F8 */ public float ShipFoVMax;
+        [NMS(Index = 322)]
+        /* 0x40FC */ public float ShipFoVMax3rdPerson;
+        [NMS(Index = 317)]
+        /* 0x4100 */ public float ShipFoVMin;
+        [NMS(Index = 318)]
+        /* 0x4104 */ public float ShipFoVMin2;
+        [NMS(Index = 321)]
+        /* 0x4108 */ public float ShipFoVMin3rdPerson;
+        [NMS(Index = 324)]
+        /* 0x410C */ public float ShipFoVMiniJump;
+        [NMS(Index = 325)]
+        /* 0x4110 */ public float ShipFoVSpring;
+        [NMS(Index = 326)]
+        /* 0x4114 */ public float ShipMiniJumpFoVSpring;
+        [NMS(Index = 262)]
+        /* 0x4118 */ public float ShipShakeDamper;
+        [NMS(Index = 44)]
+        /* 0x411C */ public float ShipThirdPersonBlendOffset;
+        [NMS(Index = 46)]
+        /* 0x4120 */ public float ShipThirdPersonBlendOutOffset;
+        [NMS(Index = 45)]
+        /* 0x4124 */ public float ShipThirdPersonBlendOutTime;
+        [NMS(Index = 42)]
+        /* 0x4128 */ public float ShipThirdPersonBlendTime;
+        [NMS(Index = 43)]
+        /* 0x412C */ public float ShipThirdPersonBlendWithOffsetTime;
+        [NMS(Index = 50)]
+        /* 0x4130 */ public float ShipThirdPersonEnterBlendOffset;
+        [NMS(Index = 49)]
+        /* 0x4134 */ public float ShipThirdPersonEnterBlendTime;
+        [NMS(Index = 320)]
+        /* 0x4138 */ public float ShipWarpFoV;
+        [NMS(Index = 20)]
+        /* 0x413C */ public float SpecialVehicleMouseRecentreTime;
+        [NMS(Index = 21)]
+        /* 0x4140 */ public float SpecialVehicleMouseRecentreWeaponTime;
+        [NMS(Index = 32)]
+        /* 0x4144 */ public float ThirdPersonAfterIntroCamBlendTime;
+        [NMS(Index = 188)]
+        /* 0x4148 */ public float ThirdPersonBlendInTime;
+        [NMS(Index = 189)]
+        /* 0x414C */ public float ThirdPersonBlendOutTime;
+        [NMS(Index = 115)]
+        /* 0x4150 */ public float ThirdPersonCameraChangeBlendTime;
+        [NMS(Index = 116)]
+        /* 0x4154 */ public float ThirdPersonCameraChangeMinimumBlend;
+        [NMS(Index = 63)]
+        /* 0x4158 */ public float ThirdPersonCloseDistance;
+        [NMS(Index = 64)]
+        /* 0x415C */ public float ThirdPersonCloseDistanceX;
+        [NMS(Index = 62)]
+        /* 0x4160 */ public float ThirdPersonClosePitch;
+        [NMS(Index = 190)]
+        /* 0x4164 */ public float ThirdPersonCollisionPushOffsetReducerStart;
+        [NMS(Index = 314)]
+        /* 0x4168 */ public float ThirdPersonCombatFoV;
+        [NMS(Index = 71)]
+        /* 0x416C */ public float ThirdPersonDownhillAdjustMaxAngle;
+        [NMS(Index = 75)]
+        /* 0x4170 */ public float ThirdPersonDownhillAdjustMaxAnglePrime;
+        [NMS(Index = 70)]
+        /* 0x4174 */ public float ThirdPersonDownhillAdjustMinAngle;
+        [NMS(Index = 74)]
+        /* 0x4178 */ public float ThirdPersonDownhillAdjustMinAnglePrime;
+        [NMS(Index = 69)]
+        /* 0x417C */ public float ThirdPersonDownhillAdjustSpringTimeMax;
+        [NMS(Index = 68)]
+        /* 0x4180 */ public float ThirdPersonDownhillAdjustSpringTimeMin;
+        [NMS(Index = 312)]
+        /* 0x4184 */ public float ThirdPersonFoV;
         [NMS(Index = 191)]
-        /* 0x40EE */ public bool MaxBob;
+        /* 0x4188 */ public float ThirdPersonOffsetSpringTime;
+        [NMS(Index = 65)]
+        /* 0x418C */ public float ThirdPersonRotationBackAdjustAngleMax;
+        [NMS(Index = 61)]
+        /* 0x4190 */ public float ThirdPersonRotationBackAdjustAngleMin;
+        [NMS(Index = 33)]
+        /* 0x4194 */ public float ThirdPersonSkipIntroCamBlendTime;
+        [NMS(Index = 79)]
+        /* 0x4198 */ public float ThirdPersonUphillAdjustCrossSlopeMaxAngle;
+        [NMS(Index = 78)]
+        /* 0x419C */ public float ThirdPersonUphillAdjustCrossSlopeMinAngle;
+        [NMS(Index = 73)]
+        /* 0x41A0 */ public float ThirdPersonUphillAdjustMaxAngle;
+        [NMS(Index = 77)]
+        /* 0x41A4 */ public float ThirdPersonUphillAdjustMaxAnglePrime;
+        [NMS(Index = 72)]
+        /* 0x41A8 */ public float ThirdPersonUphillAdjustMinAngle;
+        [NMS(Index = 76)]
+        /* 0x41AC */ public float ThirdPersonUphillAdjustMinAnglePrime;
+        [NMS(Index = 67)]
+        /* 0x41B0 */ public float ThirdPersonUphillAdjustSpringTimeMax;
+        [NMS(Index = 66)]
+        /* 0x41B4 */ public float ThirdPersonUphillAdjustSpringTimeMin;
+        [NMS(Index = 29)]
+        /* 0x41B8 */ public float TogglePerspectiveBlendTime;
+        [NMS(Index = 31)]
+        /* 0x41BC */ public float UnderwaterCameraExtraVertOffset;
+        [NMS(Index = 38)]
+        /* 0x41C0 */ public float VehicleExitFlashStrength;
+        [NMS(Index = 37)]
+        /* 0x41C4 */ public float VehicleExitFlashTime;
+        [NMS(Index = 313)]
+        /* 0x41C8 */ public float VehicleFirstPersonFoV;
+        [NMS(Index = 40)]
+        /* 0x41CC */ public float VehicleFirstToThirdExitOffsetY;
+        [NMS(Index = 41)]
+        /* 0x41D0 */ public float VehicleFirstToThirdExitOffsetZ;
+        [NMS(Index = 81)]
+        /* 0x41D4 */ public float VehicleThirdPersonShootOffsetBlendOutTime;
+        [NMS(Index = 80)]
+        /* 0x41D8 */ public float VehicleThirdPersonShootOffsetReturnTime;
+        [NMS(Index = 260)]
+        /* 0x41DC */ public float VRShakeMultiplier;
+        [NMS(Index = 216)]
+        /* 0x41E0 */ public TkCurveType AerialViewCurve;
+        [NMS(Index = 331)]
+        /* 0x41E1 */ public bool CreatureInteractionInterpolateDuringHold;
+        [NMS(Index = 257)]
+        /* 0x41E2 */ public bool DebugAICam;
+        [NMS(Index = 254)]
+        /* 0x41E3 */ public bool DebugMoveCam;
+        [NMS(Index = 353)]
+        /* 0x41E4 */ public bool FollowDrawCamProbes;
+        [NMS(Index = 30)]
+        /* 0x41E5 */ public bool LockFollowSpring;
+        [NMS(Index = 192)]
+        /* 0x41E6 */ public bool MaxBob;
         [NMS(Index = 11)]
-        /* 0x40EF */ public bool OffsetCombatCameraHorizontal;
+        /* 0x41E7 */ public bool OffsetCombatCameraHorizontal;
         [NMS(Index = 26)]
-        /* 0x40F0 */ public bool PauseThirdPersonCamInPause;
+        /* 0x41E8 */ public bool PauseThirdPersonCamInPause;
     }
 }

--- a/libMBIN/Source/NMS/Globals/GcGraphicsGlobals.cs
+++ b/libMBIN/Source/NMS/Globals/GcGraphicsGlobals.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace libMBIN.NMS.Globals
 {
-    [NMS(GUID = 0x43B8DE88B879B209, NameHash = 0xEADD2E75)]
+    [NMS(GUID = 0xF4E46A932E2BE4AA, NameHash = 0xEADD2E75)]
     public class GcGraphicsGlobals : NMSTemplate
     {
         [NMS(Index = 52)]
@@ -229,449 +229,441 @@ namespace libMBIN.NMS.Globals
         /* 0xBE0 */ public float HUDMotionYSpring;
         [NMS(Index = 209)]
         /* 0xBE4 */ public float HueVariance;
-        [NMS(Index = 329)]
-        /* 0xBE8 */ public float IblContrastBiasAmount;
-        [NMS(Index = 330)]
-        /* 0xBEC */ public float IblDiffuseShadowAmount;
-        [NMS(Index = 332)]
-        /* 0xBF0 */ public float IblSpecularShadowAmount;
-        [NMS(Index = 331)]
-        /* 0xBF4 */ public float IblTransmissiveShadowAmount;
         [NMS(Index = 102)]
-        /* 0xBF8 */ public float LensDirt;
+        /* 0xBE8 */ public float LensDirt;
         [NMS(Index = 110)]
-        /* 0xBFC */ public float LensDirtCave;
+        /* 0xBEC */ public float LensDirtCave;
         [NMS(Index = 100)]
-        /* 0xC00 */ public float LensOffset;
+        /* 0xBF0 */ public float LensOffset;
         [NMS(Index = 108)]
-        /* 0xC04 */ public float LensOffsetCave;
+        /* 0xBF4 */ public float LensOffsetCave;
         [NMS(Index = 101)]
-        /* 0xC08 */ public float LensScale;
+        /* 0xBF8 */ public float LensScale;
         [NMS(Index = 109)]
-        /* 0xC0C */ public float LensScaleCave;
+        /* 0xBFC */ public float LensScaleCave;
         [NMS(Index = 99)]
-        /* 0xC10 */ public float LensThreshold;
+        /* 0xC00 */ public float LensThreshold;
         [NMS(Index = 107)]
-        /* 0xC14 */ public float LensThresholdCave;
+        /* 0xC04 */ public float LensThresholdCave;
         [NMS(Index = 165)]
-        /* 0xC18 */ public float LowHealthDesaturationIntensityMax;
+        /* 0xC08 */ public float LowHealthDesaturationIntensityMax;
         [NMS(Index = 164)]
-        /* 0xC1C */ public float LowHealthDesaturationIntensityMin;
+        /* 0xC0C */ public float LowHealthDesaturationIntensityMin;
         [NMS(Index = 166)]
-        /* 0xC20 */ public float LowHealthDesaturationIntensityTimeSinceHit;
+        /* 0xC10 */ public float LowHealthDesaturationIntensityTimeSinceHit;
         [NMS(Index = 168)]
-        /* 0xC24 */ public float LowHealthFadeInTime;
+        /* 0xC14 */ public float LowHealthFadeInTime;
         [NMS(Index = 169)]
-        /* 0xC28 */ public float LowHealthFadeOutTime;
+        /* 0xC18 */ public float LowHealthFadeOutTime;
         [NMS(Index = 167)]
-        /* 0xC2C */ public float LowHealthOverlayIntensity;
+        /* 0xC1C */ public float LowHealthOverlayIntensity;
         [NMS(Index = 171)]
-        /* 0xC30 */ public float LowHealthPulseRateFullShield;
+        /* 0xC20 */ public float LowHealthPulseRateFullShield;
         [NMS(Index = 170)]
-        /* 0xC34 */ public float LowHealthPulseRateLowShield;
+        /* 0xC24 */ public float LowHealthPulseRateLowShield;
         [NMS(Index = 173)]
-        /* 0xC38 */ public float LowHealthStrengthFullShield;
+        /* 0xC28 */ public float LowHealthStrengthFullShield;
         [NMS(Index = 172)]
-        /* 0xC3C */ public float LowHealthStrengthLowShield;
+        /* 0xC2C */ public float LowHealthStrengthLowShield;
         [NMS(Index = 163)]
-        /* 0xC40 */ public float LowHealthVignetteEnd;
+        /* 0xC30 */ public float LowHealthVignetteEnd;
         [NMS(Index = 162)]
-        /* 0xC44 */ public float LowHealthVignetteStart;
+        /* 0xC34 */ public float LowHealthVignetteStart;
         [NMS(Index = 0)]
-        /* 0xC48 */ public float LUTDistanceFlightMultiplier;
+        /* 0xC38 */ public float LUTDistanceFlightMultiplier;
         [NMS(Index = 234)]
-        /* 0xC4C */ public float MaxParticleRenderRange;
+        /* 0xC3C */ public float MaxParticleRenderRange;
         [NMS(Index = 235)]
-        /* 0xC50 */ public float MaxParticleRenderRangeSpace;
+        /* 0xC40 */ public float MaxParticleRenderRangeSpace;
         [NMS(Index = 227)]
-        /* 0xC54 */ public float MaxSpaceFogStrength;
+        /* 0xC44 */ public float MaxSpaceFogStrength;
         [NMS(Index = 282)]
-        /* 0xC58 */ public float MinPixelSizeOfObjectsInShadowsCockpitOnPlanet;
+        /* 0xC48 */ public float MinPixelSizeOfObjectsInShadowsCockpitOnPlanet;
         [NMS(Index = 281)]
-        /* 0xC5C */ public float MinPixelSizeOfObjectsInShadowsPlanet;
+        /* 0xC4C */ public float MinPixelSizeOfObjectsInShadowsPlanet;
         [NMS(Index = 280)]
-        /* 0xC60 */ public float MinPixelSizeOfObjectsInShadowsSpace;
+        /* 0xC50 */ public float MinPixelSizeOfObjectsInShadowsSpace;
         [NMS(Index = 43)]
-        /* 0xC64 */ public float ModelRendererLightIntensity;
+        /* 0xC54 */ public float ModelRendererLightIntensity;
         [NMS(Index = 237)]
-        /* 0xC68 */ public float MotionBlurShutterAngle;
+        /* 0xC58 */ public float MotionBlurShutterAngle;
         [NMS(Index = 236)]
-        /* 0xC6C */ public float MotionBlurShutterSpeed;
+        /* 0xC5C */ public float MotionBlurShutterSpeed;
         [NMS(Index = 293)]
-        /* 0xC70 */ public float MotionBlurThresholdDefault;
+        /* 0xC60 */ public float MotionBlurThresholdDefault;
         [NMS(Index = 291)]
-        /* 0xC74 */ public float MotionBlurThresholdInVehicle;
+        /* 0xC64 */ public float MotionBlurThresholdInVehicle;
         [NMS(Index = 290)]
-        /* 0xC78 */ public float MotionBlurThresholdOnFoot;
+        /* 0xC68 */ public float MotionBlurThresholdOnFoot;
         [NMS(Index = 292)]
-        /* 0xC7C */ public float MotionBlurThresholdSpace;
+        /* 0xC6C */ public float MotionBlurThresholdSpace;
         [NMS(Index = 62)]
-        /* 0xC80 */ public float NearClipDistance;
+        /* 0xC70 */ public float NearClipDistance;
         [NMS(Index = 21)]
-        /* 0xC84 */ public float New_BounceLightIntensity;
+        /* 0xC74 */ public float New_BounceLightIntensity;
         [NMS(Index = 20)]
-        /* 0xC88 */ public float New_BounceLightPower;
+        /* 0xC78 */ public float New_BounceLightPower;
         [NMS(Index = 19)]
-        /* 0xC8C */ public float New_BounceLightWarp;
+        /* 0xC7C */ public float New_BounceLightWarp;
         [NMS(Index = 26)]
-        /* 0xC90 */ public float New_SideRimColourMixer;
+        /* 0xC80 */ public float New_SideRimColourMixer;
         [NMS(Index = 25)]
-        /* 0xC94 */ public float New_SideRimWarp;
+        /* 0xC84 */ public float New_SideRimWarp;
         [NMS(Index = 24)]
-        /* 0xC98 */ public float New_SkyLightIntensity;
+        /* 0xC88 */ public float New_SkyLightIntensity;
         [NMS(Index = 23)]
-        /* 0xC9C */ public float New_SkyLightPower;
+        /* 0xC8C */ public float New_SkyLightPower;
         [NMS(Index = 22)]
-        /* 0xCA0 */ public float New_SkyLightWarp;
+        /* 0xC90 */ public float New_SkyLightWarp;
         [NMS(Index = 28)]
-        /* 0xCA4 */ public float New_TopRimColourMixer;
+        /* 0xC94 */ public float New_TopRimColourMixer;
         [NMS(Index = 30)]
-        /* 0xCA8 */ public float New_TopRimIntensity;
+        /* 0xC98 */ public float New_TopRimIntensity;
         [NMS(Index = 29)]
-        /* 0xCAC */ public float New_TopRimPower;
+        /* 0xC9C */ public float New_TopRimPower;
         [NMS(Index = 27)]
-        /* 0xCB0 */ public float New_TopRimWarp;
+        /* 0xCA0 */ public float New_TopRimWarp;
         [NMS(Index = 296)]
-        /* 0xCB4 */ public float NoFocusMaxFPS;
+        /* 0xCA4 */ public float NoFocusMaxFPS;
         [NMS(Index = 33)]
-        /* 0xCB8 */ public float Old_BounceLightIntensity;
+        /* 0xCA8 */ public float Old_BounceLightIntensity;
         [NMS(Index = 32)]
-        /* 0xCBC */ public float Old_BounceLightPower;
+        /* 0xCAC */ public float Old_BounceLightPower;
         [NMS(Index = 31)]
-        /* 0xCC0 */ public float Old_BounceLightWarp;
+        /* 0xCB0 */ public float Old_BounceLightWarp;
         [NMS(Index = 38)]
-        /* 0xCC4 */ public float Old_SideRimColourMixer;
+        /* 0xCB4 */ public float Old_SideRimColourMixer;
         [NMS(Index = 37)]
-        /* 0xCC8 */ public float Old_SideRimWarp;
+        /* 0xCB8 */ public float Old_SideRimWarp;
         [NMS(Index = 36)]
-        /* 0xCCC */ public float Old_SkyLightIntensity;
+        /* 0xCBC */ public float Old_SkyLightIntensity;
         [NMS(Index = 35)]
-        /* 0xCD0 */ public float Old_SkyLightPower;
+        /* 0xCC0 */ public float Old_SkyLightPower;
         [NMS(Index = 34)]
-        /* 0xCD4 */ public float Old_SkyLightWarp;
+        /* 0xCC4 */ public float Old_SkyLightWarp;
         [NMS(Index = 40)]
-        /* 0xCD8 */ public float Old_TopRimColourMixer;
+        /* 0xCC8 */ public float Old_TopRimColourMixer;
         [NMS(Index = 42)]
-        /* 0xCDC */ public float Old_TopRimIntensity;
+        /* 0xCCC */ public float Old_TopRimIntensity;
         [NMS(Index = 41)]
-        /* 0xCE0 */ public float Old_TopRimPower;
+        /* 0xCD0 */ public float Old_TopRimPower;
         [NMS(Index = 39)]
-        /* 0xCE4 */ public float Old_TopRimWarp;
+        /* 0xCD4 */ public float Old_TopRimWarp;
         [NMS(Index = 44)]
-        /* 0xCE8 */ public float PetModelRendererLightIntensity;
+        /* 0xCD8 */ public float PetModelRendererLightIntensity;
         [NMS(Index = 326)]
-        /* 0xCEC */ public float PhotoModeBloomGainMax;
+        /* 0xCDC */ public float PhotoModeBloomGainMax;
         [NMS(Index = 324)]
-        /* 0xCF0 */ public float PhotoModeBloomGainMedium;
+        /* 0xCE0 */ public float PhotoModeBloomGainMedium;
         [NMS(Index = 320)]
-        /* 0xCF4 */ public float PhotoModeBloomGainMin;
+        /* 0xCE4 */ public float PhotoModeBloomGainMin;
         [NMS(Index = 327)]
-        /* 0xCF8 */ public float PhotoModeBloomThresholdMax;
+        /* 0xCE8 */ public float PhotoModeBloomThresholdMax;
         [NMS(Index = 325)]
-        /* 0xCFC */ public float PhotoModeBloomThresholdMedium;
+        /* 0xCEC */ public float PhotoModeBloomThresholdMedium;
         [NMS(Index = 321)]
-        /* 0xD00 */ public float PhotoModeBloomThresholdMin;
+        /* 0xCF0 */ public float PhotoModeBloomThresholdMin;
         [NMS(Index = 322)]
-        /* 0xD04 */ public float PhotoModeDefaultBloomValue;
+        /* 0xCF4 */ public float PhotoModeDefaultBloomValue;
         [NMS(Index = 323)]
-        /* 0xD08 */ public float PhotoModeMediumValue;
+        /* 0xCF8 */ public float PhotoModeMediumValue;
         [NMS(Index = 87)]
-        /* 0xD0C */ public float QuantizeTime;
+        /* 0xCFC */ public float QuantizeTime;
         [NMS(Index = 90)]
-        /* 0xD10 */ public float QuantizeTimeCameraView;
+        /* 0xD00 */ public float QuantizeTimeCameraView;
         [NMS(Index = 88)]
-        /* 0xD14 */ public float QuantizeTimeShip;
+        /* 0xD04 */ public float QuantizeTimeShip;
         [NMS(Index = 89)]
-        /* 0xD18 */ public float QuantizeTimeSpace;
+        /* 0xD08 */ public float QuantizeTimeSpace;
         [NMS(Index = 18)]
-        /* 0xD1C */ public float Redo_BounceIntensity;
+        /* 0xD0C */ public float Redo_BounceIntensity;
         [NMS(Index = 16)]
-        /* 0xD20 */ public float Redo_LightIntensity;
+        /* 0xD10 */ public float Redo_LightIntensity;
         [NMS(Index = 17)]
-        /* 0xD24 */ public float Redo_SkyIntensity;
+        /* 0xD14 */ public float Redo_SkyIntensity;
         [NMS(Index = 228)]
-        /* 0xD28 */ public float ReflectionStrength;
+        /* 0xD18 */ public float ReflectionStrength;
         [NMS(Index = 208)]
-        /* 0xD2C */ public float RingAvoidanceSphereInterpTime;
+        /* 0xD1C */ public float RingAvoidanceSphereInterpTime;
         [NMS(Index = 207)]
-        /* 0xD30 */ public float RingRadius;
+        /* 0xD20 */ public float RingRadius;
         [NMS(Index = 206)]
-        /* 0xD34 */ public float RingSize;
+        /* 0xD24 */ public float RingSize;
         [NMS(Index = 14)]
-        /* 0xD38 */ public float Saturation;
+        /* 0xD28 */ public float Saturation;
         [NMS(Index = 210)]
-        /* 0xD3C */ public float SaturationVariance;
+        /* 0xD2C */ public float SaturationVariance;
         [NMS(Index = 48)]
-        /* 0xD40 */ public float ScanAlpha;
+        /* 0xD30 */ public float ScanAlpha;
         [NMS(Index = 186)]
-        /* 0xD44 */ public float ScanBandWidth;
+        /* 0xD34 */ public float ScanBandWidth;
         [NMS(Index = 47)]
-        /* 0xD48 */ public float ScanClamp;
+        /* 0xD38 */ public float ScanClamp;
         [NMS(Index = 188)]
-        /* 0xD4C */ public float ScanDistance;
+        /* 0xD3C */ public float ScanDistance;
         [NMS(Index = 184)]
-        /* 0xD50 */ public float ScanEffectSpeed;
+        /* 0xD40 */ public float ScanEffectSpeed;
         [NMS(Index = 182)]
-        /* 0xD54 */ public float ScanFadeInTime;
+        /* 0xD44 */ public float ScanFadeInTime;
         [NMS(Index = 183)]
-        /* 0xD58 */ public float ScanFadeOutTime;
+        /* 0xD48 */ public float ScanFadeOutTime;
         [NMS(Index = 46)]
-        /* 0xD5C */ public float ScanFresnel;
+        /* 0xD4C */ public float ScanFresnel;
         [NMS(Index = 187)]
-        /* 0xD60 */ public float ScanHeightScale;
+        /* 0xD50 */ public float ScanHeightScale;
         [NMS(Index = 189)]
-        /* 0xD64 */ public float ScanHorizontalScale;
+        /* 0xD54 */ public float ScanHorizontalScale;
         [NMS(Index = 185)]
-        /* 0xD68 */ public float ScanObjectFade;
+        /* 0xD58 */ public float ScanObjectFade;
         [NMS(Index = 86)]
-        /* 0xD6C */ public float ShadowBillboardOffset;
+        /* 0xD5C */ public float ShadowBillboardOffset;
         [NMS(Index = 72)]
-        /* 0xD70 */ public float ShadowLength;
+        /* 0xD60 */ public float ShadowLength;
         [NMS(Index = 78)]
-        /* 0xD74 */ public float ShadowLengthCameraView;
+        /* 0xD64 */ public float ShadowLengthCameraView;
         [NMS(Index = 76)]
-        /* 0xD78 */ public float ShadowLengthFreighter;
+        /* 0xD68 */ public float ShadowLengthFreighter;
         [NMS(Index = 77)]
-        /* 0xD7C */ public float ShadowLengthFreighterAbandoned;
+        /* 0xD6C */ public float ShadowLengthFreighterAbandoned;
         [NMS(Index = 73)]
-        /* 0xD80 */ public float ShadowLengthShip;
+        /* 0xD70 */ public float ShadowLengthShip;
         [NMS(Index = 74)]
-        /* 0xD84 */ public float ShadowLengthSpace;
+        /* 0xD74 */ public float ShadowLengthSpace;
         [NMS(Index = 75)]
-        /* 0xD88 */ public float ShadowLengthStation;
+        /* 0xD78 */ public float ShadowLengthStation;
         [NMS(Index = 68)]
-        /* 0xD8C */ public int ShadowMapSize;
+        /* 0xD7C */ public int ShadowMapSize;
         [NMS(Index = 300)]
-        /* 0xD90 */ public float SharpenFilterAmount;
+        /* 0xD80 */ public float SharpenFilterAmount;
         [NMS(Index = 302)]
-        /* 0xD94 */ public float SharpenFilterDepthFactorEnd;
+        /* 0xD84 */ public float SharpenFilterDepthFactorEnd;
         [NMS(Index = 301)]
-        /* 0xD98 */ public float SharpenFilterDepthFactorStart;
+        /* 0xD88 */ public float SharpenFilterDepthFactorStart;
         [NMS(Index = 174)]
-        /* 0xD9C */ public float ShieldDownScanlineTime;
+        /* 0xD8C */ public float ShieldDownScanlineTime;
         [NMS(Index = 192)]
-        /* 0xDA0 */ public float Single1ScanBandWidth;
+        /* 0xD90 */ public float Single1ScanBandWidth;
         [NMS(Index = 193)]
-        /* 0xDA4 */ public float Single1ScanEffectSpeed;
+        /* 0xD94 */ public float Single1ScanEffectSpeed;
         [NMS(Index = 191)]
-        /* 0xDA8 */ public float Single1ScanHeightScale;
+        /* 0xD98 */ public float Single1ScanHeightScale;
         [NMS(Index = 195)]
-        /* 0xDAC */ public float Single1ScanHorizontalScale;
+        /* 0xD9C */ public float Single1ScanHorizontalScale;
         [NMS(Index = 194)]
-        /* 0xDB0 */ public float Single1ScanObjectFade;
+        /* 0xDA0 */ public float Single1ScanObjectFade;
         [NMS(Index = 190)]
-        /* 0xDB4 */ public float Single1ScanTime;
+        /* 0xDA4 */ public float Single1ScanTime;
         [NMS(Index = 198)]
-        /* 0xDB8 */ public float Single2ScanBandWidth;
+        /* 0xDA8 */ public float Single2ScanBandWidth;
         [NMS(Index = 199)]
-        /* 0xDBC */ public float Single2ScanEffectSpeed;
+        /* 0xDAC */ public float Single2ScanEffectSpeed;
         [NMS(Index = 197)]
-        /* 0xDC0 */ public float Single2ScanHeightScale;
+        /* 0xDB0 */ public float Single2ScanHeightScale;
         [NMS(Index = 201)]
-        /* 0xDC4 */ public float Single2ScanHorizontalScale;
+        /* 0xDB4 */ public float Single2ScanHorizontalScale;
         [NMS(Index = 200)]
-        /* 0xDC8 */ public float Single2ScanObjectFade;
+        /* 0xDB8 */ public float Single2ScanObjectFade;
         [NMS(Index = 196)]
-        /* 0xDCC */ public float Single2ScanTime;
+        /* 0xDBC */ public float Single2ScanTime;
         [NMS(Index = 221)]
-        /* 0xDD0 */ public float SkySaturationMax;
+        /* 0xDC0 */ public float SkySaturationMax;
         [NMS(Index = 220)]
-        /* 0xDD4 */ public float SkySaturationMin;
+        /* 0xDC4 */ public float SkySaturationMin;
         [NMS(Index = 223)]
-        /* 0xDD8 */ public float SkyValueMax;
+        /* 0xDC8 */ public float SkyValueMax;
         [NMS(Index = 222)]
-        /* 0xDDC */ public float SkyValueMin;
+        /* 0xDCC */ public float SkyValueMin;
         [NMS(Index = 295)]
-        /* 0xDE0 */ public float SpaceIBLBlendDistance;
+        /* 0xDD0 */ public float SpaceIBLBlendDistance;
         [NMS(Index = 294)]
-        /* 0xDE4 */ public float SpaceIBLBlendStart;
+        /* 0xDD4 */ public float SpaceIBLBlendStart;
         [NMS(Index = 225)]
-        /* 0xDE8 */ public float SpaceMieFactor;
+        /* 0xDD8 */ public float SpaceMieFactor;
         [NMS(Index = 224)]
-        /* 0xDEC */ public float SpaceScale;
+        /* 0xDDC */ public float SpaceScale;
         [NMS(Index = 226)]
-        /* 0xDF0 */ public float SpaceSunFactor;
+        /* 0xDE0 */ public float SpaceSunFactor;
         [NMS(Index = 2, MxmlName = "Sun Light Blend Time")]
-        /* 0xDF4 */ public float SunLightBlendTime;
+        /* 0xDE4 */ public float SunLightBlendTime;
         [NMS(Index = 1, MxmlName = "Sun Light Intensity")]
-        /* 0xDF8 */ public float SunLightIntensity;
+        /* 0xDE8 */ public float SunLightIntensity;
         [NMS(Index = 9)]
-        /* 0xDFC */ public float SunRayDecay;
+        /* 0xDEC */ public float SunRayDecay;
         [NMS(Index = 8)]
-        /* 0xE00 */ public float SunRayDensity;
+        /* 0xDF0 */ public float SunRayDensity;
         [NMS(Index = 10)]
-        /* 0xE04 */ public float SunRayExposure;
+        /* 0xDF4 */ public float SunRayExposure;
         [NMS(Index = 11)]
-        /* 0xE08 */ public float SunRayWeight;
+        /* 0xDF8 */ public float SunRayWeight;
         [NMS(Index = 285)]
-        /* 0xE0C */ public int SupersamplingLevel;
+        /* 0xDFC */ public int SupersamplingLevel;
         [NMS(Index = 240)]
-        /* 0xE10 */ public float TaaAccumDelay;
+        /* 0xE00 */ public float TaaAccumDelay;
         [NMS(Index = 239)]
-        /* 0xE14 */ public float TaaHighFreqConstant;
+        /* 0xE04 */ public float TaaHighFreqConstant;
         [NMS(Index = 238)]
-        /* 0xE18 */ public float TaaLowFreqConstant;
+        /* 0xE08 */ public float TaaLowFreqConstant;
         [NMS(Index = 289)]
-        /* 0xE1C */ public int TargetTextureMemUsageMB;
+        /* 0xE0C */ public int TargetTextureMemUsageMB;
         [NMS(Index = 202)]
-        /* 0xE20 */ public float TeleportFlashTime;
+        /* 0xE10 */ public float TeleportFlashTime;
         [NMS(Index = 259)]
-        /* 0xE24 */ public int TerrainAnisoHi;
+        /* 0xE14 */ public int TerrainAnisoHi;
         [NMS(Index = 257)]
-        /* 0xE28 */ public int TerrainAnisoLow;
+        /* 0xE18 */ public int TerrainAnisoLow;
         [NMS(Index = 258)]
-        /* 0xE2C */ public int TerrainAnisoMed;
+        /* 0xE1C */ public int TerrainAnisoMed;
         [NMS(Index = 260)]
-        /* 0xE30 */ public int TerrainAnisoUlt;
+        /* 0xE20 */ public int TerrainAnisoUlt;
         [NMS(Index = 267)]
-        /* 0xE34 */ public int TerrainBlocksPerFrameHi;
+        /* 0xE24 */ public int TerrainBlocksPerFrameHi;
         [NMS(Index = 265)]
-        /* 0xE38 */ public int TerrainBlocksPerFrameLow;
+        /* 0xE28 */ public int TerrainBlocksPerFrameLow;
         [NMS(Index = 266)]
-        /* 0xE3C */ public int TerrainBlocksPerFrameMed;
+        /* 0xE2C */ public int TerrainBlocksPerFrameMed;
         [NMS(Index = 273)]
-        /* 0xE40 */ public int TerrainBlocksPerFrameOberon;
+        /* 0xE30 */ public int TerrainBlocksPerFrameOberon;
         [NMS(Index = 269)]
-        /* 0xE44 */ public int TerrainBlocksPerFramePs430;
+        /* 0xE34 */ public int TerrainBlocksPerFramePs430;
         [NMS(Index = 270)]
-        /* 0xE48 */ public int TerrainBlocksPerFramePs460;
+        /* 0xE38 */ public int TerrainBlocksPerFramePs460;
         [NMS(Index = 268)]
-        /* 0xE4C */ public int TerrainBlocksPerFrameUlt;
+        /* 0xE3C */ public int TerrainBlocksPerFrameUlt;
         [NMS(Index = 271)]
-        /* 0xE50 */ public int TerrainBlocksPerFrameXb130;
+        /* 0xE40 */ public int TerrainBlocksPerFrameXb130;
         [NMS(Index = 272)]
-        /* 0xE54 */ public int TerrainBlocksPerFrameXb160;
+        /* 0xE44 */ public int TerrainBlocksPerFrameXb160;
         [NMS(Index = 261)]
-        /* 0xE58 */ public int TerrainDroppedMipsLow;
+        /* 0xE48 */ public int TerrainDroppedMipsLow;
         [NMS(Index = 262)]
-        /* 0xE5C */ public int TerrainDroppedMipsMed;
+        /* 0xE4C */ public int TerrainDroppedMipsMed;
         [NMS(Index = 263)]
-        /* 0xE60 */ public float TerrainMipBiasLow;
+        /* 0xE50 */ public float TerrainMipBiasLow;
         [NMS(Index = 264)]
-        /* 0xE64 */ public float TerrainMipBiasMed;
+        /* 0xE54 */ public float TerrainMipBiasMed;
         [NMS(Index = 91)]
-        /* 0xE68 */ public float ToneMapExposure;
+        /* 0xE58 */ public float ToneMapExposure;
         [NMS(Index = 103)]
-        /* 0xE6C */ public float ToneMapExposureCave;
+        /* 0xE5C */ public float ToneMapExposureCave;
         [NMS(Index = 211)]
-        /* 0xE70 */ public float ValueVariance;
+        /* 0xE60 */ public float ValueVariance;
         [NMS(Index = 143)]
-        /* 0xE74 */ public float VignetteEnd;
+        /* 0xE64 */ public float VignetteEnd;
         [NMS(Index = 147)]
-        /* 0xE78 */ public float VignetteEndMoveVR;
+        /* 0xE68 */ public float VignetteEndMoveVR;
         [NMS(Index = 151)]
-        /* 0xE7C */ public float VignetteEndMoveVRShip;
+        /* 0xE6C */ public float VignetteEndMoveVRShip;
         [NMS(Index = 160)]
-        /* 0xE80 */ public float VignetteEndRidingVR;
+        /* 0xE70 */ public float VignetteEndRidingVR;
         [NMS(Index = 157)]
-        /* 0xE84 */ public float VignetteEndTurnRidingVR;
+        /* 0xE74 */ public float VignetteEndTurnRidingVR;
         [NMS(Index = 145)]
-        /* 0xE88 */ public float VignetteEndTurnVR;
+        /* 0xE78 */ public float VignetteEndTurnVR;
         [NMS(Index = 154)]
-        /* 0xE8C */ public float VignetteEndTurnVRShip;
+        /* 0xE7C */ public float VignetteEndTurnVRShip;
         [NMS(Index = 142)]
-        /* 0xE90 */ public float VignetteStart;
+        /* 0xE80 */ public float VignetteStart;
         [NMS(Index = 146)]
-        /* 0xE94 */ public float VignetteStartMoveVR;
+        /* 0xE84 */ public float VignetteStartMoveVR;
         [NMS(Index = 150)]
-        /* 0xE98 */ public float VignetteStartMoveVRShip;
+        /* 0xE88 */ public float VignetteStartMoveVRShip;
         [NMS(Index = 159)]
-        /* 0xE9C */ public float VignetteStartRidingVR;
+        /* 0xE8C */ public float VignetteStartRidingVR;
         [NMS(Index = 156)]
-        /* 0xEA0 */ public float VignetteStartTurnRidingVR;
+        /* 0xE90 */ public float VignetteStartTurnRidingVR;
         [NMS(Index = 144)]
-        /* 0xEA4 */ public float VignetteStartTurnVR;
+        /* 0xE94 */ public float VignetteStartTurnVR;
         [NMS(Index = 153)]
-        /* 0xEA8 */ public float VignetteStartTurnVRShip;
+        /* 0xE98 */ public float VignetteStartTurnVRShip;
         [NMS(Index = 149)]
-        /* 0xEAC */ public float VignetteVRMoveInterpTime;
+        /* 0xE9C */ public float VignetteVRMoveInterpTime;
         [NMS(Index = 152)]
-        /* 0xEB0 */ public float VignetteVRMoveInterpTimeShip;
+        /* 0xEA0 */ public float VignetteVRMoveInterpTimeShip;
         [NMS(Index = 161)]
-        /* 0xEB4 */ public float VignetteVRRidingInterpTime;
+        /* 0xEA4 */ public float VignetteVRRidingInterpTime;
         [NMS(Index = 148)]
-        /* 0xEB8 */ public float VignetteVRTurnInterpTime;
+        /* 0xEA8 */ public float VignetteVRTurnInterpTime;
         [NMS(Index = 155)]
-        /* 0xEBC */ public float VignetteVRTurnInterpTimeShip;
+        /* 0xEAC */ public float VignetteVRTurnInterpTimeShip;
         [NMS(Index = 158)]
-        /* 0xEC0 */ public float VignetteVRTurnRidingInterpTime;
+        /* 0xEB0 */ public float VignetteVRTurnRidingInterpTime;
         [NMS(Index = 64)]
-        /* 0xEC4 */ public float WarpK;
+        /* 0xEB4 */ public float WarpK;
         [NMS(Index = 65)]
-        /* 0xEC8 */ public float WarpKCube;
+        /* 0xEB8 */ public float WarpKCube;
         [NMS(Index = 67)]
-        /* 0xECC */ public float WarpKDispersion;
+        /* 0xEBC */ public float WarpKDispersion;
         [NMS(Index = 66)]
-        /* 0xED0 */ public float WarpScale;
+        /* 0xEC0 */ public float WarpScale;
         [NMS(Index = 231)]
-        /* 0xED4 */ public float WaterHueShift;
+        /* 0xEC4 */ public float WaterHueShift;
         [NMS(Index = 232)]
-        /* 0xED8 */ public float WaterSaturation;
+        /* 0xEC8 */ public float WaterSaturation;
         [NMS(Index = 233)]
-        /* 0xEDC */ public float WaterValue;
+        /* 0xECC */ public float WaterValue;
         [NMS(Index = 45)]
-        /* 0xEE0 */ public float WonderModelRendererLightIntensity;
+        /* 0xED0 */ public float WonderModelRendererLightIntensity;
         [NMS(Index = 283)]
-        /* 0xEE4 */ public bool AllowPartialCascadeRender;
+        /* 0xED4 */ public bool AllowPartialCascadeRender;
         [NMS(Index = 244)]
-        /* 0xEE5 */ public bool ApplyTaaTest;
+        /* 0xED5 */ public bool ApplyTaaTest;
         [NMS(Index = 51)]
-        /* 0xEE6 */ public bool CenterRenderSpaceOffset;
+        /* 0xED6 */ public bool CenterRenderSpaceOffset;
         [NMS(Index = 50)]
-        /* 0xEE7 */ public bool DebugLinesDepthTest;
+        /* 0xED7 */ public bool DebugLinesDepthTest;
         [NMS(Index = 139)]
-        /* 0xEE8 */ public bool DOFEnableBokeh;
+        /* 0xED8 */ public bool DOFEnableBokeh;
         [NMS(Index = 140)]
-        /* 0xEE9 */ public bool DOFEnableNewBokehShader;
+        /* 0xED9 */ public bool DOFEnableNewBokehShader;
         [NMS(Index = 141)]
-        /* 0xEEA */ public bool DOFEnablePhysCamera;
+        /* 0xEDA */ public bool DOFEnablePhysCamera;
         [NMS(Index = 297)]
-        /* 0xEEB */ public bool EnableCrossPipeSharing;
+        /* 0xEDB */ public bool EnableCrossPipeSharing;
         [NMS(Index = 298)]
-        /* 0xEEC */ public bool EnableSSR;
+        /* 0xEDC */ public bool EnableSSR;
         [NMS(Index = 274)]
-        /* 0xEED */ public bool EnableTerrainCachePs4Base;
+        /* 0xEDD */ public bool EnableTerrainCachePs4Base;
         [NMS(Index = 275)]
-        /* 0xEEE */ public bool EnableTerrainCachePs4Pro;
+        /* 0xEDE */ public bool EnableTerrainCachePs4Pro;
         [NMS(Index = 276)]
-        /* 0xEEF */ public bool EnableTerrainCacheXb1Base;
+        /* 0xEDF */ public bool EnableTerrainCacheXb1Base;
         [NMS(Index = 277)]
-        /* 0xEF0 */ public bool EnableTerrainCacheXb1X;
+        /* 0xEE0 */ public bool EnableTerrainCacheXb1X;
         [NMS(Index = 286)]
-        /* 0xEF1 */ public bool EnableTextureStreaming;
+        /* 0xEE1 */ public bool EnableTextureStreaming;
         [NMS(Index = 318)]
-        /* 0xEF2 */ public bool EnableVariableUpdate;
+        /* 0xEE2 */ public bool EnableVariableUpdate;
         [NMS(Index = 278)]
-        /* 0xEF3 */ public bool ForceCachedTerrain;
+        /* 0xEE3 */ public bool ForceCachedTerrain;
         [NMS(Index = 288)]
-        /* 0xEF4 */ public bool ForceEvictAllTextures;
+        /* 0xEE4 */ public bool ForceEvictAllTextures;
         [NMS(Index = 287)]
-        /* 0xEF5 */ public bool ForceStreamAllTextures;
+        /* 0xEE5 */ public bool ForceStreamAllTextures;
         [NMS(Index = 279)]
-        /* 0xEF6 */ public bool ForceUncachedTerrain;
+        /* 0xEE6 */ public bool ForceUncachedTerrain;
         [NMS(Index = 175)]
-        /* 0xEF7 */ public bool FullscreenScanEffect;
+        /* 0xEE7 */ public bool FullscreenScanEffect;
         [NMS(Index = 328)]
-        /* 0xEF8 */ public bool IBLReflections;
+        /* 0xEE8 */ public bool IBLReflections;
         [NMS(Index = 15)]
-        /* 0xEF9 */ public bool Redo_On;
+        /* 0xEE9 */ public bool Redo_On;
         [NMS(Index = 85)]
-        /* 0xEFA */ public bool ShadowQuantized;
+        /* 0xEEA */ public bool ShadowQuantized;
         [NMS(Index = 299)]
-        /* 0xEFB */ public bool ShowReflectionProbes;
+        /* 0xEEB */ public bool ShowReflectionProbes;
         [NMS(Index = 245)]
-        /* 0xEFC */ public bool ShowTaaBuf;
+        /* 0xEEC */ public bool ShowTaaBuf;
         [NMS(Index = 249)]
-        /* 0xEFD */ public bool ShowTaaCVarianceBuf;
+        /* 0xEED */ public bool ShowTaaCVarianceBuf;
         [NMS(Index = 248)]
-        /* 0xEFE */ public bool ShowTaaNVarianceBuf;
+        /* 0xEEE */ public bool ShowTaaNVarianceBuf;
         [NMS(Index = 247)]
-        /* 0xEFF */ public bool ShowTaaVarianceBuf;
+        /* 0xEEF */ public bool ShowTaaVarianceBuf;
         [NMS(Index = 246)]
-        /* 0xF00 */ public bool TonemapInLuminance;
+        /* 0xEF0 */ public bool TonemapInLuminance;
         [NMS(Index = 176)]
-        /* 0xF01 */ public bool UseImposters;
+        /* 0xEF1 */ public bool UseImposters;
         [NMS(Index = 243)]
-        /* 0xF02 */ public bool UseTaaResolve;
+        /* 0xEF2 */ public bool UseTaaResolve;
     }
 }

--- a/libMBIN/Source/NMS/Globals/GcUIGlobals.cs
+++ b/libMBIN/Source/NMS/Globals/GcUIGlobals.cs
@@ -4,2896 +4,2896 @@ using System.Collections.Generic;
 
 namespace libMBIN.NMS.Globals
 {
-    [NMS(GUID = 0x5D3A1B64BFBA14, NameHash = 0xD1FA1B1C)]
+    [NMS(GUID = 0xD716AC067C21E002, NameHash = 0xD1FA1B1C)]
     public class GcUIGlobals : NMSTemplate
     {
         [NMS(Index = 1082)]
         /* 0x0000 */ public GcModelViewCollection ModelViews;
         [NMS(Index = 1081, Size = 0xA, EnumType = typeof(GcSpaceshipClasses.ShipClassEnum))]
-        /* 0x2100 */ public TkModelRendererData[] ShipThumbnailRenderSettings;
+        /* 0x21B0 */ public TkModelRendererData[] ShipThumbnailRenderSettings;
         [NMS(Index = 1080)]
-        /* 0x27E0 */ public TkModelRendererData HoverShipThumbnailModelView;
+        /* 0x2890 */ public TkModelRendererData HoverShipThumbnailModelView;
         [NMS(Index = 1078)]
-        /* 0x2890 */ public TkModelRendererData LargeMultitoolThumbnailModelView;
+        /* 0x2940 */ public TkModelRendererData LargeMultitoolThumbnailModelView;
         [NMS(Index = 1077)]
-        /* 0x2940 */ public TkModelRendererData MultitoolThumbnailModelView;
+        /* 0x29F0 */ public TkModelRendererData MultitoolThumbnailModelView;
         [NMS(Index = 1076)]
-        /* 0x29F0 */ public TkModelRendererData PetThumbnailModelView;
+        /* 0x2AA0 */ public TkModelRendererData PetThumbnailModelView;
         [NMS(Index = 457)]
-        /* 0x2AA0 */ public TkModelRendererData RepairBackpackCamera;
+        /* 0x2B50 */ public TkModelRendererData RepairBackpackCamera;
         [NMS(Index = 455)]
-        /* 0x2B50 */ public TkModelRendererData RepairCamera;
+        /* 0x2C00 */ public TkModelRendererData RepairCamera;
         [NMS(Index = 458)]
-        /* 0x2C00 */ public TkModelRendererData RepairShipCameraInWorld;
+        /* 0x2CB0 */ public TkModelRendererData RepairShipCameraInWorld;
         [NMS(Index = 459)]
-        /* 0x2CB0 */ public TkModelRendererData RepairShipCameraModelView;
+        /* 0x2D60 */ public TkModelRendererData RepairShipCameraModelView;
         [NMS(Index = 460)]
-        /* 0x2D60 */ public TkModelRendererData RepairShipCameraVR;
+        /* 0x2E10 */ public TkModelRendererData RepairShipCameraVR;
         [NMS(Index = 456)]
-        /* 0x2E10 */ public TkModelRendererData RepairWeaponCamera;
+        /* 0x2EC0 */ public TkModelRendererData RepairWeaponCamera;
         [NMS(Index = 1079)]
-        /* 0x2EC0 */ public TkModelRendererData SpookShipThumbnailModelView;
+        /* 0x2F70 */ public TkModelRendererData SpookShipThumbnailModelView;
         [NMS(Index = 1416)]
-        /* 0x2F70 */ public TkNGuiTreeViewTemplate FileBrowserTreeViewTemplate;
+        /* 0x3020 */ public TkNGuiTreeViewTemplate FileBrowserTreeViewTemplate;
         [NMS(Index = 1415)]
-        /* 0x2FF0 */ public TkNGuiTreeViewTemplate SceneInfoTreeViewTemplate;
+        /* 0x30A0 */ public TkNGuiTreeViewTemplate SceneInfoTreeViewTemplate;
         [NMS(Index = 1417)]
-        /* 0x3070 */ public TkNGuiTreeViewTemplate SkeletonToolsTreeViewTemplate;
+        /* 0x3120 */ public TkNGuiTreeViewTemplate SkeletonToolsTreeViewTemplate;
         [NMS(Index = 562)]
-        /* 0x30F0 */ public GcScanEffectData DebugEditorPreviewEffect;
+        /* 0x31A0 */ public GcScanEffectData DebugEditorPreviewEffect;
         [NMS(Index = 648)]
-        /* 0x3140 */ public GcScanEffectData FreighterSummonScanEffect;
+        /* 0x31F0 */ public GcScanEffectData FreighterSummonScanEffect;
         [NMS(Index = 325)]
-        /* 0x3190 */ public GcHUDEffectRewardData OSDEpicItemRewardEffect;
+        /* 0x3240 */ public GcHUDEffectRewardData OSDEpicItemRewardEffect;
         [NMS(Index = 324)]
-        /* 0x31E0 */ public GcHUDEffectRewardData OSDRareItemRewardEffect;
+        /* 0x3290 */ public GcHUDEffectRewardData OSDRareItemRewardEffect;
         [NMS(Index = 863, Size = 0x5, EnumType = typeof(GcGalaxyStarTypes.GalaxyStarTypeEnum))]
-        /* 0x3230 */ public Colour[] SystemHooverLEDColours;
+        /* 0x32E0 */ public Colour[] SystemHooverLEDColours;
         [NMS(Index = 864, Size = 0x5, EnumType = typeof(GcGalaxyStarTypes.GalaxyStarTypeEnum))]
-        /* 0x3280 */ public Colour[] SystemHooverStatusBarColours;
+        /* 0x3330 */ public Colour[] SystemHooverStatusBarColours;
         [NMS(Index = 549)]
-        /* 0x32D0 */ public GcScanEffectData TargetDisplayScanEffect;
+        /* 0x3380 */ public GcScanEffectData TargetDisplayScanEffect;
         [NMS(Index = 1274)]
-        /* 0x3320 */ public GcSpaceMapObjectData SpaceMapAtlasData;
+        /* 0x33D0 */ public GcSpaceMapObjectData SpaceMapAtlasData;
         [NMS(Index = 1275)]
-        /* 0x3350 */ public GcSpaceMapObjectData SpaceMapBlackHoleData;
+        /* 0x3400 */ public GcSpaceMapObjectData SpaceMapBlackHoleData;
         [NMS(Index = 1277)]
-        /* 0x3380 */ public GcSpaceMapObjectData SpaceMapFreighterData;
+        /* 0x3430 */ public GcSpaceMapObjectData SpaceMapFreighterData;
         [NMS(Index = 1270)]
-        /* 0x33B0 */ public GcSpaceMapObjectData SpaceMapMarkerData;
+        /* 0x3460 */ public GcSpaceMapObjectData SpaceMapMarkerData;
         [NMS(Index = 1273)]
-        /* 0x33E0 */ public GcSpaceMapObjectData SpaceMapNexusData;
+        /* 0x3490 */ public GcSpaceMapObjectData SpaceMapNexusData;
         [NMS(Index = 1271)]
-        /* 0x3410 */ public GcSpaceMapObjectData SpaceMapPlanetData;
+        /* 0x34C0 */ public GcSpaceMapObjectData SpaceMapPlanetData;
         [NMS(Index = 1278)]
-        /* 0x3440 */ public GcSpaceMapObjectData SpaceMapPulseEncounterData;
+        /* 0x34F0 */ public GcSpaceMapObjectData SpaceMapPulseEncounterData;
         [NMS(Index = 1276)]
-        /* 0x3470 */ public GcSpaceMapObjectData SpaceMapShipData;
+        /* 0x3520 */ public GcSpaceMapObjectData SpaceMapShipData;
         [NMS(Index = 1272)]
-        /* 0x34A0 */ public GcSpaceMapObjectData SpaceMapStationData;
+        /* 0x3550 */ public GcSpaceMapObjectData SpaceMapStationData;
         [NMS(Index = 1348)]
-        /* 0x34D0 */ public Colour AltimeterBandColour1;
+        /* 0x3580 */ public Colour AltimeterBandColour1;
         [NMS(Index = 1349)]
-        /* 0x34E0 */ public Colour AltimeterBandColour2;
+        /* 0x3590 */ public Colour AltimeterBandColour2;
         [NMS(Index = 1350)]
-        /* 0x34F0 */ public Colour AltimeterColour1;
+        /* 0x35A0 */ public Colour AltimeterColour1;
         [NMS(Index = 1351)]
-        /* 0x3500 */ public Colour AltimeterColour2;
+        /* 0x35B0 */ public Colour AltimeterColour2;
         [NMS(Index = 387)]
-        /* 0x3510 */ public Colour BaseComplexityDangerColour;
+        /* 0x35C0 */ public Colour BaseComplexityDangerColour;
         [NMS(Index = 385)]
-        /* 0x3520 */ public Colour BaseComplexityDefaultColour;
+        /* 0x35D0 */ public Colour BaseComplexityDefaultColour;
         [NMS(Index = 386)]
-        /* 0x3530 */ public Colour BaseComplexityWarningColour;
+        /* 0x35E0 */ public Colour BaseComplexityWarningColour;
         [NMS(Index = 171)]
-        /* 0x3540 */ public Vector3f BinocularPanelLinePointOffset;
+        /* 0x35F0 */ public Vector3f BinocularPanelLinePointOffset;
         [NMS(Index = 395)]
-        /* 0x3550 */ public Colour BuildMenuErrorTextColour;
+        /* 0x3600 */ public Colour BuildMenuErrorTextColour;
         [NMS(Index = 397)]
-        /* 0x3560 */ public Colour BuildMenuErrorTextFlashColour;
+        /* 0x3610 */ public Colour BuildMenuErrorTextFlashColour;
         [NMS(Index = 396)]
-        /* 0x3570 */ public Colour BuildMenuErrorTextOutlineColour;
+        /* 0x3620 */ public Colour BuildMenuErrorTextOutlineColour;
         [NMS(Index = 398)]
-        /* 0x3580 */ public Colour BuildMenuErrorTextOutlineFlashColour;
+        /* 0x3630 */ public Colour BuildMenuErrorTextOutlineFlashColour;
         [NMS(Index = 399)]
-        /* 0x3590 */ public Colour BuildMenuInfoTextColour;
+        /* 0x3640 */ public Colour BuildMenuInfoTextColour;
         [NMS(Index = 400)]
-        /* 0x35A0 */ public Colour BuildMenuInfoTextOutlineColour;
+        /* 0x3650 */ public Colour BuildMenuInfoTextOutlineColour;
         [NMS(Index = 393)]
-        /* 0x35B0 */ public Colour BuildMenuPassiveErrorTextColour;
+        /* 0x3660 */ public Colour BuildMenuPassiveErrorTextColour;
         [NMS(Index = 394)]
-        /* 0x35C0 */ public Colour BuildMenuPassiveErrorTextOutlineColour;
+        /* 0x3670 */ public Colour BuildMenuPassiveErrorTextOutlineColour;
         [NMS(Index = 1131)]
-        /* 0x35D0 */ public Colour ByteBeatArpGridActiveColour;
+        /* 0x3680 */ public Colour ByteBeatArpGridActiveColour;
         [NMS(Index = 1130)]
-        /* 0x35E0 */ public Colour ByteBeatArpGridInactiveColour;
+        /* 0x3690 */ public Colour ByteBeatArpGridInactiveColour;
         [NMS(Index = 1133)]
-        /* 0x35F0 */ public Colour ByteBeatArpPipActiveColour;
+        /* 0x36A0 */ public Colour ByteBeatArpPipActiveColour;
         [NMS(Index = 1132)]
-        /* 0x3600 */ public Colour ByteBeatArpPipInactiveColour;
+        /* 0x36B0 */ public Colour ByteBeatArpPipInactiveColour;
         [NMS(Index = 1149)]
-        /* 0x3610 */ public Colour ByteBeatRhythmColour0Active;
+        /* 0x36C0 */ public Colour ByteBeatRhythmColour0Active;
         [NMS(Index = 1150)]
-        /* 0x3620 */ public Colour ByteBeatRhythmColour0Inactive;
+        /* 0x36D0 */ public Colour ByteBeatRhythmColour0Inactive;
         [NMS(Index = 1151)]
-        /* 0x3630 */ public Colour ByteBeatRhythmColour1Active;
+        /* 0x36E0 */ public Colour ByteBeatRhythmColour1Active;
         [NMS(Index = 1152)]
-        /* 0x3640 */ public Colour ByteBeatRhythmColour1Inactive;
+        /* 0x36F0 */ public Colour ByteBeatRhythmColour1Inactive;
         [NMS(Index = 1153)]
-        /* 0x3650 */ public Colour ByteBeatRhythmColour2Active;
+        /* 0x3700 */ public Colour ByteBeatRhythmColour2Active;
         [NMS(Index = 1154)]
-        /* 0x3660 */ public Colour ByteBeatRhythmColour2Inactive;
+        /* 0x3710 */ public Colour ByteBeatRhythmColour2Inactive;
         [NMS(Index = 1145)]
-        /* 0x3670 */ public Colour ByteBeatSequencerBGColourActive;
+        /* 0x3720 */ public Colour ByteBeatSequencerBGColourActive;
         [NMS(Index = 1146)]
-        /* 0x3680 */ public Colour ByteBeatSequencerBGColourInactive;
+        /* 0x3730 */ public Colour ByteBeatSequencerBGColourInactive;
         [NMS(Index = 1155)]
-        /* 0x3690 */ public Colour ByteBeatSequencerHighlightColour;
+        /* 0x3740 */ public Colour ByteBeatSequencerHighlightColour;
         [NMS(Index = 1147)]
-        /* 0x36A0 */ public Colour ByteBeatSequencerRimColourActive;
+        /* 0x3750 */ public Colour ByteBeatSequencerRimColourActive;
         [NMS(Index = 1148)]
-        /* 0x36B0 */ public Colour ByteBeatSequencerRimColourInactive;
+        /* 0x3760 */ public Colour ByteBeatSequencerRimColourInactive;
         [NMS(Index = 1144)]
-        /* 0x36C0 */ public Colour ByteBeatSequencerUnpoweredTint;
+        /* 0x3770 */ public Colour ByteBeatSequencerUnpoweredTint;
         [NMS(Index = 1160)]
-        /* 0x36D0 */ public Colour ByteBeatSliderFGColour;
+        /* 0x3780 */ public Colour ByteBeatSliderFGColour;
         [NMS(Index = 1161)]
-        /* 0x36E0 */ public Colour ByteBeatSliderTextActiveColour;
+        /* 0x3790 */ public Colour ByteBeatSliderTextActiveColour;
         [NMS(Index = 1162)]
-        /* 0x36F0 */ public Colour ByteBeatSliderTextInactiveColour;
+        /* 0x37A0 */ public Colour ByteBeatSliderTextInactiveColour;
         [NMS(Index = 1121)]
-        /* 0x3700 */ public Colour ByteBeatTreeLineColour;
+        /* 0x37B0 */ public Colour ByteBeatTreeLineColour;
         [NMS(Index = 1124)]
-        /* 0x3710 */ public Colour ByteBeatVisGridColour;
+        /* 0x37C0 */ public Colour ByteBeatVisGridColour;
         [NMS(Index = 1123)]
-        /* 0x3720 */ public Colour ByteBeatVisLineColour;
+        /* 0x37D0 */ public Colour ByteBeatVisLineColour;
         [NMS(Index = 552)]
-        /* 0x3730 */ public Colour CommunicatorMessageColour;
+        /* 0x37E0 */ public Colour CommunicatorMessageColour;
         [NMS(Index = 705)]
-        /* 0x3740 */ public Colour CrosshairColour;
+        /* 0x37F0 */ public Colour CrosshairColour;
         [NMS(Index = 694)]
-        /* 0x3750 */ public Colour CrosshairLeadPassiveColour;
+        /* 0x3800 */ public Colour CrosshairLeadPassiveColour;
         [NMS(Index = 693)]
-        /* 0x3760 */ public Colour CrosshairLeadThreatColour;
+        /* 0x3810 */ public Colour CrosshairLeadThreatColour;
         [NMS(Index = 1083)]
-        /* 0x3770 */ public Colour CursorColour;
+        /* 0x3820 */ public Colour CursorColour;
         [NMS(Index = 1084)]
-        /* 0x3780 */ public Colour CursorConfirmColour;
+        /* 0x3830 */ public Colour CursorConfirmColour;
         [NMS(Index = 1086)]
-        /* 0x3790 */ public Colour CursorDeleteColour;
+        /* 0x3840 */ public Colour CursorDeleteColour;
         [NMS(Index = 1085)]
-        /* 0x37A0 */ public Colour CursorTransferUploadColour;
+        /* 0x3850 */ public Colour CursorTransferUploadColour;
         [NMS(Index = 617)]
-        /* 0x37B0 */ public Colour DamageNumberCriticalColour;
+        /* 0x3860 */ public Colour DamageNumberCriticalColour;
         [NMS(Index = 618)]
-        /* 0x37C0 */ public Colour DamageNumberIneffectiveColour;
+        /* 0x3870 */ public Colour DamageNumberIneffectiveColour;
         [NMS(Index = 619)]
-        /* 0x37D0 */ public Colour DamageNumberIneffectiveWarningColour;
+        /* 0x3880 */ public Colour DamageNumberIneffectiveWarningColour;
         [NMS(Index = 933)]
-        /* 0x37E0 */ public Colour DeathMessageColour;
+        /* 0x3890 */ public Colour DeathMessageColour;
         [NMS(Index = 284)]
-        /* 0x37F0 */ public Colour DebugEditorAxisColourAtActive;
+        /* 0x38A0 */ public Colour DebugEditorAxisColourAtActive;
         [NMS(Index = 283)]
-        /* 0x3800 */ public Colour DebugEditorAxisColourAtInactive;
+        /* 0x38B0 */ public Colour DebugEditorAxisColourAtInactive;
         [NMS(Index = 282)]
-        /* 0x3810 */ public Colour DebugEditorAxisColourRightActive;
+        /* 0x38C0 */ public Colour DebugEditorAxisColourRightActive;
         [NMS(Index = 281)]
-        /* 0x3820 */ public Colour DebugEditorAxisColourRightInactive;
+        /* 0x38D0 */ public Colour DebugEditorAxisColourRightInactive;
         [NMS(Index = 280)]
-        /* 0x3830 */ public Colour DebugEditorAxisColourUpActive;
+        /* 0x38E0 */ public Colour DebugEditorAxisColourUpActive;
         [NMS(Index = 279)]
-        /* 0x3840 */ public Colour DebugEditorAxisColourUpInactive;
+        /* 0x38F0 */ public Colour DebugEditorAxisColourUpInactive;
         [NMS(Index = 473)]
-        /* 0x3850 */ public Vector3f DefaultRefinerOffsetIn;
+        /* 0x3900 */ public Vector3f DefaultRefinerOffsetIn;
         [NMS(Index = 474)]
-        /* 0x3860 */ public Vector3f DefaultRefinerOffsetOut;
+        /* 0x3910 */ public Vector3f DefaultRefinerOffsetOut;
         [NMS(Index = 1049)]
-        /* 0x3870 */ public Colour EnergyBgColour;
+        /* 0x3920 */ public Colour EnergyBgColour;
         [NMS(Index = 1050)]
-        /* 0x3880 */ public Colour EnergyBgPulseColour;
+        /* 0x3930 */ public Colour EnergyBgPulseColour;
         [NMS(Index = 202)]
-        /* 0x3890 */ public Vector3f FaceLockedScreenOffset;
+        /* 0x3940 */ public Vector3f FaceLockedScreenOffset;
         [NMS(Index = 649)]
-        /* 0x38A0 */ public Colour FreighterSummonScanEffectColourBlocked;
+        /* 0x3950 */ public Colour FreighterSummonScanEffectColourBlocked;
         [NMS(Index = 650)]
-        /* 0x38B0 */ public Colour FreighterSummonScanEffectColourHighlight;
+        /* 0x3960 */ public Colour FreighterSummonScanEffectColourHighlight;
         [NMS(Index = 287)]
-        /* 0x38C0 */ public Colour FrontendCursorBackgroundColour;
+        /* 0x3970 */ public Colour FrontendCursorBackgroundColour;
         [NMS(Index = 622)]
-        /* 0x38D0 */ public Colour FuelBgColour;
+        /* 0x3980 */ public Colour FuelBgColour;
         [NMS(Index = 491)]
-        /* 0x38E0 */ public Colour GridBackgroundNegativeColour;
+        /* 0x3990 */ public Colour GridBackgroundNegativeColour;
         [NMS(Index = 489)]
-        /* 0x38F0 */ public Colour GridBackgroundNeutralColour;
+        /* 0x39A0 */ public Colour GridBackgroundNeutralColour;
         [NMS(Index = 490)]
-        /* 0x3900 */ public Colour GridBackgroundPositiveColour;
+        /* 0x39B0 */ public Colour GridBackgroundPositiveColour;
         [NMS(Index = 486)]
-        /* 0x3910 */ public Colour GridDisconnectedColour;
+        /* 0x39C0 */ public Colour GridDisconnectedColour;
         [NMS(Index = 488)]
-        /* 0x3920 */ public Colour GridOfflineColour;
+        /* 0x39D0 */ public Colour GridOfflineColour;
         [NMS(Index = 487)]
-        /* 0x3930 */ public Colour GridOnlineColour;
+        /* 0x39E0 */ public Colour GridOnlineColour;
         [NMS(Index = 1051)]
-        /* 0x3940 */ public Colour HazardBgPulseColour;
+        /* 0x39F0 */ public Colour HazardBgPulseColour;
         [NMS(Index = 1052)]
-        /* 0x3950 */ public Colour HazardDamagePulseColour;
+        /* 0x3A00 */ public Colour HazardDamagePulseColour;
         [NMS(Index = 290)]
-        /* 0x3960 */ public Vector3f HmdFramerateScreenOffset;
+        /* 0x3A10 */ public Vector3f HmdFramerateScreenOffset;
         [NMS(Index = 1289)]
-        /* 0x3970 */ public Colour HUDMarkerColour;
+        /* 0x3A20 */ public Colour HUDMarkerColour;
         [NMS(Index = 860)]
-        /* 0x3980 */ public Colour HUDNotifyColour;
+        /* 0x3A30 */ public Colour HUDNotifyColour;
         [NMS(Index = 1293)]
-        /* 0x3990 */ public Colour HUDOutpostColour;
+        /* 0x3A40 */ public Colour HUDOutpostColour;
         [NMS(Index = 824)]
-        /* 0x39A0 */ public Colour HUDPlayerTrackArrowDamageGlowHullHitMaxColour;
+        /* 0x3A50 */ public Colour HUDPlayerTrackArrowDamageGlowHullHitMaxColour;
         [NMS(Index = 825)]
-        /* 0x39B0 */ public Colour HUDPlayerTrackArrowDamageGlowHullHitMinColour;
+        /* 0x3A60 */ public Colour HUDPlayerTrackArrowDamageGlowHullHitMinColour;
         [NMS(Index = 828)]
-        /* 0x39C0 */ public Colour HUDPlayerTrackArrowDamageGlowShieldHitMaxColour;
+        /* 0x3A70 */ public Colour HUDPlayerTrackArrowDamageGlowShieldHitMaxColour;
         [NMS(Index = 829)]
-        /* 0x39D0 */ public Colour HUDPlayerTrackArrowDamageGlowShieldHitMinColour;
+        /* 0x3A80 */ public Colour HUDPlayerTrackArrowDamageGlowShieldHitMinColour;
         [NMS(Index = 855)]
-        /* 0x39E0 */ public Colour HUDPlayerTrackArrowDotColour;
+        /* 0x3A90 */ public Colour HUDPlayerTrackArrowDotColour;
         [NMS(Index = 857)]
-        /* 0x39F0 */ public Colour HUDPlayerTrackArrowDotColourPirate;
+        /* 0x3AA0 */ public Colour HUDPlayerTrackArrowDotColourPirate;
         [NMS(Index = 856)]
-        /* 0x3A00 */ public Colour HUDPlayerTrackArrowDotColourPolice;
+        /* 0x3AB0 */ public Colour HUDPlayerTrackArrowDotColourPolice;
         [NMS(Index = 858)]
-        /* 0x3A10 */ public Colour HUDPlayerTrackArrowDotColourTrader;
+        /* 0x3AC0 */ public Colour HUDPlayerTrackArrowDotColourTrader;
         [NMS(Index = 816)]
-        /* 0x3A20 */ public Colour HUDPlayerTrackArrowEnergyShieldColour;
+        /* 0x3AD0 */ public Colour HUDPlayerTrackArrowEnergyShieldColour;
         [NMS(Index = 837)]
-        /* 0x3A30 */ public Colour HUDPlayerTrackArrowEnergyShieldDepletedGlowMaxColour;
+        /* 0x3AE0 */ public Colour HUDPlayerTrackArrowEnergyShieldDepletedGlowMaxColour;
         [NMS(Index = 838)]
-        /* 0x3A40 */ public Colour HUDPlayerTrackArrowEnergyShieldDepletedGlowMinColour;
+        /* 0x3AF0 */ public Colour HUDPlayerTrackArrowEnergyShieldDepletedGlowMinColour;
         [NMS(Index = 817)]
-        /* 0x3A50 */ public Colour HUDPlayerTrackArrowEnergyShieldLowColour;
+        /* 0x3B00 */ public Colour HUDPlayerTrackArrowEnergyShieldLowColour;
         [NMS(Index = 842)]
-        /* 0x3A60 */ public Colour HUDPlayerTrackArrowEnergyShieldStartChargeGlowMaxColour;
+        /* 0x3B10 */ public Colour HUDPlayerTrackArrowEnergyShieldStartChargeGlowMaxColour;
         [NMS(Index = 843)]
-        /* 0x3A70 */ public Colour HUDPlayerTrackArrowEnergyShieldStartChargeGlowMinColour;
+        /* 0x3B20 */ public Colour HUDPlayerTrackArrowEnergyShieldStartChargeGlowMinColour;
         [NMS(Index = 813)]
-        /* 0x3A80 */ public Colour HUDPlayerTrackArrowTextColour;
+        /* 0x3B30 */ public Colour HUDPlayerTrackArrowTextColour;
         [NMS(Index = 1291)]
-        /* 0x3A90 */ public Colour HUDRelicMarkerColourDiscovered;
+        /* 0x3B40 */ public Colour HUDRelicMarkerColourDiscovered;
         [NMS(Index = 1292)]
-        /* 0x3AA0 */ public Colour HUDRelicMarkerColourUnknown;
+        /* 0x3B50 */ public Colour HUDRelicMarkerColourUnknown;
         [NMS(Index = 1290)]
-        /* 0x3AB0 */ public Colour HUDSpaceshipColour;
+        /* 0x3B60 */ public Colour HUDSpaceshipColour;
         [NMS(Index = 859)]
-        /* 0x3AC0 */ public Colour HUDWarningColour;
+        /* 0x3B70 */ public Colour HUDWarningColour;
         [NMS(Index = 406)]
-        /* 0x3AD0 */ public Colour IconGlowColourActive;
+        /* 0x3B80 */ public Colour IconGlowColourActive;
         [NMS(Index = 405)]
-        /* 0x3AE0 */ public Colour IconGlowColourError;
+        /* 0x3B90 */ public Colour IconGlowColourError;
         [NMS(Index = 408)]
-        /* 0x3AF0 */ public Colour IconGlowColourHighlight;
+        /* 0x3BA0 */ public Colour IconGlowColourHighlight;
         [NMS(Index = 407)]
-        /* 0x3B00 */ public Colour IconGlowColourNeutral;
+        /* 0x3BB0 */ public Colour IconGlowColourNeutral;
         [NMS(Index = 463)]
-        /* 0x3B10 */ public Colour InteractionLabelCostColour;
+        /* 0x3BC0 */ public Colour InteractionLabelCostColour;
         [NMS(Index = 464)]
-        /* 0x3B20 */ public Colour InteractionLabelPickupColour;
+        /* 0x3BD0 */ public Colour InteractionLabelPickupColour;
         [NMS(Index = 465)]
-        /* 0x3B30 */ public Colour InteractionLabelPickupFillColour;
+        /* 0x3BE0 */ public Colour InteractionLabelPickupFillColour;
         [NMS(Index = 68)]
-        /* 0x3B40 */ public Colour InvSlotGradientBaseColour;
+        /* 0x3BF0 */ public Colour InvSlotGradientBaseColour;
         [NMS(Index = 136)]
-        /* 0x3B50 */ public Vector3f InWorldInteractLabelCentreOffset;
+        /* 0x3C00 */ public Vector3f InWorldInteractLabelCentreOffset;
         [NMS(Index = 138)]
-        /* 0x3B60 */ public Vector3f InWorldInteractLabelLineOffset;
+        /* 0x3C10 */ public Vector3f InWorldInteractLabelLineOffset;
         [NMS(Index = 137)]
-        /* 0x3B70 */ public Vector3f InWorldInteractLabelTopOffset;
+        /* 0x3C20 */ public Vector3f InWorldInteractLabelTopOffset;
         [NMS(Index = 195)]
-        /* 0x3B80 */ public Vector3f InWorldNGuiScreenRotation;
+        /* 0x3C30 */ public Vector3f InWorldNGuiScreenRotation;
         [NMS(Index = 139)]
-        /* 0x3B90 */ public Vector3f InWorldStaffBinocsScreenOffset;
+        /* 0x3C40 */ public Vector3f InWorldStaffBinocsScreenOffset;
         [NMS(Index = 967)]
-        /* 0x3BA0 */ public Colour ItemSlotColourPartiallyInstalled;
+        /* 0x3C50 */ public Colour ItemSlotColourPartiallyInstalled;
         [NMS(Index = 969)]
-        /* 0x3BB0 */ public Colour ItemSlotColourProduct;
+        /* 0x3C60 */ public Colour ItemSlotColourProduct;
         [NMS(Index = 963)]
-        /* 0x3BC0 */ public Colour ItemSlotColourSubstance;
+        /* 0x3C70 */ public Colour ItemSlotColourSubstance;
         [NMS(Index = 964)]
-        /* 0x3BD0 */ public Colour ItemSlotColourTech;
+        /* 0x3C80 */ public Colour ItemSlotColourTech;
         [NMS(Index = 965)]
-        /* 0x3BE0 */ public Colour ItemSlotColourTechCharge;
+        /* 0x3C90 */ public Colour ItemSlotColourTechCharge;
         [NMS(Index = 966)]
-        /* 0x3BF0 */ public Colour ItemSlotColourTechDamage;
+        /* 0x3CA0 */ public Colour ItemSlotColourTechDamage;
         [NMS(Index = 972)]
-        /* 0x3C00 */ public Colour ItemSlotTextColourProduct;
+        /* 0x3CB0 */ public Colour ItemSlotTextColourProduct;
         [NMS(Index = 970)]
-        /* 0x3C10 */ public Colour ItemSlotTextColourSubstance;
+        /* 0x3CC0 */ public Colour ItemSlotTextColourSubstance;
         [NMS(Index = 971)]
-        /* 0x3C20 */ public Colour ItemSlotTextColourTech;
+        /* 0x3CD0 */ public Colour ItemSlotTextColourTech;
         [NMS(Index = 67)]
-        /* 0x3C30 */ public Colour JoaoBoxCompletedObjectiveColour;
+        /* 0x3CE0 */ public Colour JoaoBoxCompletedObjectiveColour;
         [NMS(Index = 1354)]
-        /* 0x3C40 */ public Colour LockOnMarkerActiveColour;
+        /* 0x3CF0 */ public Colour LockOnMarkerActiveColour;
         [NMS(Index = 191)]
-        /* 0x3C50 */ public Vector3f LowerHelmetScreenOffset;
+        /* 0x3D00 */ public Vector3f LowerHelmetScreenOffset;
         [NMS(Index = 439)]
-        /* 0x3C60 */ public Colour MarkerRingBGColour;
+        /* 0x3D10 */ public Colour MarkerRingBGColour;
         [NMS(Index = 515)]
-        /* 0x3C70 */ public Colour MissionOSDMessageBarColour;
+        /* 0x3D20 */ public Colour MissionOSDMessageBarColour;
         [NMS(Index = 336)]
-        /* 0x3C80 */ public Colour MultiplayerMissionParticipantsColour;
+        /* 0x3D30 */ public Colour MultiplayerMissionParticipantsColour;
         [NMS(Index = 50)]
-        /* 0x3C90 */ public Colour NetworkPopupTextDisabledColour;
+        /* 0x3D40 */ public Colour NetworkPopupTextDisabledColour;
         [NMS(Index = 49)]
-        /* 0x3CA0 */ public Colour NetworkPopupTextEnabledColour;
+        /* 0x3D50 */ public Colour NetworkPopupTextEnabledColour;
         [NMS(Index = 1372)]
-        /* 0x3CB0 */ public Vector3f NGuiModelTranslationFactors;
+        /* 0x3D60 */ public Vector3f NGuiModelTranslationFactors;
         [NMS(Index = 1373)]
-        /* 0x3CC0 */ public Vector3f NGuiModelTranslationFactorsInteraction;
+        /* 0x3D70 */ public Vector3f NGuiModelTranslationFactorsInteraction;
         [NMS(Index = 1374)]
-        /* 0x3CD0 */ public Vector3f NGuiThumbnailModelTranslationFactors;
+        /* 0x3D80 */ public Vector3f NGuiThumbnailModelTranslationFactors;
         [NMS(Index = 517)]
-        /* 0x3CE0 */ public Colour NotificationDangerColour;
+        /* 0x3D90 */ public Colour NotificationDangerColour;
         [NMS(Index = 516)]
-        /* 0x3CF0 */ public Colour NotificationDefaultColour;
+        /* 0x3DA0 */ public Colour NotificationDefaultColour;
         [NMS(Index = 518)]
-        /* 0x3D00 */ public Colour NotificationInfoColour;
+        /* 0x3DB0 */ public Colour NotificationInfoColour;
         [NMS(Index = 519)]
-        /* 0x3D10 */ public Colour NotificationUrgentColour;
+        /* 0x3DC0 */ public Colour NotificationUrgentColour;
         [NMS(Index = 620)]
-        /* 0x3D20 */ public Colour PhotoModeSelectedColour;
+        /* 0x3DD0 */ public Colour PhotoModeSelectedColour;
         [NMS(Index = 621)]
-        /* 0x3D30 */ public Colour PhotoModeUnselectedColour;
+        /* 0x3DE0 */ public Colour PhotoModeUnselectedColour;
         [NMS(Index = 335)]
-        /* 0x3D40 */ public Colour PickedItemBorderColour;
+        /* 0x3DF0 */ public Colour PickedItemBorderColour;
         [NMS(Index = 934)]
-        /* 0x3D50 */ public Colour PinnedRecipeBorder;
+        /* 0x3E00 */ public Colour PinnedRecipeBorder;
         [NMS(Index = 331)]
-        /* 0x3D60 */ public Colour ProcProductColourCommon;
+        /* 0x3E10 */ public Colour ProcProductColourCommon;
         [NMS(Index = 333)]
-        /* 0x3D70 */ public Colour ProcProductColourRare;
+        /* 0x3E20 */ public Colour ProcProductColourRare;
         [NMS(Index = 332)]
-        /* 0x3D80 */ public Colour ProcProductColourUncommon;
+        /* 0x3E30 */ public Colour ProcProductColourUncommon;
         [NMS(Index = 798)]
-        /* 0x3D90 */ public Colour PulseAlertColour;
+        /* 0x3E40 */ public Colour PulseAlertColour;
         [NMS(Index = 797)]
-        /* 0x3DA0 */ public Colour PulseDamageColour;
+        /* 0x3E50 */ public Colour PulseDamageColour;
         [NMS(Index = 285)]
-        /* 0x3DB0 */ public Colour QuickMenuSelectedItemColour1;
+        /* 0x3E60 */ public Colour QuickMenuSelectedItemColour1;
         [NMS(Index = 286)]
-        /* 0x3DC0 */ public Colour QuickMenuSelectedItemColour2;
+        /* 0x3E70 */ public Colour QuickMenuSelectedItemColour2;
         [NMS(Index = 1169)]
-        /* 0x3DD0 */ public Colour RadialMenuInnerColourDisabled;
+        /* 0x3E80 */ public Colour RadialMenuInnerColourDisabled;
         [NMS(Index = 1165)]
-        /* 0x3DE0 */ public Colour RadialMenuInnerColourSelected;
+        /* 0x3E90 */ public Colour RadialMenuInnerColourSelected;
         [NMS(Index = 1167)]
-        /* 0x3DF0 */ public Colour RadialMenuInnerColourUnselected;
+        /* 0x3EA0 */ public Colour RadialMenuInnerColourUnselected;
         [NMS(Index = 1170)]
-        /* 0x3E00 */ public Colour RadialMenuOuterColourDisabled;
+        /* 0x3EB0 */ public Colour RadialMenuOuterColourDisabled;
         [NMS(Index = 1166)]
-        /* 0x3E10 */ public Colour RadialMenuOuterColourSelected;
+        /* 0x3EC0 */ public Colour RadialMenuOuterColourSelected;
         [NMS(Index = 1168)]
-        /* 0x3E20 */ public Colour RadialMenuOuterColourUnselected;
+        /* 0x3ED0 */ public Colour RadialMenuOuterColourUnselected;
         [NMS(Index = 484)]
-        /* 0x3E30 */ public Colour RefinerBackgroundColour;
+        /* 0x3EE0 */ public Colour RefinerBackgroundColour;
         [NMS(Index = 485)]
-        /* 0x3E40 */ public Colour RefinerErrorBackgroundColour;
+        /* 0x3EF0 */ public Colour RefinerErrorBackgroundColour;
         [NMS(Index = 711)]
-        /* 0x3E50 */ public Colour RemappedControlColour;
+        /* 0x3F00 */ public Colour RemappedControlColour;
         [NMS(Index = 710)]
-        /* 0x3E60 */ public Colour SelectedControlColour;
+        /* 0x3F10 */ public Colour SelectedControlColour;
         [NMS(Index = 1421)]
-        /* 0x3E70 */ public Colour SettlementStatBackgroundColour;
+        /* 0x3F20 */ public Colour SettlementStatBackgroundColour;
         [NMS(Index = 1420)]
-        /* 0x3E80 */ public Colour SettlementStatColour;
+        /* 0x3F30 */ public Colour SettlementStatColour;
         [NMS(Index = 1055)]
-        /* 0x3E90 */ public Colour ShieldBgColour;
+        /* 0x3F40 */ public Colour ShieldBgColour;
         [NMS(Index = 1053)]
-        /* 0x3EA0 */ public Colour ShieldColour;
+        /* 0x3F50 */ public Colour ShieldColour;
         [NMS(Index = 1056)]
-        /* 0x3EB0 */ public Colour ShieldDamageBgColour;
+        /* 0x3F60 */ public Colour ShieldDamageBgColour;
         [NMS(Index = 1054)]
-        /* 0x3EC0 */ public Colour ShieldDamageColour;
+        /* 0x3F70 */ public Colour ShieldDamageColour;
         [NMS(Index = 15)]
-        /* 0x3ED0 */ public Colour ShipBuilderLineColour;
+        /* 0x3F80 */ public Colour ShipBuilderLineColour;
         [NMS(Index = 14)]
-        /* 0x3EE0 */ public Colour ShipBuilderLineColourHologram;
+        /* 0x3F90 */ public Colour ShipBuilderLineColourHologram;
         [NMS(Index = 997)]
-        /* 0x3EF0 */ public Colour ShipHUDAimTargetColour;
+        /* 0x3FA0 */ public Colour ShipHUDAimTargetColour;
         [NMS(Index = 998)]
-        /* 0x3F00 */ public Colour ShipHUDAimTargetCritColour;
+        /* 0x3FB0 */ public Colour ShipHUDAimTargetCritColour;
         [NMS(Index = 995)]
-        /* 0x3F10 */ public Colour ShipHUDTargetArrowsColourLocal;
+        /* 0x3FC0 */ public Colour ShipHUDTargetArrowsColourLocal;
         [NMS(Index = 993)]
-        /* 0x3F20 */ public Colour ShipHUDTargetArrowsColourOutOfRange;
+        /* 0x3FD0 */ public Colour ShipHUDTargetArrowsColourOutOfRange;
         [NMS(Index = 994)]
-        /* 0x3F30 */ public Colour ShipHUDTargetArrowsColourThreat;
+        /* 0x3FE0 */ public Colour ShipHUDTargetArrowsColourThreat;
         [NMS(Index = 1262)]
-        /* 0x3F40 */ public Colour SpaceEnemyShipLineColour;
+        /* 0x3FF0 */ public Colour SpaceEnemyShipLineColour;
         [NMS(Index = 1261)]
-        /* 0x3F50 */ public Colour SpaceFriendlyShipLineColour;
+        /* 0x4000 */ public Colour SpaceFriendlyShipLineColour;
         [NMS(Index = 1264)]
-        /* 0x3F60 */ public Colour SpaceMapAttackColour;
+        /* 0x4010 */ public Colour SpaceMapAttackColour;
         [NMS(Index = 532)]
-        /* 0x3F70 */ public Vector3f SpaceMapCockpitOffset;
+        /* 0x4020 */ public Vector3f SpaceMapCockpitOffset;
         [NMS(Index = 1269)]
-        /* 0x3F80 */ public Colour SpaceMapDeathPointColour;
+        /* 0x4030 */ public Colour SpaceMapDeathPointColour;
         [NMS(Index = 1267)]
-        /* 0x3F90 */ public Colour SpaceMapNeutralColour;
+        /* 0x4040 */ public Colour SpaceMapNeutralColour;
         [NMS(Index = 1265)]
-        /* 0x3FA0 */ public Colour SpaceMapOtherPlayerColour;
+        /* 0x4050 */ public Colour SpaceMapOtherPlayerColour;
         [NMS(Index = 1263)]
-        /* 0x3FB0 */ public Vector3f SpaceMapPosScaler;
+        /* 0x4060 */ public Vector3f SpaceMapPosScaler;
         [NMS(Index = 1268)]
-        /* 0x3FC0 */ public Colour SpaceMapSquadronColour;
+        /* 0x4070 */ public Colour SpaceMapSquadronColour;
         [NMS(Index = 1266)]
-        /* 0x3FD0 */ public Colour SpaceMapThreatColour;
+        /* 0x4080 */ public Colour SpaceMapThreatColour;
         [NMS(Index = 1443)]
-        /* 0x3FE0 */ public Colour SpookMeterColour;
+        /* 0x4090 */ public Colour SpookMeterColour;
         [NMS(Index = 26)]
-        /* 0x3FF0 */ public Colour StoreDialFillColour;
+        /* 0x40A0 */ public Colour StoreDialFillColour;
         [NMS(Index = 74)]
-        /* 0x4000 */ public Colour SuperchargeGradientBaseColour;
+        /* 0x40B0 */ public Colour SuperchargeGradientBaseColour;
         [NMS(Index = 75)]
-        /* 0x4010 */ public Colour SuperchargeGradientBlendColour;
+        /* 0x40C0 */ public Colour SuperchargeGradientBlendColour;
         [NMS(Index = 76)]
-        /* 0x4020 */ public Colour SuperchargeGradientTechColour;
+        /* 0x40D0 */ public Colour SuperchargeGradientTechColour;
         [NMS(Index = 73)]
-        /* 0x4030 */ public Colour SuperchargePopupColour;
+        /* 0x40E0 */ public Colour SuperchargePopupColour;
         [NMS(Index = 546)]
-        /* 0x4040 */ public Vector3f TargetDisplayShipOffset;
+        /* 0x40F0 */ public Vector3f TargetDisplayShipOffset;
         [NMS(Index = 547)]
-        /* 0x4050 */ public Vector3f TargetDisplayTorpedoOffset;
+        /* 0x4100 */ public Vector3f TargetDisplayTorpedoOffset;
         [NMS(Index = 1198)]
-        /* 0x4060 */ public Colour TargetMarkerColour;
+        /* 0x4110 */ public Colour TargetMarkerColour;
         [NMS(Index = 1199)]
-        /* 0x4070 */ public Colour TargetMarkerHighlightColour;
+        /* 0x4120 */ public Colour TargetMarkerHighlightColour;
         [NMS(Index = 20)]
-        /* 0x4080 */ public Colour TouchButtonChargeIndicatorColour;
+        /* 0x4130 */ public Colour TouchButtonChargeIndicatorColour;
         [NMS(Index = 492)]
-        /* 0x4090 */ public Colour TransferSendPopupColour;
+        /* 0x4140 */ public Colour TransferSendPopupColour;
         [NMS(Index = 310)]
-        /* 0x40A0 */ public Colour TravelLineColour;
+        /* 0x4150 */ public Colour TravelLineColour;
         [NMS(Index = 313)]
-        /* 0x40B0 */ public Colour TravelLineInvalidColour;
+        /* 0x4160 */ public Colour TravelLineInvalidColour;
         [NMS(Index = 314)]
-        /* 0x40C0 */ public Colour TravelLineNotAllowedColour;
+        /* 0x4170 */ public Colour TravelLineNotAllowedColour;
         [NMS(Index = 311)]
-        /* 0x40D0 */ public Colour TravelLineTooFarColour;
+        /* 0x4180 */ public Colour TravelLineTooFarColour;
         [NMS(Index = 312)]
-        /* 0x40E0 */ public Colour TravelLineTooSteepColour;
+        /* 0x4190 */ public Colour TravelLineTooSteepColour;
         [NMS(Index = 315)]
-        /* 0x40F0 */ public Colour TravelTargetColour;
+        /* 0x41A0 */ public Colour TravelTargetColour;
         [NMS(Index = 1208)]
-        /* 0x4100 */ public Colour UnseenItemColour;
+        /* 0x41B0 */ public Colour UnseenItemColour;
         [NMS(Index = 1207)]
-        /* 0x4110 */ public Colour WantedColour;
+        /* 0x41C0 */ public Colour WantedColour;
         [NMS(Index = 41)]
-        /* 0x4120 */ public Colour WristMenuDefaultBorderColour;
+        /* 0x41D0 */ public Colour WristMenuDefaultBorderColour;
         [NMS(Index = 42)]
-        /* 0x4130 */ public Colour WristMenuRepositionableBorderColour;
+        /* 0x41E0 */ public Colour WristMenuRepositionableBorderColour;
         [NMS(Index = 60, Size = 0xF, EnumType = typeof(GcWonderCreatureCategory.WonderCreatureCategoryEnum))]
-        /* 0x4140 */ public GcWonderCategoryConfig[] WonderCreatureCategoryConfig;
+        /* 0x41F0 */ public GcWonderCategoryConfig[] WonderCreatureCategoryConfig;
         [NMS(Index = 63, Size = 0xD, EnumType = typeof(GcWonderTreasureCategory.WonderTreasureCategoryEnum))]
-        /* 0x4488 */ public GcWonderCategoryConfig[] WonderTreasureCategoryConfig;
+        /* 0x4538 */ public GcWonderCategoryConfig[] WonderTreasureCategoryConfig;
         [NMS(Index = 65, Size = 0xC, EnumType = typeof(GcWonderCustomCategory.WonderCustomCategoryEnum))]
-        /* 0x4760 */ public GcWonderCategoryConfig[] WonderCustomCategoryConfig;
+        /* 0x4810 */ public GcWonderCategoryConfig[] WonderCustomCategoryConfig;
         [NMS(Index = 59, Size = 0xB, EnumType = typeof(GcWonderPlanetCategory.WonderPlanetCategoryEnum))]
-        /* 0x4A00 */ public GcWonderCategoryConfig[] WonderPlanetCategoryConfig;
+        /* 0x4AB0 */ public GcWonderCategoryConfig[] WonderPlanetCategoryConfig;
         [NMS(Index = 64, Size = 0xB, EnumType = typeof(GcWonderWeirdBasePartCategory.WonderWeirdBasePartCategoryEnum))]
-        /* 0x4C68 */ public GcWonderCategoryConfig[] WonderWeirdBasePartCategoryConfig;
+        /* 0x4D18 */ public GcWonderCategoryConfig[] WonderWeirdBasePartCategoryConfig;
         [NMS(Index = 390, Size = 0x10, EnumType = typeof(GcBuildMenuOption.BuildMenuOptionEnum))]
-        /* 0x4ED0 */ public NMSString0x20A[] BuildMenuOnActionDisabledLocIDs;
+        /* 0x4F80 */ public NMSString0x20A[] BuildMenuOnActionDisabledLocIDs;
         [NMS(Index = 391, Size = 0x10, EnumType = typeof(GcBuildMenuOption.BuildMenuOptionEnum))]
-        /* 0x50D0 */ public NMSString0x20A[] BuildMenuOnActionErrorLocIDs;
+        /* 0x5180 */ public NMSString0x20A[] BuildMenuOnActionErrorLocIDs;
         [NMS(Index = 389, Size = 0x10, EnumType = typeof(GcBuildMenuOption.BuildMenuOptionEnum))]
-        /* 0x52D0 */ public NMSString0x20A[] BuildMenuOnActionLocIDs;
+        /* 0x5380 */ public NMSString0x20A[] BuildMenuOnActionLocIDs;
         [NMS(Index = 61, Size = 0x8, EnumType = typeof(GcWonderFloraCategory.WonderFloraCategoryEnum))]
-        /* 0x54D0 */ public GcWonderCategoryConfig[] WonderFloraCategoryConfig;
+        /* 0x5580 */ public GcWonderCategoryConfig[] WonderFloraCategoryConfig;
         [NMS(Index = 62, Size = 0x8, EnumType = typeof(GcWonderMineralCategory.WonderMineralCategoryEnum))]
-        /* 0x5690 */ public GcWonderCategoryConfig[] WonderMineralCategoryConfig;
+        /* 0x5740 */ public GcWonderCategoryConfig[] WonderMineralCategoryConfig;
         [NMS(Index = 1390)]
-        /* 0x5850 */ public GcHUDStartupTable IntroTiming;
+        /* 0x5900 */ public GcHUDStartupTable IntroTiming;
         [NMS(Index = 1391)]
-        /* 0x59A0 */ public GcHUDStartupTable IntroTimingFreighter;
+        /* 0x5A50 */ public GcHUDStartupTable IntroTimingFreighter;
         [NMS(Index = 1392)]
-        /* 0x5AF0 */ public GcHUDStartupTable IntroTimingFreighterRepaired;
+        /* 0x5BA0 */ public GcHUDStartupTable IntroTimingFreighterRepaired;
         [NMS(Index = 1423, Size = 0x7, EnumType = typeof(GcSettlementStatType.SettlementStatTypeEnum))]
-        /* 0x5C40 */ public NMSString0x20A[] SettlementStatFormatLoc;
+        /* 0x5CF0 */ public NMSString0x20A[] SettlementStatFormatLoc;
         [NMS(Index = 1422, Size = 0x7, EnumType = typeof(GcSettlementStatType.SettlementStatTypeEnum))]
-        /* 0x5D20 */ public NMSString0x20A[] SettlementStatLoc;
+        /* 0x5DD0 */ public NMSString0x20A[] SettlementStatLoc;
         [NMS(Index = 1424, Size = 0x7, EnumType = typeof(GcSettlementStatType.SettlementStatTypeEnum))]
-        /* 0x5E00 */ public TkTextureResource[] SettlementStatBasicImages;
+        /* 0x5EB0 */ public TkTextureResource[] SettlementStatBasicImages;
         [NMS(Index = 1426, Size = 0x7, EnumType = typeof(GcSettlementStatType.SettlementStatTypeEnum))]
-        /* 0x5EA8 */ public TkTextureResource[] SettlementStatNegativeImages;
+        /* 0x5F58 */ public TkTextureResource[] SettlementStatNegativeImages;
         [NMS(Index = 1425, Size = 0x7, EnumType = typeof(GcSettlementStatType.SettlementStatTypeEnum))]
-        /* 0x5F50 */ public TkTextureResource[] SettlementStatPositiveImages;
+        /* 0x6000 */ public TkTextureResource[] SettlementStatPositiveImages;
         [NMS(Index = 54, Size = 0x7, EnumType = typeof(GcWonderType.WonderTypeEnum))]
-        /* 0x5FF8 */ public TkTextureResource[] WonderTypeIcons;
+        /* 0x60A8 */ public TkTextureResource[] WonderTypeIcons;
         [NMS(Index = 434)]
-        /* 0x60A0 */ public TkTextureResource BaseBuildingPartsGridExpandableIcon;
+        /* 0x6150 */ public TkTextureResource BaseBuildingPartsGridExpandableIcon;
         [NMS(Index = 435)]
-        /* 0x60B8 */ public TkTextureResource BaseBuildingPartsGridExpandedIcon;
+        /* 0x6168 */ public TkTextureResource BaseBuildingPartsGridExpandedIcon;
         [NMS(Index = 436)]
-        /* 0x60D0 */ public TkTextureResource BaseBuildingPartsGridRetractableIcon;
+        /* 0x6180 */ public TkTextureResource BaseBuildingPartsGridRetractableIcon;
         [NMS(Index = 468)]
-        /* 0x60E8 */ public TkTextureResource RefinerPopupEmptyOutputIcon;
+        /* 0x6198 */ public TkTextureResource RefinerPopupEmptyOutputIcon;
         [NMS(Index = 1047)]
-        /* 0x6100 */ public VariableSizeString CamoNormalTexture;
+        /* 0x61B0 */ public VariableSizeString CamoNormalTexture;
         [NMS(Index = 1046)]
-        /* 0x6110 */ public VariableSizeString CamoTexture;
+        /* 0x61C0 */ public VariableSizeString CamoTexture;
         [NMS(Index = 83)]
-        /* 0x6120 */ public NMSString0x10 DebugInventoryHint;
+        /* 0x61D0 */ public NMSString0x10 DebugInventoryHint;
         [NMS(Index = 114)]
-        /* 0x6130 */ public NMSString0x10 ExplorationLogMissionID;
+        /* 0x61E0 */ public NMSString0x10 ExplorationLogMissionID;
         [NMS(Index = 1045)]
-        /* 0x6140 */ public List<Vector4f> HazardDistortionParams;
+        /* 0x61F0 */ public List<Vector4f> HazardDistortionParams;
         [NMS(Index = 1041)]
-        /* 0x6150 */ public List<VariableSizeString> HazardHeightmaps;
+        /* 0x6200 */ public List<VariableSizeString> HazardHeightmaps;
         [NMS(Index = 1044)]
-        /* 0x6160 */ public List<VariableSizeString> HazardHeightmapsVR;
+        /* 0x6210 */ public List<VariableSizeString> HazardHeightmapsVR;
         [NMS(Index = 1040)]
-        /* 0x6170 */ public List<VariableSizeString> HazardNormalMaps;
+        /* 0x6220 */ public List<VariableSizeString> HazardNormalMaps;
         [NMS(Index = 1043)]
-        /* 0x6180 */ public List<VariableSizeString> HazardNormalMapsVR;
+        /* 0x6230 */ public List<VariableSizeString> HazardNormalMapsVR;
         [NMS(Index = 1039)]
-        /* 0x6190 */ public List<VariableSizeString> HazardTextures;
+        /* 0x6240 */ public List<VariableSizeString> HazardTextures;
         [NMS(Index = 1042)]
-        /* 0x61A0 */ public List<VariableSizeString> HazardTexturesVR;
+        /* 0x6250 */ public List<VariableSizeString> HazardTexturesVR;
         [NMS(Index = 334)]
-        /* 0x61B0 */ public List<Vector2f> InventoryIconPositions;
+        /* 0x6260 */ public List<Vector2f> InventoryIconPositions;
         [NMS(Index = 338)]
-        /* 0x61C0 */ public NMSString0x10 MultiplayerMissionInteractEndTrigger;
+        /* 0x6270 */ public NMSString0x10 MultiplayerMissionInteractEndTrigger;
         [NMS(Index = 337)]
-        /* 0x61D0 */ public NMSString0x10 MultiplayerMissionInteractStartTrigger;
+        /* 0x6280 */ public NMSString0x10 MultiplayerMissionInteractStartTrigger;
         [NMS(Index = 102)]
-        /* 0x61E0 */ public List<GcSeasonalRingArray> SeasonalRingTable;
+        /* 0x6290 */ public List<GcSeasonalRingArray> SeasonalRingTable;
         [NMS(Index = 996)]
-        /* 0x61F0 */ public List<Colour> ShipHUDTargetArrowsColour;
+        /* 0x62A0 */ public List<Colour> ShipHUDTargetArrowsColour;
         [NMS(Index = 802)]
-        /* 0x6200 */ public NMSString0x10 ShowStatWithDeathQuote;
+        /* 0x62B0 */ public NMSString0x10 ShowStatWithDeathQuote;
         [NMS(Index = 874)]
-        /* 0x6210 */ public List<VariableSizeString> StatIcons;
+        /* 0x62C0 */ public List<VariableSizeString> StatIcons;
         [NMS(Index = 461)]
-        /* 0x6220 */ public List<TkModelRendererData> VehicleTypeRepairCamera;
+        /* 0x62D0 */ public List<TkModelRendererData> VehicleTypeRepairCamera;
         [NMS(Index = 702, Size = 0x14, EnumType = typeof(GcPlayerWeapons.WeaponModeEnum))]
-        /* 0x6230 */ public float[] CrosshairTargetLockSizeSpecific;
+        /* 0x62E0 */ public float[] CrosshairTargetLockSizeSpecific;
         [NMS(Index = 956)]
-        /* 0x6280 */ public GcWorldUISettings WorldUISettings;
+        /* 0x6330 */ public GcWorldUISettings WorldUISettings;
         [NMS(Index = 56, Size = 0xF, EnumType = typeof(GcWonderCreatureCategory.WonderCreatureCategoryEnum))]
-        /* 0x62D0 */ public float[] WonderValueModifiersCreature;
+        /* 0x6380 */ public float[] WonderValueModifiersCreature;
         [NMS(Index = 55, Size = 0xB, EnumType = typeof(GcWonderPlanetCategory.WonderPlanetCategoryEnum))]
-        /* 0x630C */ public float[] WonderValueModifiersPlanet;
+        /* 0x63BC */ public float[] WonderValueModifiersPlanet;
         [NMS(Index = 57, Size = 0x8, EnumType = typeof(GcWonderFloraCategory.WonderFloraCategoryEnum))]
-        /* 0x6338 */ public float[] WonderValueModifiersFlora;
+        /* 0x63E8 */ public float[] WonderValueModifiersFlora;
         [NMS(Index = 58, Size = 0x8, EnumType = typeof(GcWonderMineralCategory.WonderMineralCategoryEnum))]
-        /* 0x6358 */ public float[] WonderValueModifiersMineral;
+        /* 0x6408 */ public float[] WonderValueModifiersMineral;
         [NMS(Index = 1394)]
-        /* 0x6378 */ public GcInventorySlotActionData BuildProductSlotAction;
+        /* 0x6428 */ public GcInventorySlotActionData BuildProductSlotAction;
         [NMS(Index = 1395)]
-        /* 0x6394 */ public GcInventorySlotActionData ChargeSlotAction;
+        /* 0x6444 */ public GcInventorySlotActionData ChargeSlotAction;
         [NMS(Index = 1393)]
-        /* 0x63B0 */ public GcInventorySlotActionData InstallTechSlotAction;
+        /* 0x6460 */ public GcInventorySlotActionData InstallTechSlotAction;
         [NMS(Index = 1399)]
-        /* 0x63CC */ public GcInventorySlotActionData InventoryHintAction;
+        /* 0x647C */ public GcInventorySlotActionData InventoryHintAction;
         [NMS(Index = 1400)]
-        /* 0x63E8 */ public GcInventorySlotActionData InventoryHintActionNoGlow;
+        /* 0x6498 */ public GcInventorySlotActionData InventoryHintActionNoGlow;
         [NMS(Index = 1398)]
-        /* 0x6404 */ public GcInventorySlotActionData NewSlotPulseAction;
+        /* 0x64B4 */ public GcInventorySlotActionData NewSlotPulseAction;
         [NMS(Index = 1397)]
-        /* 0x6420 */ public GcInventorySlotActionData NewSlotRevealAction;
+        /* 0x64D0 */ public GcInventorySlotActionData NewSlotRevealAction;
         [NMS(Index = 1396)]
-        /* 0x643C */ public GcInventorySlotActionData RepairSlotAction;
+        /* 0x64EC */ public GcInventorySlotActionData RepairSlotAction;
         [NMS(Index = 0)]
-        /* 0x6458 */ public GcInteractionDof InteractionDOFDisabled;
+        /* 0x6508 */ public GcInteractionDof InteractionDOFDisabled;
         [NMS(Index = 795)]
-        /* 0x646C */ public TkNGuiRectanglePulseEffect PulseBarData;
+        /* 0x651C */ public TkNGuiRectanglePulseEffect PulseBarData;
         [NMS(Index = 796)]
-        /* 0x647C */ public TkNGuiRectanglePulseEffect PulseIconData;
+        /* 0x652C */ public TkNGuiRectanglePulseEffect PulseIconData;
         [NMS(Index = 706)]
-        /* 0x648C */ public TkHitCurveData CrosshairLeadHitCurve;
+        /* 0x653C */ public TkHitCurveData CrosshairLeadHitCurve;
         [NMS(Index = 1389)]
-        /* 0x6498 */ public GcDiscoveryHelperTimings DiscoveryHelperTimings;
+        /* 0x6548 */ public GcDiscoveryHelperTimings DiscoveryHelperTimings;
         [NMS(Index = 707)]
-        /* 0x64A4 */ public TkHitCurveData ShootableHitCurve;
+        /* 0x6554 */ public TkHitCurveData ShootableHitCurve;
         [NMS(Index = 156)]
-        /* 0x64B0 */ public Vector2f BinocularEdgeFade;
+        /* 0x6560 */ public Vector2f BinocularEdgeFade;
         [NMS(Index = 462)]
-        /* 0x64B8 */ public Vector2f BinocularsDiscoveryPos;
+        /* 0x6568 */ public Vector2f BinocularsDiscoveryPos;
         [NMS(Index = 367)]
-        /* 0x64C0 */ public Vector2f CompassCentre;
+        /* 0x6570 */ public Vector2f CompassCentre;
         [NMS(Index = 527)]
-        /* 0x64C8 */ public Vector2f CursorlessDialogPageCursorOffset;
+        /* 0x6578 */ public Vector2f CursorlessDialogPageCursorOffset;
         [NMS(Index = 612)]
-        /* 0x64D0 */ public Vector2f DamageNumberSideSpeed;
+        /* 0x6580 */ public Vector2f DamageNumberSideSpeed;
         [NMS(Index = 525)]
-        /* 0x64D8 */ public Vector2f DialogPageCursorOffset;
+        /* 0x6588 */ public Vector2f DialogPageCursorOffset;
         [NMS(Index = 1295)]
-        /* 0x64E0 */ public Vector2f HUDMarkerCompassPrimaryIndicatorOffset;
+        /* 0x6590 */ public Vector2f HUDMarkerCompassPrimaryIndicatorOffset;
         [NMS(Index = 1294)]
-        /* 0x64E8 */ public Vector2f HUDMarkerPrimaryIndicatorOffset;
+        /* 0x6598 */ public Vector2f HUDMarkerPrimaryIndicatorOffset;
         [NMS(Index = 477)]
-        /* 0x64F0 */ public Vector2f HUDPlayerSentinelPulseFreq;
+        /* 0x65A0 */ public Vector2f HUDPlayerSentinelPulseFreq;
         [NMS(Index = 478)]
-        /* 0x64F8 */ public Vector2f HUDPlayerSentinelPulseSize;
+        /* 0x65A8 */ public Vector2f HUDPlayerSentinelPulseSize;
         [NMS(Index = 831)]
-        /* 0x6500 */ public Vector2f HUDPlayerTrackArrowDamageGlowSize;
+        /* 0x65B0 */ public Vector2f HUDPlayerTrackArrowDamageGlowSize;
         [NMS(Index = 833)]
-        /* 0x6508 */ public Vector2f HUDPlayerTrackArrowEnergyShieldGlowSize;
+        /* 0x65B8 */ public Vector2f HUDPlayerTrackArrowEnergyShieldGlowSize;
         [NMS(Index = 820)]
-        /* 0x6510 */ public Vector2f HUDPlayerTrackArrowEnergyShieldSize;
+        /* 0x65C0 */ public Vector2f HUDPlayerTrackArrowEnergyShieldSize;
         [NMS(Index = 815)]
-        /* 0x6518 */ public Vector2f HUDPlayerTrackArrowHealthSize;
+        /* 0x65C8 */ public Vector2f HUDPlayerTrackArrowHealthSize;
         [NMS(Index = 768)]
-        /* 0x6520 */ public Vector2f HUDPlayerTrackArrowIconPulseSize;
+        /* 0x65D0 */ public Vector2f HUDPlayerTrackArrowIconPulseSize;
         [NMS(Index = 780)]
-        /* 0x6528 */ public Vector2f HUDPlayerTrackIconOffset;
+        /* 0x65D8 */ public Vector2f HUDPlayerTrackIconOffset;
         [NMS(Index = 1281)]
-        /* 0x6530 */ public Vector2f HUDTargetHealthIconOffset;
+        /* 0x65E0 */ public Vector2f HUDTargetHealthIconOffset;
         [NMS(Index = 1279)]
-        /* 0x6538 */ public Vector2f HUDTargetHealthOffset;
+        /* 0x65E8 */ public Vector2f HUDTargetHealthOffset;
         [NMS(Index = 1280)]
-        /* 0x6540 */ public Vector2f HUDTargetHealthSize;
+        /* 0x65F0 */ public Vector2f HUDTargetHealthSize;
         [NMS(Index = 1058)]
-        /* 0x6548 */ public Vector2f InteractionLabelOffset;
+        /* 0x65F8 */ public Vector2f InteractionLabelOffset;
         [NMS(Index = 1059)]
-        /* 0x6550 */ public Vector2f InteractionLabelOffset_1;
+        /* 0x6600 */ public Vector2f InteractionLabelOffset_1;
         [NMS(Index = 1062)]
-        /* 0x6558 */ public Vector2f InteractionLabelScreenMax;
+        /* 0x6608 */ public Vector2f InteractionLabelScreenMax;
         [NMS(Index = 1061)]
-        /* 0x6560 */ public Vector2f InteractionLabelScreenMin;
+        /* 0x6610 */ public Vector2f InteractionLabelScreenMin;
         [NMS(Index = 1063)]
-        /* 0x6568 */ public Vector2f InteractionLabelSize;
+        /* 0x6618 */ public Vector2f InteractionLabelSize;
         [NMS(Index = 1065)]
-        /* 0x6570 */ public Vector2f InteractionLabelTouchAreaMax;
+        /* 0x6620 */ public Vector2f InteractionLabelTouchAreaMax;
         [NMS(Index = 1064)]
-        /* 0x6578 */ public Vector2f InteractionLabelTouchAreaMin;
+        /* 0x6628 */ public Vector2f InteractionLabelTouchAreaMin;
         [NMS(Index = 1383)]
-        /* 0x6580 */ public Vector2f InteractionWorldParallax;
+        /* 0x6630 */ public Vector2f InteractionWorldParallax;
         [NMS(Index = 526)]
-        /* 0x6588 */ public Vector2f IntermediateInteractionPageCursorOffset;
+        /* 0x6638 */ public Vector2f IntermediateInteractionPageCursorOffset;
         [NMS(Index = 197)]
-        /* 0x6590 */ public Vector2f InWorldGameGuiAlignment;
+        /* 0x6640 */ public Vector2f InWorldGameGuiAlignment;
         [NMS(Index = 135)]
-        /* 0x6598 */ public Vector2f InWorldInteractLabelAlignment;
+        /* 0x6648 */ public Vector2f InWorldInteractLabelAlignment;
         [NMS(Index = 196)]
-        /* 0x65A0 */ public Vector2f InWorldNGuiParallax;
+        /* 0x6650 */ public Vector2f InWorldNGuiParallax;
         [NMS(Index = 510)]
-        /* 0x65A8 */ public Vector2f MainMenuSaveIconPosition;
+        /* 0x6658 */ public Vector2f MainMenuSaveIconPosition;
         [NMS(Index = 187)]
-        /* 0x65B0 */ public Vector2f MarkerDistanceVRAlignment;
+        /* 0x6660 */ public Vector2f MarkerDistanceVRAlignment;
         [NMS(Index = 476)]
-        /* 0x65B8 */ public Vector2f ModelViewWorldParallax;
+        /* 0x6668 */ public Vector2f ModelViewWorldParallax;
         [NMS(Index = 1380)]
-        /* 0x65C0 */ public Vector2f NGuiMax2DParallax;
+        /* 0x6670 */ public Vector2f NGuiMax2DParallax;
         [NMS(Index = 1379)]
-        /* 0x65C8 */ public Vector2f NGuiMin2DParallax;
+        /* 0x6678 */ public Vector2f NGuiMin2DParallax;
         [NMS(Index = 1381)]
-        /* 0x65D0 */ public Vector2f NGuiModelParallax;
+        /* 0x6680 */ public Vector2f NGuiModelParallax;
         [NMS(Index = 1382)]
-        /* 0x65D8 */ public Vector2f NGuiShipInteractParallax;
+        /* 0x6688 */ public Vector2f NGuiShipInteractParallax;
         [NMS(Index = 1197)]
-        /* 0x65E0 */ public Vector2f NGuiTouchPadSensitivity;
+        /* 0x6690 */ public Vector2f NGuiTouchPadSensitivity;
         [NMS(Index = 922)]
-        /* 0x65E8 */ public Vector2f NotificationMissionHintPauseTime;
+        /* 0x6698 */ public Vector2f NotificationMissionHintPauseTime;
         [NMS(Index = 923)]
-        /* 0x65F0 */ public Vector2f NotificationMissionHintPauseTimeCritical;
+        /* 0x66A0 */ public Vector2f NotificationMissionHintPauseTimeCritical;
         [NMS(Index = 924)]
-        /* 0x65F8 */ public Vector2f NotificationMissionHintPauseTimeSecondary;
+        /* 0x66A8 */ public Vector2f NotificationMissionHintPauseTimeSecondary;
         [NMS(Index = 466)]
-        /* 0x6600 */ public Vector2f PersonalRefinerInputPos;
+        /* 0x66B0 */ public Vector2f PersonalRefinerInputPos;
         [NMS(Index = 467)]
-        /* 0x6608 */ public Vector2f PersonalRefinerOutputPos;
+        /* 0x66B8 */ public Vector2f PersonalRefinerOutputPos;
         [NMS(Index = 88)]
-        /* 0x6610 */ public Vector2f PickingCursorOffset;
+        /* 0x66C0 */ public Vector2f PickingCursorOffset;
         [NMS(Index = 958)]
-        /* 0x6618 */ public Vector2f PlanetLabelOffset;
+        /* 0x66C8 */ public Vector2f PlanetLabelOffset;
         [NMS(Index = 960)]
-        /* 0x6620 */ public Vector2f PlanetLineOffset;
+        /* 0x66D0 */ public Vector2f PlanetLineOffset;
         [NMS(Index = 959)]
-        /* 0x6628 */ public Vector2f PlanetMeasureOffset;
+        /* 0x66D8 */ public Vector2f PlanetMeasureOffset;
         [NMS(Index = 475)]
-        /* 0x6630 */ public Vector2f RefinerParallax;
+        /* 0x66E0 */ public Vector2f RefinerParallax;
         [NMS(Index = 509)]
-        /* 0x6638 */ public Vector2f SaveIconPosition;
+        /* 0x66E8 */ public Vector2f SaveIconPosition;
         [NMS(Index = 1057)]
-        /* 0x6640 */ public Vector2f ScanLabelOffset;
+        /* 0x66F0 */ public Vector2f ScanLabelOffset;
         [NMS(Index = 1003)]
-        /* 0x6648 */ public Vector2f TargetScreenCamOffset;
+        /* 0x66F8 */ public Vector2f TargetScreenCamOffset;
         [NMS(Index = 758)]
-        /* 0x6650 */ public Vector2f TrackCriticalHitOffset;
+        /* 0x6700 */ public Vector2f TrackCriticalHitOffset;
         [NMS(Index = 722)]
-        /* 0x6658 */ public Vector2f TrackTypeIconOffset;
+        /* 0x6708 */ public Vector2f TrackTypeIconOffset;
         [NMS(Index = 1414)]
-        /* 0x6660 */ public int AbandonedFreighterAirlockRoomNumber;
+        /* 0x6710 */ public int AbandonedFreighterAirlockRoomNumber;
         [NMS(Index = 1430)]
-        /* 0x6664 */ public float AccessibleUIHUDPopupScale;
+        /* 0x6714 */ public float AccessibleUIHUDPopupScale;
         [NMS(Index = 1429)]
-        /* 0x6668 */ public float AccessibleUIPopupScale;
+        /* 0x6718 */ public float AccessibleUIPopupScale;
         [NMS(Index = 170)]
-        /* 0x666C */ public float AlignmentRequiredToDisableFrostedGlass;
+        /* 0x671C */ public float AlignmentRequiredToDisableFrostedGlass;
         [NMS(Index = 1342)]
-        /* 0x6670 */ public float AltimeterLineSpacing;
+        /* 0x6720 */ public float AltimeterLineSpacing;
         [NMS(Index = 1345)]
-        /* 0x6674 */ public float AltimeterMax;
+        /* 0x6724 */ public float AltimeterMax;
         [NMS(Index = 1344)]
-        /* 0x6678 */ public float AltimeterMin;
+        /* 0x6728 */ public float AltimeterMin;
         [NMS(Index = 1347)]
-        /* 0x667C */ public float AltimeterMinValue;
+        /* 0x672C */ public float AltimeterMinValue;
         [NMS(Index = 1341)]
-        /* 0x6680 */ public float AltimeterResolution;
+        /* 0x6730 */ public float AltimeterResolution;
         [NMS(Index = 1346)]
-        /* 0x6684 */ public float AltimeterTextSize;
+        /* 0x6734 */ public float AltimeterTextSize;
         [NMS(Index = 1343)]
-        /* 0x6688 */ public float AltimeterWidth;
+        /* 0x6738 */ public float AltimeterWidth;
         [NMS(Index = 1032)]
-        /* 0x668C */ public float AlwaysOnHazardMultiplierCold;
+        /* 0x673C */ public float AlwaysOnHazardMultiplierCold;
         [NMS(Index = 1030)]
-        /* 0x6690 */ public float AlwaysOnHazardMultiplierHeat;
+        /* 0x6740 */ public float AlwaysOnHazardMultiplierHeat;
         [NMS(Index = 1031)]
-        /* 0x6694 */ public float AlwaysOnHazardMultiplierRad;
+        /* 0x6744 */ public float AlwaysOnHazardMultiplierRad;
         [NMS(Index = 1037)]
-        /* 0x6698 */ public float AlwaysOnHazardMultiplierSpook;
+        /* 0x6748 */ public float AlwaysOnHazardMultiplierSpook;
         [NMS(Index = 1029)]
-        /* 0x669C */ public float AlwaysOnHazardMultiplierTox;
+        /* 0x674C */ public float AlwaysOnHazardMultiplierTox;
         [NMS(Index = 1027)]
-        /* 0x66A0 */ public float AlwaysOnHazardStrengthCold;
+        /* 0x6750 */ public float AlwaysOnHazardStrengthCold;
         [NMS(Index = 1025)]
-        /* 0x66A4 */ public float AlwaysOnHazardStrengthHeat;
+        /* 0x6754 */ public float AlwaysOnHazardStrengthHeat;
         [NMS(Index = 1026)]
-        /* 0x66A8 */ public float AlwaysOnHazardStrengthRad;
+        /* 0x6758 */ public float AlwaysOnHazardStrengthRad;
         [NMS(Index = 1028)]
-        /* 0x66AC */ public float AlwaysOnHazardStrengthSpook;
+        /* 0x675C */ public float AlwaysOnHazardStrengthSpook;
         [NMS(Index = 1024)]
-        /* 0x66B0 */ public float AlwaysOnHazardStrengthTox;
+        /* 0x6760 */ public float AlwaysOnHazardStrengthTox;
         [NMS(Index = 1023)]
-        /* 0x66B4 */ public float AlwaysOnHazardThreshold;
+        /* 0x6764 */ public float AlwaysOnHazardThreshold;
         [NMS(Index = 667)]
-        /* 0x66B8 */ public float AlwaysShowIconFadeDistance;
+        /* 0x6768 */ public float AlwaysShowIconFadeDistance;
         [NMS(Index = 668)]
-        /* 0x66BC */ public float AlwaysShowIconFadeRange;
+        /* 0x676C */ public float AlwaysShowIconFadeRange;
         [NMS(Index = 1405)]
-        /* 0x66C0 */ public float AmbientModeFadeTime;
+        /* 0x6770 */ public float AmbientModeFadeTime;
         [NMS(Index = 662)]
-        /* 0x66C4 */ public float ArrowBounceLeftRate1;
+        /* 0x6774 */ public float ArrowBounceLeftRate1;
         [NMS(Index = 663)]
-        /* 0x66C8 */ public float ArrowBounceLeftRate2;
+        /* 0x6778 */ public float ArrowBounceLeftRate2;
         [NMS(Index = 664)]
-        /* 0x66CC */ public float ArrowBounceLeftRate3;
+        /* 0x677C */ public float ArrowBounceLeftRate3;
         [NMS(Index = 657)]
-        /* 0x66D0 */ public float ArrowBounceLength;
+        /* 0x6780 */ public float ArrowBounceLength;
         [NMS(Index = 658)]
-        /* 0x66D4 */ public float ArrowBounceRate;
+        /* 0x6784 */ public float ArrowBounceRate;
         [NMS(Index = 659)]
-        /* 0x66D8 */ public float ArrowBounceRightRate1;
+        /* 0x6788 */ public float ArrowBounceRightRate1;
         [NMS(Index = 660)]
-        /* 0x66DC */ public float ArrowBounceRightRate2;
+        /* 0x678C */ public float ArrowBounceRightRate2;
         [NMS(Index = 1356)]
-        /* 0x66E0 */ public float AsteroidMarkerMinDisplayAngleDegrees;
+        /* 0x6790 */ public float AsteroidMarkerMinDisplayAngleDegrees;
         [NMS(Index = 1355)]
-        /* 0x66E4 */ public float AsteroidMarkerMinDisplayDistance;
+        /* 0x6794 */ public float AsteroidMarkerMinDisplayDistance;
         [NMS(Index = 419)]
-        /* 0x66E8 */ public float BaseBuildingFreeRotateDelayBeforeAudioStops;
+        /* 0x6798 */ public float BaseBuildingFreeRotateDelayBeforeAudioStops;
         [NMS(Index = 418)]
-        /* 0x66EC */ public float BaseBuildingFreeRotateDelayBeforeReset;
+        /* 0x679C */ public float BaseBuildingFreeRotateDelayBeforeReset;
         [NMS(Index = 417)]
-        /* 0x66F0 */ public float BaseBuildingFreeRotateSpeedPadMultiplier;
+        /* 0x67A0 */ public float BaseBuildingFreeRotateSpeedPadMultiplier;
         [NMS(Index = 411)]
-        /* 0x66F4 */ public float BaseBuildingInputHighlightAlpha;
+        /* 0x67A4 */ public float BaseBuildingInputHighlightAlpha;
         [NMS(Index = 410)]
-        /* 0x66F8 */ public float BaseBuildingInputHighlightDuration;
+        /* 0x67A8 */ public float BaseBuildingInputHighlightDuration;
         [NMS(Index = 414)]
-        /* 0x66FC */ public float BaseBuildingMaxFreeRotateSpeed;
+        /* 0x67AC */ public float BaseBuildingMaxFreeRotateSpeed;
         [NMS(Index = 413)]
-        /* 0x6700 */ public float BaseBuildingMinFreeRotateSpeed;
+        /* 0x67B0 */ public float BaseBuildingMinFreeRotateSpeed;
         [NMS(Index = 430)]
-        /* 0x6704 */ public float BaseBuildingPartsGridBreadcrumbFlashDuration;
+        /* 0x67B4 */ public float BaseBuildingPartsGridBreadcrumbFlashDuration;
         [NMS(Index = 429)]
-        /* 0x6708 */ public float BaseBuildingPartsGridMaxCursorRestorationTime;
+        /* 0x67B8 */ public float BaseBuildingPartsGridMaxCursorRestorationTime;
         [NMS(Index = 431)]
-        /* 0x670C */ public float BaseBuildingPartsGridMinVisibilityForActive;
+        /* 0x67BC */ public float BaseBuildingPartsGridMinVisibilityForActive;
         [NMS(Index = 433)]
-        /* 0x6710 */ public float BaseBuildingPartsGridPopupDelay;
+        /* 0x67C0 */ public float BaseBuildingPartsGridPopupDelay;
         [NMS(Index = 432)]
-        /* 0x6714 */ public float BaseBuildingPartsGridScrollSpeed;
+        /* 0x67C4 */ public float BaseBuildingPartsGridScrollSpeed;
         [NMS(Index = 409)]
-        /* 0x6718 */ public float BaseBuildingPinHighlightDuration;
+        /* 0x67C8 */ public float BaseBuildingPinHighlightDuration;
         [NMS(Index = 416)]
-        /* 0x671C */ public float BaseBuildingRotationResetRate;
+        /* 0x67CC */ public float BaseBuildingRotationResetRate;
         [NMS(Index = 412)]
-        /* 0x6720 */ public float BaseBuildingScaleSpeed;
+        /* 0x67D0 */ public float BaseBuildingScaleSpeed;
         [NMS(Index = 415)]
-        /* 0x6724 */ public float BaseBuildingTimeToMaxRotationSpeed;
+        /* 0x67D4 */ public float BaseBuildingTimeToMaxRotationSpeed;
         [NMS(Index = 428)]
-        /* 0x6728 */ public float BaseBuildingUIAdjustTime;
+        /* 0x67D8 */ public float BaseBuildingUIAdjustTime;
         [NMS(Index = 427)]
-        /* 0x672C */ public float BaseBuildingUIErrorFadeTime;
+        /* 0x67DC */ public float BaseBuildingUIErrorFadeTime;
         [NMS(Index = 421)]
-        /* 0x6730 */ public float BaseBuildingUIHorizontalSafeArea;
+        /* 0x67E0 */ public float BaseBuildingUIHorizontalSafeArea;
         [NMS(Index = 424)]
-        /* 0x6734 */ public float BaseBuildingUIVerticalOffset;
+        /* 0x67E4 */ public float BaseBuildingUIVerticalOffset;
         [NMS(Index = 425)]
-        /* 0x6738 */ public float BaseBuildingUIVerticalOffsetEdit;
+        /* 0x67E8 */ public float BaseBuildingUIVerticalOffsetEdit;
         [NMS(Index = 426)]
-        /* 0x673C */ public float BaseBuildingUIVerticalOffsetFromBB;
+        /* 0x67EC */ public float BaseBuildingUIVerticalOffsetFromBB;
         [NMS(Index = 423)]
-        /* 0x6740 */ public float BaseBuildingUIVerticalPosWiring;
+        /* 0x67F0 */ public float BaseBuildingUIVerticalPosWiring;
         [NMS(Index = 422)]
-        /* 0x6744 */ public float BaseBuildingUIVerticalSafeArea;
+        /* 0x67F4 */ public float BaseBuildingUIVerticalSafeArea;
         [NMS(Index = 383)]
-        /* 0x6748 */ public float BaseComplexityDangerFactor;
+        /* 0x67F8 */ public float BaseComplexityDangerFactor;
         [NMS(Index = 384)]
-        /* 0x674C */ public float BaseComplexityWarningFactor;
+        /* 0x67FC */ public float BaseComplexityWarningFactor;
         [NMS(Index = 1)]
-        /* 0x6750 */ public float BattleHUDBarInterpTime;
+        /* 0x6800 */ public float BattleHUDBarInterpTime;
         [NMS(Index = 155)]
-        /* 0x6754 */ public float BeaconHUDMarkerOffset;
+        /* 0x6804 */ public float BeaconHUDMarkerOffset;
         [NMS(Index = 159)]
-        /* 0x6758 */ public float BinocularMarkerSideAngle;
+        /* 0x6808 */ public float BinocularMarkerSideAngle;
         [NMS(Index = 160)]
-        /* 0x675C */ public float BinocularMarkerUpAngle;
+        /* 0x680C */ public float BinocularMarkerUpAngle;
         [NMS(Index = 169)]
-        /* 0x6760 */ public float BinocularsAltUIRescaleFactor;
+        /* 0x6810 */ public float BinocularsAltUIRescaleFactor;
         [NMS(Index = 157)]
-        /* 0x6764 */ public float BinocularScreenOffset;
+        /* 0x6814 */ public float BinocularScreenOffset;
         [NMS(Index = 158)]
-        /* 0x6768 */ public float BinocularScreenScale;
+        /* 0x6818 */ public float BinocularScreenScale;
         [NMS(Index = 167)]
-        /* 0x676C */ public float BinocularsFarIconDist;
+        /* 0x681C */ public float BinocularsFarIconDist;
         [NMS(Index = 168)]
-        /* 0x6770 */ public float BinocularsFarIconFadeDist;
+        /* 0x6820 */ public float BinocularsFarIconFadeDist;
         [NMS(Index = 166)]
-        /* 0x6774 */ public float BinocularsFarIconOpacity;
+        /* 0x6824 */ public float BinocularsFarIconOpacity;
         [NMS(Index = 165)]
-        /* 0x6778 */ public float BinocularsMidIconOpacity;
+        /* 0x6828 */ public float BinocularsMidIconOpacity;
         [NMS(Index = 163)]
-        /* 0x677C */ public float BinocularsNearIconDist;
+        /* 0x682C */ public float BinocularsNearIconDist;
         [NMS(Index = 164)]
-        /* 0x6780 */ public float BinocularsNearIconFadeDist;
+        /* 0x6830 */ public float BinocularsNearIconFadeDist;
         [NMS(Index = 162)]
-        /* 0x6784 */ public float BinocularsNearIconOpacity;
+        /* 0x6834 */ public float BinocularsNearIconOpacity;
         [NMS(Index = 493)]
-        /* 0x6788 */ public float BountyMarkerOffset;
+        /* 0x6838 */ public float BountyMarkerOffset;
         [NMS(Index = 1410)]
-        /* 0x678C */ public int BuildingShopMaxItems;
+        /* 0x683C */ public int BuildingShopMaxItems;
         [NMS(Index = 388)]
-        /* 0x6790 */ public float BuildMenuActionMessageDuration;
+        /* 0x6840 */ public float BuildMenuActionMessageDuration;
         [NMS(Index = 252)]
-        /* 0x6794 */ public float BuildMenuItemNavAnimTime;
+        /* 0x6844 */ public float BuildMenuItemNavAnimTime;
         [NMS(Index = 253)]
-        /* 0x6798 */ public float BuildMenuItemNextNavAnimTime;
+        /* 0x6848 */ public float BuildMenuItemNextNavAnimTime;
         [NMS(Index = 254)]
-        /* 0x679C */ public float BuildMenuItemNextNavAnimWait;
+        /* 0x684C */ public float BuildMenuItemNextNavAnimWait;
         [NMS(Index = 1127)]
-        /* 0x67A0 */ public float ByteBeatArpLineWidth;
+        /* 0x6850 */ public float ByteBeatArpLineWidth;
         [NMS(Index = 1129)]
-        /* 0x67A4 */ public float ByteBeatArpPad;
+        /* 0x6854 */ public float ByteBeatArpPad;
         [NMS(Index = 1128)]
-        /* 0x67A8 */ public float ByteBeatArpRadius;
+        /* 0x6858 */ public float ByteBeatArpRadius;
         [NMS(Index = 1125)]
-        /* 0x67AC */ public float ByteBeatIconLineWidth;
+        /* 0x685C */ public float ByteBeatIconLineWidth;
         [NMS(Index = 1126)]
-        /* 0x67B0 */ public float ByteBeatIconPad;
+        /* 0x6860 */ public float ByteBeatIconPad;
         [NMS(Index = 1136)]
-        /* 0x67B4 */ public float ByteBeatPartSequencerPad;
+        /* 0x6864 */ public float ByteBeatPartSequencerPad;
         [NMS(Index = 1138)]
-        /* 0x67B8 */ public float ByteBeatRhythmBeatPad;
+        /* 0x6868 */ public float ByteBeatRhythmBeatPad;
         [NMS(Index = 1142)]
-        /* 0x67BC */ public float ByteBeatRhythmSequencerActiveSaturation;
+        /* 0x686C */ public float ByteBeatRhythmSequencerActiveSaturation;
         [NMS(Index = 1141)]
-        /* 0x67C0 */ public float ByteBeatRhythmSequencerInactiveSaturation;
+        /* 0x6870 */ public float ByteBeatRhythmSequencerInactiveSaturation;
         [NMS(Index = 1140)]
-        /* 0x67C4 */ public float ByteBeatSequencerActiveSaturation;
+        /* 0x6874 */ public float ByteBeatSequencerActiveSaturation;
         [NMS(Index = 1137)]
-        /* 0x67C8 */ public float ByteBeatSequencerCornerRadius;
+        /* 0x6878 */ public float ByteBeatSequencerCornerRadius;
         [NMS(Index = 1156)]
-        /* 0x67CC */ public float ByteBeatSequencerHighlightLineWidth;
+        /* 0x687C */ public float ByteBeatSequencerHighlightLineWidth;
         [NMS(Index = 1139)]
-        /* 0x67D0 */ public float ByteBeatSequencerInactiveSaturation;
+        /* 0x6880 */ public float ByteBeatSequencerInactiveSaturation;
         [NMS(Index = 1134)]
-        /* 0x67D4 */ public float ByteBeatSequencerLineWidth;
+        /* 0x6884 */ public float ByteBeatSequencerLineWidth;
         [NMS(Index = 1135)]
-        /* 0x67D8 */ public float ByteBeatSequencerPad;
+        /* 0x6888 */ public float ByteBeatSequencerPad;
         [NMS(Index = 1143)]
-        /* 0x67DC */ public float ByteBeatSequencerUnpoweredTintStrength;
+        /* 0x688C */ public float ByteBeatSequencerUnpoweredTintStrength;
         [NMS(Index = 1159)]
-        /* 0x67E0 */ public float ByteBeatSliderCornerRadius;
+        /* 0x6890 */ public float ByteBeatSliderCornerRadius;
         [NMS(Index = 1157)]
-        /* 0x67E4 */ public float ByteBeatSliderLineWidth;
+        /* 0x6894 */ public float ByteBeatSliderLineWidth;
         [NMS(Index = 1158)]
-        /* 0x67E8 */ public float ByteBeatSliderPad;
+        /* 0x6898 */ public float ByteBeatSliderPad;
         [NMS(Index = 1163)]
-        /* 0x67EC */ public float ByteBeatSwitchPanelAlpha;
+        /* 0x689C */ public float ByteBeatSwitchPanelAlpha;
         [NMS(Index = 1164)]
-        /* 0x67F0 */ public float ByteBeatSwitchPanelSplit;
+        /* 0x68A0 */ public float ByteBeatSwitchPanelSplit;
         [NMS(Index = 1120)]
-        /* 0x67F4 */ public float ByteBeatTreeLineWidth;
+        /* 0x68A4 */ public float ByteBeatTreeLineWidth;
         [NMS(Index = 1122)]
-        /* 0x67F8 */ public float ByteBeatVisLineWidth;
+        /* 0x68A8 */ public float ByteBeatVisLineWidth;
         [NMS(Index = 120)]
-        /* 0x67FC */ public float ClosestDoorMarkerBuffer;
+        /* 0x68AC */ public float ClosestDoorMarkerBuffer;
         [NMS(Index = 182)]
-        /* 0x6800 */ public float CockpitGlassDefrostTime;
+        /* 0x68B0 */ public float CockpitGlassDefrostTime;
         [NMS(Index = 181)]
-        /* 0x6804 */ public float CockpitGlassFrostTime;
+        /* 0x68B4 */ public float CockpitGlassFrostTime;
         [NMS(Index = 551)]
-        /* 0x6808 */ public float CommunicatorMessageTime;
+        /* 0x68B8 */ public float CommunicatorMessageTime;
         [NMS(Index = 379)]
-        /* 0x680C */ public float CompassAngleClamp;
+        /* 0x68BC */ public float CompassAngleClamp;
         [NMS(Index = 382)]
-        /* 0x6810 */ public float CompassAngleClampSpace;
+        /* 0x68C0 */ public float CompassAngleClampSpace;
         [NMS(Index = 380)]
-        /* 0x6814 */ public float CompassAngleFade;
+        /* 0x68C4 */ public float CompassAngleFade;
         [NMS(Index = 376)]
-        /* 0x6818 */ public float CompassDistanceMarkerMinScale;
+        /* 0x68C8 */ public float CompassDistanceMarkerMinScale;
         [NMS(Index = 377)]
-        /* 0x681C */ public float CompassDistanceMaxAngle;
+        /* 0x68CC */ public float CompassDistanceMaxAngle;
         [NMS(Index = 374)]
-        /* 0x6820 */ public float CompassDistanceScale;
+        /* 0x68D0 */ public float CompassDistanceScale;
         [NMS(Index = 370)]
-        /* 0x6824 */ public float CompassDistanceScaleMin;
+        /* 0x68D4 */ public float CompassDistanceScaleMin;
         [NMS(Index = 371)]
-        /* 0x6828 */ public float CompassDistanceScaleRange;
+        /* 0x68D8 */ public float CompassDistanceScaleRange;
         [NMS(Index = 375)]
-        /* 0x682C */ public float CompassDistanceShipMinScale;
+        /* 0x68DC */ public float CompassDistanceShipMinScale;
         [NMS(Index = 372)]
-        /* 0x6830 */ public float CompassDistanceSpaceScaleMin;
+        /* 0x68E0 */ public float CompassDistanceSpaceScaleMin;
         [NMS(Index = 373)]
-        /* 0x6834 */ public float CompassDistanceSpaceScaleRange;
+        /* 0x68E4 */ public float CompassDistanceSpaceScaleRange;
         [NMS(Index = 378)]
-        /* 0x6838 */ public float CompassDistanceYOffset;
+        /* 0x68E8 */ public float CompassDistanceYOffset;
         [NMS(Index = 368)]
-        /* 0x683C */ public float CompassHeight;
+        /* 0x68EC */ public float CompassHeight;
         [NMS(Index = 188)]
-        /* 0x6840 */ public float CompassIconOffsetVR;
+        /* 0x68F0 */ public float CompassIconOffsetVR;
         [NMS(Index = 209)]
-        /* 0x6844 */ public float CompassLineContractionEndAngle;
+        /* 0x68F4 */ public float CompassLineContractionEndAngle;
         [NMS(Index = 208)]
-        /* 0x6848 */ public float CompassLineContractionStartAngle;
+        /* 0x68F8 */ public float CompassLineContractionStartAngle;
         [NMS(Index = 210)]
-        /* 0x684C */ public float CompassLineContractionTargetAngle;
+        /* 0x68FC */ public float CompassLineContractionTargetAngle;
         [NMS(Index = 214)]
-        /* 0x6850 */ public float CompassLineNotchAngleRange;
+        /* 0x6900 */ public float CompassLineNotchAngleRange;
         [NMS(Index = 216)]
-        /* 0x6854 */ public float CompassLineNotchLength;
+        /* 0x6904 */ public float CompassLineNotchLength;
         [NMS(Index = 215)]
-        /* 0x6858 */ public float CompassLineNotchThickness;
+        /* 0x6908 */ public float CompassLineNotchThickness;
         [NMS(Index = 211)]
-        /* 0x685C */ public int CompassLineNumNotches;
+        /* 0x690C */ public int CompassLineNumNotches;
         [NMS(Index = 213)]
-        /* 0x6860 */ public float CompassLineOffset;
+        /* 0x6910 */ public float CompassLineOffset;
         [NMS(Index = 212)]
-        /* 0x6864 */ public float CompassLineThickness;
+        /* 0x6914 */ public float CompassLineThickness;
         [NMS(Index = 207)]
-        /* 0x6868 */ public int CompassScreenHeight;
+        /* 0x6918 */ public int CompassScreenHeight;
         [NMS(Index = 206)]
-        /* 0x686C */ public int CompassScreenWidth;
+        /* 0x691C */ public int CompassScreenWidth;
         [NMS(Index = 369)]
-        /* 0x6870 */ public float CompassWidth;
+        /* 0x6920 */ public float CompassWidth;
         [NMS(Index = 581)]
-        /* 0x6874 */ public float ConsoleTextSpeed;
+        /* 0x6924 */ public float ConsoleTextSpeed;
         [NMS(Index = 583)]
-        /* 0x6878 */ public float ConsoleTextTimeMax;
+        /* 0x6928 */ public float ConsoleTextTimeMax;
         [NMS(Index = 582)]
-        /* 0x687C */ public float ConsoleTextTimeMin;
+        /* 0x692C */ public float ConsoleTextTimeMin;
         [NMS(Index = 709)]
-        /* 0x6880 */ public float ControlScrollDistance;
+        /* 0x6930 */ public float ControlScrollDistance;
         [NMS(Index = 708)]
-        /* 0x6884 */ public int ControlScrollSteps;
+        /* 0x6934 */ public int ControlScrollSteps;
         [NMS(Index = 594)]
-        /* 0x6888 */ public float CreatureDistanceAlpha;
+        /* 0x6938 */ public float CreatureDistanceAlpha;
         [NMS(Index = 592)]
-        /* 0x688C */ public float CreatureDistanceDisplayAngle;
+        /* 0x693C */ public float CreatureDistanceDisplayAngle;
         [NMS(Index = 593)]
-        /* 0x6890 */ public float CreatureDistanceFadeTime;
+        /* 0x6940 */ public float CreatureDistanceFadeTime;
         [NMS(Index = 590)]
-        /* 0x6894 */ public float CreatureDistanceOffsetY;
+        /* 0x6944 */ public float CreatureDistanceOffsetY;
         [NMS(Index = 591)]
-        /* 0x6898 */ public float CreatureDistanceShadowOffset;
+        /* 0x6948 */ public float CreatureDistanceShadowOffset;
         [NMS(Index = 589)]
-        /* 0x689C */ public float CreatureDistanceSize;
+        /* 0x694C */ public float CreatureDistanceSize;
         [NMS(Index = 360)]
-        /* 0x68A0 */ public float CreatureIconMergeAngle;
+        /* 0x6950 */ public float CreatureIconMergeAngle;
         [NMS(Index = 626)]
-        /* 0x68A4 */ public float CreatureIconOffset;
+        /* 0x6954 */ public float CreatureIconOffset;
         [NMS(Index = 627)]
-        /* 0x68A8 */ public float CreatureIconOffsetPhysics;
+        /* 0x6958 */ public float CreatureIconOffsetPhysics;
         [NMS(Index = 748)]
-        /* 0x68AC */ public float CreatureInteractLabelOffsetY;
+        /* 0x695C */ public float CreatureInteractLabelOffsetY;
         [NMS(Index = 744)]
-        /* 0x68B0 */ public float CreatureReticuleScale;
+        /* 0x6960 */ public float CreatureReticuleScale;
         [NMS(Index = 714)]
-        /* 0x68B4 */ public float CreatureRoutineMarkerTime;
+        /* 0x6964 */ public float CreatureRoutineMarkerTime;
         [NMS(Index = 715)]
-        /* 0x68B8 */ public int CreatureRoutineRegionsPerFrame;
+        /* 0x6968 */ public int CreatureRoutineRegionsPerFrame;
         [NMS(Index = 800)]
-        /* 0x68BC */ public float CriticalMessageTime;
+        /* 0x696C */ public float CriticalMessageTime;
         [NMS(Index = 676)]
-        /* 0x68C0 */ public float CrosshairAimOffTime;
+        /* 0x6970 */ public float CrosshairAimOffTime;
         [NMS(Index = 675)]
-        /* 0x68C4 */ public float CrosshairAimTime;
+        /* 0x6974 */ public float CrosshairAimTime;
         [NMS(Index = 677)]
-        /* 0x68C8 */ public float CrosshairInnerMinFade;
+        /* 0x6978 */ public float CrosshairInnerMinFade;
         [NMS(Index = 678)]
-        /* 0x68CC */ public float CrosshairInnerMinFadeRange;
+        /* 0x697C */ public float CrosshairInnerMinFadeRange;
         [NMS(Index = 699)]
-        /* 0x68D0 */ public float CrosshairInterceptAlpha;
+        /* 0x6980 */ public float CrosshairInterceptAlpha;
         [NMS(Index = 696)]
-        /* 0x68D4 */ public float CrosshairInterceptBaseSize;
+        /* 0x6984 */ public float CrosshairInterceptBaseSize;
         [NMS(Index = 697)]
-        /* 0x68D8 */ public float CrosshairInterceptCentreBaseSize;
+        /* 0x6988 */ public float CrosshairInterceptCentreBaseSize;
         [NMS(Index = 700)]
-        /* 0x68DC */ public float CrosshairInterceptLockRange;
+        /* 0x698C */ public float CrosshairInterceptLockRange;
         [NMS(Index = 695)]
-        /* 0x68E0 */ public float CrosshairInterceptSize;
+        /* 0x6990 */ public float CrosshairInterceptSize;
         [NMS(Index = 698)]
-        /* 0x68E4 */ public float CrosshairInterceptSpringTime;
+        /* 0x6994 */ public float CrosshairInterceptSpringTime;
         [NMS(Index = 682)]
-        /* 0x68E8 */ public float CrosshairLeadCornerOffset;
+        /* 0x6998 */ public float CrosshairLeadCornerOffset;
         [NMS(Index = 691)]
-        /* 0x68EC */ public float CrosshairLeadFadeRange;
+        /* 0x699C */ public float CrosshairLeadFadeRange;
         [NMS(Index = 692)]
-        /* 0x68F0 */ public float CrosshairLeadFadeSize;
+        /* 0x69A0 */ public float CrosshairLeadFadeSize;
         [NMS(Index = 680)]
-        /* 0x68F4 */ public float CrosshairLeadInDelay;
+        /* 0x69A4 */ public float CrosshairLeadInDelay;
         [NMS(Index = 681)]
-        /* 0x68F8 */ public float CrosshairLeadInTime;
+        /* 0x69A8 */ public float CrosshairLeadInTime;
         [NMS(Index = 685)]
-        /* 0x68FC */ public float CrosshairLeadPulseSize;
+        /* 0x69AC */ public float CrosshairLeadPulseSize;
         [NMS(Index = 679)]
-        /* 0x6900 */ public float CrosshairLeadScaleIn;
+        /* 0x69B0 */ public float CrosshairLeadScaleIn;
         [NMS(Index = 689)]
-        /* 0x6904 */ public float CrosshairLeadSpring;
+        /* 0x69B4 */ public float CrosshairLeadSpring;
         [NMS(Index = 690)]
-        /* 0x6908 */ public float CrosshairLeadSpringOff;
+        /* 0x69B8 */ public float CrosshairLeadSpringOff;
         [NMS(Index = 684)]
-        /* 0x690C */ public float CrosshairLeadTopLock;
+        /* 0x69BC */ public float CrosshairLeadTopLock;
         [NMS(Index = 683)]
-        /* 0x6910 */ public float CrosshairLeadTopOffset;
+        /* 0x69C0 */ public float CrosshairLeadTopOffset;
         [NMS(Index = 292)]
-        /* 0x6914 */ public float CrosshairOffsetHmd;
+        /* 0x69C4 */ public float CrosshairOffsetHmd;
         [NMS(Index = 293)]
-        /* 0x6918 */ public float CrosshairOffsetHmdUp;
+        /* 0x69C8 */ public float CrosshairOffsetHmdUp;
         [NMS(Index = 291)]
-        /* 0x691C */ public float CrosshairScaleHmd;
+        /* 0x69CC */ public float CrosshairScaleHmd;
         [NMS(Index = 295)]
-        /* 0x6920 */ public int CrosshairScreenHeight;
+        /* 0x69D0 */ public int CrosshairScreenHeight;
         [NMS(Index = 294)]
-        /* 0x6924 */ public int CrosshairScreenWidth;
+        /* 0x69D4 */ public int CrosshairScreenWidth;
         [NMS(Index = 688)]
-        /* 0x6928 */ public float CrosshairSpringAimTime;
+        /* 0x69D8 */ public float CrosshairSpringAimTime;
         [NMS(Index = 687)]
-        /* 0x692C */ public float CrosshairSpringTime;
+        /* 0x69DC */ public float CrosshairSpringTime;
         [NMS(Index = 701)]
-        /* 0x6930 */ public float CrosshairTargetLockSize;
+        /* 0x69E0 */ public float CrosshairTargetLockSize;
         [NMS(Index = 1089)]
-        /* 0x6934 */ public float CursorHoverSlowFactor;
+        /* 0x69E4 */ public float CursorHoverSlowFactor;
         [NMS(Index = 1090)]
-        /* 0x6938 */ public float CursorHoverSlowFactorMin;
+        /* 0x69E8 */ public float CursorHoverSlowFactorMin;
         [NMS(Index = 1087)]
-        /* 0x693C */ public float CursorHoverSlowFixedValue;
+        /* 0x69EC */ public float CursorHoverSlowFixedValue;
         [NMS(Index = 524)]
-        /* 0x6940 */ public float DamageDirectionIndicatorOnScreenRadiusMultiplier;
+        /* 0x69F0 */ public float DamageDirectionIndicatorOnScreenRadiusMultiplier;
         [NMS(Index = 596)]
-        /* 0x6944 */ public float DamageImpactMergeTime;
+        /* 0x69F4 */ public float DamageImpactMergeTime;
         [NMS(Index = 598)]
-        /* 0x6948 */ public float DamageImpactMinDistance;
+        /* 0x69F8 */ public float DamageImpactMinDistance;
         [NMS(Index = 597)]
-        /* 0x694C */ public float DamageImpactTimeBetweenNumbers;
+        /* 0x69FC */ public float DamageImpactTimeBetweenNumbers;
         [NMS(Index = 607)]
-        /* 0x6950 */ public float DamageNumberBlackAlpha;
+        /* 0x6A00 */ public float DamageNumberBlackAlpha;
         [NMS(Index = 613)]
-        /* 0x6954 */ public float DamageNumberFadeIn;
+        /* 0x6A04 */ public float DamageNumberFadeIn;
         [NMS(Index = 614)]
-        /* 0x6958 */ public float DamageNumberFadeOut;
+        /* 0x6A08 */ public float DamageNumberFadeOut;
         [NMS(Index = 606)]
-        /* 0x695C */ public float DamageNumberLaserMaxDamage;
+        /* 0x6A0C */ public float DamageNumberLaserMaxDamage;
         [NMS(Index = 605)]
-        /* 0x6960 */ public float DamageNumberLaserMinDamage;
+        /* 0x6A10 */ public float DamageNumberLaserMinDamage;
         [NMS(Index = 610)]
-        /* 0x6964 */ public float DamageNumberOffsetX;
+        /* 0x6A14 */ public float DamageNumberOffsetX;
         [NMS(Index = 611)]
-        /* 0x6968 */ public float DamageNumberOffsetY;
+        /* 0x6A18 */ public float DamageNumberOffsetY;
         [NMS(Index = 608)]
-        /* 0x696C */ public float DamageNumberOutline;
+        /* 0x6A1C */ public float DamageNumberOutline;
         [NMS(Index = 609)]
-        /* 0x6970 */ public float DamageNumberOutline2;
+        /* 0x6A20 */ public float DamageNumberOutline2;
         [NMS(Index = 602)]
-        /* 0x6974 */ public float DamageNumberSize;
+        /* 0x6A24 */ public float DamageNumberSize;
         [NMS(Index = 603)]
-        /* 0x6978 */ public float DamageNumberSizeCritMultiplier;
+        /* 0x6A28 */ public float DamageNumberSizeCritMultiplier;
         [NMS(Index = 601)]
-        /* 0x697C */ public float DamageNumberSizeInShip;
+        /* 0x6A2C */ public float DamageNumberSizeInShip;
         [NMS(Index = 604)]
-        /* 0x6980 */ public float DamageNumberSizeLaserMultiplier;
+        /* 0x6A30 */ public float DamageNumberSizeLaserMultiplier;
         [NMS(Index = 600)]
-        /* 0x6984 */ public float DamageNumberTime;
+        /* 0x6A34 */ public float DamageNumberTime;
         [NMS(Index = 615)]
-        /* 0x6988 */ public float DamageNumberUpOffset;
+        /* 0x6A38 */ public float DamageNumberUpOffset;
         [NMS(Index = 599)]
-        /* 0x698C */ public float DamagePerSecondSampleTime;
+        /* 0x6A3C */ public float DamagePerSecondSampleTime;
         [NMS(Index = 446)]
-        /* 0x6990 */ public float DamageScannableHighlightTime;
+        /* 0x6A40 */ public float DamageScannableHighlightTime;
         [NMS(Index = 447)]
-        /* 0x6994 */ public float DamageTrackArrowTime;
+        /* 0x6A44 */ public float DamageTrackArrowTime;
         [NMS(Index = 931)]
-        /* 0x6998 */ public float DeathMessageSwitchTime;
+        /* 0x6A48 */ public float DeathMessageSwitchTime;
         [NMS(Index = 932)]
-        /* 0x699C */ public float DeathMessageTotalTime;
+        /* 0x6A4C */ public float DeathMessageTotalTime;
         [NMS(Index = 53)]
-        /* 0x69A0 */ public int DebugMedalRank;
+        /* 0x6A50 */ public int DebugMedalRank;
         [NMS(Index = 1036)]
-        /* 0x69A4 */ public float DeepSeaHazardMultiplierCold;
+        /* 0x6A54 */ public float DeepSeaHazardMultiplierCold;
         [NMS(Index = 1034)]
-        /* 0x69A8 */ public float DeepSeaHazardMultiplierHeat;
+        /* 0x6A58 */ public float DeepSeaHazardMultiplierHeat;
         [NMS(Index = 1035)]
-        /* 0x69AC */ public float DeepSeaHazardMultiplierRad;
+        /* 0x6A5C */ public float DeepSeaHazardMultiplierRad;
         [NMS(Index = 1033)]
-        /* 0x69B0 */ public float DeepSeaHazardMultiplierTox;
+        /* 0x6A60 */ public float DeepSeaHazardMultiplierTox;
         [NMS(Index = 628)]
-        /* 0x69B4 */ public float DelayBeforeHidingHangarAfterGalaxyMap;
+        /* 0x6A64 */ public float DelayBeforeHidingHangarAfterGalaxyMap;
         [NMS(Index = 629)]
-        /* 0x69B8 */ public float DelayBeforeShowingHangarIntoGalaxyMap;
+        /* 0x6A68 */ public float DelayBeforeShowingHangarIntoGalaxyMap;
         [NMS(Index = 576)]
-        /* 0x69BC */ public float DescriptionTextDelay;
+        /* 0x6A6C */ public float DescriptionTextDelay;
         [NMS(Index = 577)]
-        /* 0x69C0 */ public float DescriptionTextSpeed;
+        /* 0x6A70 */ public float DescriptionTextSpeed;
         [NMS(Index = 578)]
-        /* 0x69C4 */ public float DescriptionTextSpeedProgressive;
+        /* 0x6A74 */ public float DescriptionTextSpeedProgressive;
         [NMS(Index = 580)]
-        /* 0x69C8 */ public float DescriptionTextTimeMax;
+        /* 0x6A78 */ public float DescriptionTextTimeMax;
         [NMS(Index = 579)]
-        /* 0x69CC */ public float DescriptionTextTimeMin;
+        /* 0x6A7C */ public float DescriptionTextTimeMin;
         [NMS(Index = 1431)]
-        /* 0x69D0 */ public float DetailMessageDismissTime;
+        /* 0x6A80 */ public float DetailMessageDismissTime;
         [NMS(Index = 342)]
-        /* 0x69D4 */ public float DroneIndicatorCentreRadiusMax;
+        /* 0x6A84 */ public float DroneIndicatorCentreRadiusMax;
         [NMS(Index = 343)]
-        /* 0x69D8 */ public float DroneIndicatorCentreRadiusMin;
+        /* 0x6A88 */ public float DroneIndicatorCentreRadiusMin;
         [NMS(Index = 344)]
-        /* 0x69DC */ public float DroneIndicatorFadeRange;
+        /* 0x6A8C */ public float DroneIndicatorFadeRange;
         [NMS(Index = 341)]
-        /* 0x69E0 */ public float DroneIndicatorRadius;
+        /* 0x6A90 */ public float DroneIndicatorRadius;
         [NMS(Index = 100)]
-        /* 0x69E4 */ public float EggModifiyAnimLoopTime;
+        /* 0x6A94 */ public float EggModifiyAnimLoopTime;
         [NMS(Index = 99)]
-        /* 0x69E8 */ public float EggModifiyAnimMaxSize;
+        /* 0x6A98 */ public float EggModifiyAnimMaxSize;
         [NMS(Index = 110)]
-        /* 0x69EC */ public float EndOfSeasonAlertDelay;
+        /* 0x6A9C */ public float EndOfSeasonAlertDelay;
         [NMS(Index = 147)]
-        /* 0x69F0 */ public float ExocraftHUDMarkerHideDistance;
+        /* 0x6AA0 */ public float ExocraftHUDMarkerHideDistance;
         [NMS(Index = 148)]
-        /* 0x69F4 */ public float ExocraftHUDMarkerOffset;
+        /* 0x6AA4 */ public float ExocraftHUDMarkerOffset;
         [NMS(Index = 107)]
-        /* 0x69F8 */ public float ExpeditionStageChangeTime;
+        /* 0x6AA8 */ public float ExpeditionStageChangeTime;
         [NMS(Index = 47)]
-        /* 0x69FC */ public float EyeTrackingCursorBlendRate;
+        /* 0x6AAC */ public float EyeTrackingCursorBlendRate;
         [NMS(Index = 46)]
-        /* 0x6A00 */ public float EyeTrackingCursorBlendRateGameModeSelect;
+        /* 0x6AB0 */ public float EyeTrackingCursorBlendRateGameModeSelect;
         [NMS(Index = 45)]
-        /* 0x6A04 */ public float EyeTrackingPopupLookAwayTime;
+        /* 0x6AB4 */ public float EyeTrackingPopupLookAwayTime;
         [NMS(Index = 48)]
-        /* 0x6A08 */ public float EyeTrackingStickyHoverTime;
+        /* 0x6AB8 */ public float EyeTrackingStickyHoverTime;
         [NMS(Index = 44)]
-        /* 0x6A0C */ public float EyeTrackingTimeBeforePopupsActivate;
+        /* 0x6ABC */ public float EyeTrackingTimeBeforePopupsActivate;
         [NMS(Index = 1439)]
-        /* 0x6A10 */ public float FeedFrigateAnimAlphaChange;
+        /* 0x6AC0 */ public float FeedFrigateAnimAlphaChange;
         [NMS(Index = 1437)]
-        /* 0x6A14 */ public int FeedFrigateAnimNumPeriods;
+        /* 0x6AC4 */ public int FeedFrigateAnimNumPeriods;
         [NMS(Index = 1436)]
-        /* 0x6A18 */ public float FeedFrigateAnimPeriod;
+        /* 0x6AC8 */ public float FeedFrigateAnimPeriod;
         [NMS(Index = 1438)]
-        /* 0x6A1C */ public float FeedFrigateAnimScaleChange;
+        /* 0x6ACC */ public float FeedFrigateAnimScaleChange;
         [NMS(Index = 115)]
-        /* 0x6A20 */ public int ForceOpenHazardProtInventoryThreshold;
+        /* 0x6AD0 */ public int ForceOpenHazardProtInventoryThreshold;
         [NMS(Index = 641)]
-        /* 0x6A24 */ public float FreighterCommanderMarkerMinDistance;
+        /* 0x6AD4 */ public float FreighterCommanderMarkerMinDistance;
         [NMS(Index = 672)]
-        /* 0x6A28 */ public float FreighterEntranceOffset;
+        /* 0x6AD8 */ public float FreighterEntranceOffset;
         [NMS(Index = 647)]
-        /* 0x6A2C */ public float FreighterHighlightRange;
+        /* 0x6ADC */ public float FreighterHighlightRange;
         [NMS(Index = 671)]
-        /* 0x6A30 */ public float FreighterLeaderIconDistance;
+        /* 0x6AE0 */ public float FreighterLeaderIconDistance;
         [NMS(Index = 89)]
-        /* 0x6A34 */ public float FreighterMegaWarpTransitionTime;
+        /* 0x6AE4 */ public float FreighterMegaWarpTransitionTime;
         [NMS(Index = 637)]
-        /* 0x6A38 */ public float FreighterSummonDelay;
+        /* 0x6AE8 */ public float FreighterSummonDelay;
         [NMS(Index = 640)]
-        /* 0x6A3C */ public float FreighterSummonGridSize;
+        /* 0x6AEC */ public float FreighterSummonGridSize;
         [NMS(Index = 646)]
-        /* 0x6A40 */ public float FreighterSummonLookTime;
+        /* 0x6AF0 */ public float FreighterSummonLookTime;
         [NMS(Index = 632)]
-        /* 0x6A44 */ public float FreighterSummonOffset;
+        /* 0x6AF4 */ public float FreighterSummonOffset;
         [NMS(Index = 633)]
-        /* 0x6A48 */ public float FreighterSummonOffsetPulse;
+        /* 0x6AF8 */ public float FreighterSummonOffsetPulse;
         [NMS(Index = 631)]
-        /* 0x6A4C */ public float FreighterSummonPitch;
+        /* 0x6AFC */ public float FreighterSummonPitch;
         [NMS(Index = 645)]
-        /* 0x6A50 */ public float FreighterSummonPlanetOffset;
+        /* 0x6B00 */ public float FreighterSummonPlanetOffset;
         [NMS(Index = 644)]
-        /* 0x6A54 */ public float FreighterSummonPulseFadeAmount;
+        /* 0x6B04 */ public float FreighterSummonPulseFadeAmount;
         [NMS(Index = 643)]
-        /* 0x6A58 */ public float FreighterSummonPulseRate;
+        /* 0x6B08 */ public float FreighterSummonPulseRate;
         [NMS(Index = 630)]
-        /* 0x6A5C */ public float FreighterSummonTurn;
+        /* 0x6B0C */ public float FreighterSummonTurn;
         [NMS(Index = 639)]
-        /* 0x6A60 */ public float FreighterSummonTurnAngleIncrement;
+        /* 0x6B10 */ public float FreighterSummonTurnAngleIncrement;
         [NMS(Index = 638)]
-        /* 0x6A64 */ public int FreighterSummonTurnNumTries;
+        /* 0x6B14 */ public int FreighterSummonTurnNumTries;
         [NMS(Index = 642)]
-        /* 0x6A68 */ public float FreighterSurfaceMinAngle;
+        /* 0x6B18 */ public float FreighterSurfaceMinAngle;
         [NMS(Index = 670)]
-        /* 0x6A6C */ public float FrigateDamageIconVisibilityDistance;
+        /* 0x6B1C */ public float FrigateDamageIconVisibilityDistance;
         [NMS(Index = 625)]
-        /* 0x6A70 */ public float FrigateIconOffset;
+        /* 0x6B20 */ public float FrigateIconOffset;
         [NMS(Index = 669)]
-        /* 0x6A74 */ public float FrigatePurchaseNotificationResetDistanceMultiplier;
+        /* 0x6B24 */ public float FrigatePurchaseNotificationResetDistanceMultiplier;
         [NMS(Index = 1109)]
-        /* 0x6A78 */ public float FrontendActivateSplit;
+        /* 0x6B28 */ public float FrontendActivateSplit;
         [NMS(Index = 1108)]
-        /* 0x6A7C */ public float FrontendActivateTime;
+        /* 0x6B2C */ public float FrontendActivateTime;
         [NMS(Index = 1093)]
-        /* 0x6A80 */ public float FrontendBGAlpha;
+        /* 0x6B30 */ public float FrontendBGAlpha;
         [NMS(Index = 1113)]
-        /* 0x6A84 */ public float FrontendBootBarTime;
+        /* 0x6B34 */ public float FrontendBootBarTime;
         [NMS(Index = 1112)]
-        /* 0x6A88 */ public float FrontendBootTime;
+        /* 0x6B38 */ public float FrontendBootTime;
         [NMS(Index = 1097)]
-        /* 0x6A8C */ public float FrontendConfirmTime;
+        /* 0x6B3C */ public float FrontendConfirmTime;
         [NMS(Index = 1095)]
-        /* 0x6A90 */ public float FrontendConfirmTimeFast;
+        /* 0x6B40 */ public float FrontendConfirmTimeFast;
         [NMS(Index = 1094)]
-        /* 0x6A94 */ public float FrontendConfirmTimeMouseMultiplier;
+        /* 0x6B44 */ public float FrontendConfirmTimeMouseMultiplier;
         [NMS(Index = 1098)]
-        /* 0x6A98 */ public float FrontendConfirmTimeSlow;
+        /* 0x6B48 */ public float FrontendConfirmTimeSlow;
         [NMS(Index = 1101)]
-        /* 0x6A9C */ public float FrontendCursorOffset;
+        /* 0x6B4C */ public float FrontendCursorOffset;
         [NMS(Index = 1100)]
-        /* 0x6AA0 */ public float FrontendCursorSize;
+        /* 0x6B50 */ public float FrontendCursorSize;
         [NMS(Index = 1105)]
-        /* 0x6AA4 */ public float FrontendCursorWidth;
+        /* 0x6B54 */ public float FrontendCursorWidth;
         [NMS(Index = 1107)]
-        /* 0x6AA8 */ public float FrontendDeactivateSplit;
+        /* 0x6B58 */ public float FrontendDeactivateSplit;
         [NMS(Index = 1106)]
-        /* 0x6AAC */ public float FrontendDeactivateTime;
+        /* 0x6B5C */ public float FrontendDeactivateTime;
         [NMS(Index = 1188)]
-        /* 0x6AB0 */ public float FrontendDoFBlurMultiplier;
+        /* 0x6B60 */ public float FrontendDoFBlurMultiplier;
         [NMS(Index = 1187)]
-        /* 0x6AB4 */ public float FrontendDoFFarPlaneFadeMax;
+        /* 0x6B64 */ public float FrontendDoFFarPlaneFadeMax;
         [NMS(Index = 1186)]
-        /* 0x6AB8 */ public float FrontendDoFFarPlaneFadeMin;
+        /* 0x6B68 */ public float FrontendDoFFarPlaneFadeMin;
         [NMS(Index = 1185)]
-        /* 0x6ABC */ public float FrontendDoFFarPlaneMax;
+        /* 0x6B6C */ public float FrontendDoFFarPlaneMax;
         [NMS(Index = 1184)]
-        /* 0x6AC0 */ public float FrontendDoFFarPlaneMin;
+        /* 0x6B70 */ public float FrontendDoFFarPlaneMin;
         [NMS(Index = 1183)]
-        /* 0x6AC4 */ public float FrontendDoFNearPlaneMax;
+        /* 0x6B74 */ public float FrontendDoFNearPlaneMax;
         [NMS(Index = 1182)]
-        /* 0x6AC8 */ public float FrontendDoFNearPlaneMin;
+        /* 0x6B78 */ public float FrontendDoFNearPlaneMin;
         [NMS(Index = 173)]
-        /* 0x6ACC */ public float FrontendOffsetVR;
+        /* 0x6B7C */ public float FrontendOffsetVR;
         [NMS(Index = 1191)]
-        /* 0x6AD0 */ public float FrontendShineSpeed;
+        /* 0x6B80 */ public float FrontendShineSpeed;
         [NMS(Index = 1110)]
-        /* 0x6AD4 */ public float FrontendStatCircleWidth;
+        /* 0x6B84 */ public float FrontendStatCircleWidth;
         [NMS(Index = 1111)]
-        /* 0x6AD8 */ public float FrontendStatCircleWidthExtra;
+        /* 0x6B88 */ public float FrontendStatCircleWidthExtra;
         [NMS(Index = 1194)]
-        /* 0x6ADC */ public float FrontendTitleFontSpacing;
+        /* 0x6B8C */ public float FrontendTitleFontSpacing;
         [NMS(Index = 1192)]
-        /* 0x6AE0 */ public float FrontendToolbarTextHeight;
+        /* 0x6B90 */ public float FrontendToolbarTextHeight;
         [NMS(Index = 1193)]
-        /* 0x6AE4 */ public float FrontendToolbarTextHeightSelected;
+        /* 0x6B94 */ public float FrontendToolbarTextHeightSelected;
         [NMS(Index = 1096)]
-        /* 0x6AE8 */ public float FrontendTouchConfirmTimeFastMultiplier;
+        /* 0x6B98 */ public float FrontendTouchConfirmTimeFastMultiplier;
         [NMS(Index = 571)]
-        /* 0x6AEC */ public float FrontendWaitFadeProgressiveDialogOut;
+        /* 0x6B9C */ public float FrontendWaitFadeProgressiveDialogOut;
         [NMS(Index = 570)]
-        /* 0x6AF0 */ public float FrontendWaitFadeTextFrameOut;
+        /* 0x6BA0 */ public float FrontendWaitFadeTextFrameOut;
         [NMS(Index = 569)]
-        /* 0x6AF4 */ public float FrontendWaitFadeTextOut;
+        /* 0x6BA4 */ public float FrontendWaitFadeTextOut;
         [NMS(Index = 567)]
-        /* 0x6AF8 */ public float FrontendWaitInitial;
+        /* 0x6BA8 */ public float FrontendWaitInitial;
         [NMS(Index = 568)]
-        /* 0x6AFC */ public float FrontendWaitInitialTerminal;
+        /* 0x6BAC */ public float FrontendWaitInitialTerminal;
         [NMS(Index = 566)]
-        /* 0x6B00 */ public float FrontendWaitResponse;
+        /* 0x6BB0 */ public float FrontendWaitResponse;
         [NMS(Index = 572)]
-        /* 0x6B04 */ public float FrontendWaitResponseOffset;
+        /* 0x6BB4 */ public float FrontendWaitResponseOffset;
         [NMS(Index = 865)]
-        /* 0x6B08 */ public float GalaxyMapRadialBorder;
+        /* 0x6BB8 */ public float GalaxyMapRadialBorder;
         [NMS(Index = 866)]
-        /* 0x6B0C */ public float GalaxyMapRadialTargetDist;
+        /* 0x6BBC */ public float GalaxyMapRadialTargetDist;
         [NMS(Index = 172)]
-        /* 0x6B10 */ public float GalmapDiscoveryOffsetVR;
+        /* 0x6BC0 */ public float GalmapDiscoveryOffsetVR;
         [NMS(Index = 98)]
-        /* 0x6B14 */ public float GameModeSelectColourFadeTime;
+        /* 0x6BC4 */ public float GameModeSelectColourFadeTime;
         [NMS(Index = 80)]
-        /* 0x6B18 */ public float GridDecayRateSwitchValue;
+        /* 0x6BC8 */ public float GridDecayRateSwitchValue;
         [NMS(Index = 555)]
-        /* 0x6B1C */ public float GridFlickerAmp;
+        /* 0x6BCC */ public float GridFlickerAmp;
         [NMS(Index = 553)]
-        /* 0x6B20 */ public float GridFlickerBaseAlpha;
+        /* 0x6BD0 */ public float GridFlickerBaseAlpha;
         [NMS(Index = 554)]
-        /* 0x6B24 */ public float GridFlickerFreq;
+        /* 0x6BD4 */ public float GridFlickerFreq;
         [NMS(Index = 235)]
-        /* 0x6B28 */ public float HandButtonClickTime;
+        /* 0x6BD8 */ public float HandButtonClickTime;
         [NMS(Index = 231)]
-        /* 0x6B2C */ public float HandButtonCursorScale;
+        /* 0x6BDC */ public float HandButtonCursorScale;
         [NMS(Index = 239)]
-        /* 0x6B30 */ public float HandButtonDotRadius;
+        /* 0x6BE0 */ public float HandButtonDotRadius;
         [NMS(Index = 237)]
-        /* 0x6B34 */ public float HandButtonFrontendCursorScale;
+        /* 0x6BE4 */ public float HandButtonFrontendCursorScale;
         [NMS(Index = 233)]
-        /* 0x6B38 */ public float HandButtonNearDistance;
+        /* 0x6BE8 */ public float HandButtonNearDistance;
         [NMS(Index = 228)]
-        /* 0x6B3C */ public float HandButtonPostClickTime;
+        /* 0x6BEC */ public float HandButtonPostClickTime;
         [NMS(Index = 240)]
-        /* 0x6B40 */ public float HandButtonPulseRadius;
+        /* 0x6BF0 */ public float HandButtonPulseRadius;
         [NMS(Index = 241)]
-        /* 0x6B44 */ public float HandButtonPulseThickness;
+        /* 0x6BF4 */ public float HandButtonPulseThickness;
         [NMS(Index = 232)]
-        /* 0x6B48 */ public float HandButtonPushDistance;
+        /* 0x6BF8 */ public float HandButtonPushDistance;
         [NMS(Index = 224)]
-        /* 0x6B4C */ public float HandButtonRadius;
+        /* 0x6BFC */ public float HandButtonRadius;
         [NMS(Index = 234)]
-        /* 0x6B50 */ public float HandButtonRadiusClick;
+        /* 0x6C00 */ public float HandButtonRadiusClick;
         [NMS(Index = 225)]
-        /* 0x6B54 */ public float HandButtonRadiusTouch;
+        /* 0x6C04 */ public float HandButtonRadiusTouch;
         [NMS(Index = 226)]
-        /* 0x6B58 */ public float HandButtonRadiusTouchNear;
+        /* 0x6C08 */ public float HandButtonRadiusTouchNear;
         [NMS(Index = 227)]
-        /* 0x6B5C */ public float HandButtonRadiusTouchNearActive;
+        /* 0x6C0C */ public float HandButtonRadiusTouchNearActive;
         [NMS(Index = 229)]
-        /* 0x6B60 */ public float HandButtonReleaseThreshold;
+        /* 0x6C10 */ public float HandButtonReleaseThreshold;
         [NMS(Index = 230)]
-        /* 0x6B64 */ public float HandButtonReleaseThresholdInit;
+        /* 0x6C14 */ public float HandButtonReleaseThresholdInit;
         [NMS(Index = 238)]
-        /* 0x6B68 */ public float HandButtonThickness;
+        /* 0x6C18 */ public float HandButtonThickness;
         [NMS(Index = 236)]
-        /* 0x6B6C */ public float HandButtonTouchReturnTime;
+        /* 0x6C1C */ public float HandButtonTouchReturnTime;
         [NMS(Index = 261)]
-        /* 0x6B70 */ public float HandControlButtonSize;
+        /* 0x6C20 */ public float HandControlButtonSize;
         [NMS(Index = 268)]
-        /* 0x6B74 */ public float HandControlMenuAngle;
+        /* 0x6C24 */ public float HandControlMenuAngle;
         [NMS(Index = 218)]
-        /* 0x6B78 */ public float HandControlMenuCursorScale;
+        /* 0x6C28 */ public float HandControlMenuCursorScale;
         [NMS(Index = 274)]
-        /* 0x6B7C */ public float HandControlMenuDepth;
+        /* 0x6C2C */ public float HandControlMenuDepth;
         [NMS(Index = 267)]
-        /* 0x6B80 */ public float HandControlMenuMoveActionDistance;
+        /* 0x6C30 */ public float HandControlMenuMoveActionDistance;
         [NMS(Index = 264)]
-        /* 0x6B84 */ public float HandControlMenuMoveDistance;
+        /* 0x6C34 */ public float HandControlMenuMoveDistance;
         [NMS(Index = 265)]
-        /* 0x6B88 */ public float HandControlMenuMoveDistanceScroll;
+        /* 0x6C38 */ public float HandControlMenuMoveDistanceScroll;
         [NMS(Index = 266)]
-        /* 0x6B8C */ public float HandControlMenuMoveDistanceVertical;
+        /* 0x6C3C */ public float HandControlMenuMoveDistanceVertical;
         [NMS(Index = 270)]
-        /* 0x6B90 */ public float HandControlMenuSelectRadius;
+        /* 0x6C40 */ public float HandControlMenuSelectRadius;
         [NMS(Index = 271)]
-        /* 0x6B94 */ public float HandControlMenuSelectRadius1;
+        /* 0x6C44 */ public float HandControlMenuSelectRadius1;
         [NMS(Index = 272)]
-        /* 0x6B98 */ public float HandControlMenuSelectRadius2;
+        /* 0x6C48 */ public float HandControlMenuSelectRadius2;
         [NMS(Index = 269)]
-        /* 0x6B9C */ public float HandControlMenuSurfaceOffset;
+        /* 0x6C4C */ public float HandControlMenuSurfaceOffset;
         [NMS(Index = 263)]
-        /* 0x6BA0 */ public float HandControlPointActiveMargin;
+        /* 0x6C50 */ public float HandControlPointActiveMargin;
         [NMS(Index = 262)]
-        /* 0x6BA4 */ public float HandControlPointMargin;
+        /* 0x6C54 */ public float HandControlPointMargin;
         [NMS(Index = 273)]
-        /* 0x6BA8 */ public float HandControlTopMenuSelectRadius;
+        /* 0x6C58 */ public float HandControlTopMenuSelectRadius;
         [NMS(Index = 123)]
-        /* 0x6BAC */ public float HandheldZoomFactor;
+        /* 0x6C5C */ public float HandheldZoomFactor;
         [NMS(Index = 222)]
-        /* 0x6BB0 */ public float HandScreenGraphicsHeight;
+        /* 0x6C60 */ public float HandScreenGraphicsHeight;
         [NMS(Index = 221)]
-        /* 0x6BB4 */ public float HandScreenGraphicsWidth;
+        /* 0x6C64 */ public float HandScreenGraphicsWidth;
         [NMS(Index = 278)]
-        /* 0x6BB8 */ public int HandScreenHeight;
+        /* 0x6C68 */ public int HandScreenHeight;
         [NMS(Index = 223)]
-        /* 0x6BBC */ public float HandScreenNearActivateDistance;
+        /* 0x6C6C */ public float HandScreenNearActivateDistance;
         [NMS(Index = 276)]
-        /* 0x6BC0 */ public int HandScreenWeaponHeight;
+        /* 0x6C70 */ public int HandScreenWeaponHeight;
         [NMS(Index = 275)]
-        /* 0x6BC4 */ public int HandScreenWeaponWidth;
+        /* 0x6C74 */ public int HandScreenWeaponWidth;
         [NMS(Index = 277)]
-        /* 0x6BC8 */ public int HandScreenWidth;
+        /* 0x6C78 */ public int HandScreenWidth;
         [NMS(Index = 1180)]
-        /* 0x6BCC */ public float HatchAlphaBase;
+        /* 0x6C7C */ public float HatchAlphaBase;
         [NMS(Index = 1181)]
-        /* 0x6BD0 */ public float HatchAlphaCursor;
+        /* 0x6C80 */ public float HatchAlphaCursor;
         [NMS(Index = 1179)]
-        /* 0x6BD4 */ public float HatchAlphaMain;
+        /* 0x6C84 */ public float HatchAlphaMain;
         [NMS(Index = 1177)]
-        /* 0x6BD8 */ public int HatchCount;
+        /* 0x6C88 */ public int HatchCount;
         [NMS(Index = 1178)]
-        /* 0x6BDC */ public float HatchCursorRadius;
+        /* 0x6C8C */ public float HatchCursorRadius;
         [NMS(Index = 1176)]
-        /* 0x6BE0 */ public float HatchPulsePauseTime;
+        /* 0x6C90 */ public float HatchPulsePauseTime;
         [NMS(Index = 1174)]
-        /* 0x6BE4 */ public float HatchPulseSpeed;
+        /* 0x6C94 */ public float HatchPulseSpeed;
         [NMS(Index = 1175)]
-        /* 0x6BE8 */ public float HatchPulseWidth;
+        /* 0x6C98 */ public float HatchPulseWidth;
         [NMS(Index = 655)]
-        /* 0x6BEC */ public float HazardArrowsLevel2Threshold;
+        /* 0x6C9C */ public float HazardArrowsLevel2Threshold;
         [NMS(Index = 656)]
-        /* 0x6BF0 */ public float HazardArrowsLevel3Threshold;
+        /* 0x6CA0 */ public float HazardArrowsLevel3Threshold;
         [NMS(Index = 1012)]
-        /* 0x6BF4 */ public float HazardBarPulseTime;
+        /* 0x6CA4 */ public float HazardBarPulseTime;
         [NMS(Index = 1017)]
-        /* 0x6BF8 */ public float HazardPainPulseStrength;
+        /* 0x6CA8 */ public float HazardPainPulseStrength;
         [NMS(Index = 1038)]
-        /* 0x6BFC */ public float HazardPulseRate;
+        /* 0x6CAC */ public float HazardPulseRate;
         [NMS(Index = 1009)]
-        /* 0x6C00 */ public float HazardScreenEffectPulseRate;
+        /* 0x6CB0 */ public float HazardScreenEffectPulseRate;
         [NMS(Index = 1013)]
-        /* 0x6C04 */ public float HazardScreenEffectPulseTime;
+        /* 0x6CB4 */ public float HazardScreenEffectPulseTime;
         [NMS(Index = 1014)]
-        /* 0x6C08 */ public float HazardScreenEffectStrength;
+        /* 0x6CB8 */ public float HazardScreenEffectStrength;
         [NMS(Index = 1016)]
-        /* 0x6C0C */ public float HazardWarningPulseStrength;
+        /* 0x6CBC */ public float HazardWarningPulseStrength;
         [NMS(Index = 1015)]
-        /* 0x6C10 */ public float HazardWarningPulseTime;
+        /* 0x6CC0 */ public float HazardWarningPulseTime;
         [NMS(Index = 1204)]
-        /* 0x6C14 */ public float HitMarkerPulseSize;
+        /* 0x6CC4 */ public float HitMarkerPulseSize;
         [NMS(Index = 1205)]
-        /* 0x6C18 */ public float HitMarkerPulseSizeStatic;
+        /* 0x6CC8 */ public float HitMarkerPulseSizeStatic;
         [NMS(Index = 1206)]
-        /* 0x6C1C */ public float HitMarkerPulseTime;
+        /* 0x6CCC */ public float HitMarkerPulseTime;
         [NMS(Index = 289)]
-        /* 0x6C20 */ public float HmdFramerateScreenPitch;
+        /* 0x6CD0 */ public float HmdFramerateScreenPitch;
         [NMS(Index = 1005)]
-        /* 0x6C24 */ public float HoldTimerResetTime;
+        /* 0x6CD4 */ public float HoldTimerResetTime;
         [NMS(Index = 584)]
-        /* 0x6C28 */ public float HoverOffscreenBorder;
+        /* 0x6CD8 */ public float HoverOffscreenBorder;
         [NMS(Index = 585)]
-        /* 0x6C2C */ public float HoverOffscreenBorderXVR;
+        /* 0x6CDC */ public float HoverOffscreenBorderXVR;
         [NMS(Index = 586)]
-        /* 0x6C30 */ public float HoverOffscreenBorderYAltUI;
+        /* 0x6CE0 */ public float HoverOffscreenBorderYAltUI;
         [NMS(Index = 40)]
-        /* 0x6C34 */ public float HoverPopAnimDuration;
+        /* 0x6CE4 */ public float HoverPopAnimDuration;
         [NMS(Index = 39)]
-        /* 0x6C38 */ public float HoverPopScaleModification;
+        /* 0x6CE8 */ public float HoverPopScaleModification;
         [NMS(Index = 805)]
-        /* 0x6C3C */ public float HUDDisplayTime;
+        /* 0x6CEC */ public float HUDDisplayTime;
         [NMS(Index = 751)]
-        /* 0x6C40 */ public float HUDDroneCombatPulse;
+        /* 0x6CF0 */ public float HUDDroneCombatPulse;
         [NMS(Index = 749)]
-        /* 0x6C44 */ public float HUDDroneHealingPulse;
+        /* 0x6CF4 */ public float HUDDroneHealingPulse;
         [NMS(Index = 750)]
-        /* 0x6C48 */ public float HUDDroneSummoningPulse;
+        /* 0x6CF8 */ public float HUDDroneSummoningPulse;
         [NMS(Index = 943)]
-        /* 0x6C4C */ public float HUDElementsOffsetHMDBottom;
+        /* 0x6CFC */ public float HUDElementsOffsetHMDBottom;
         [NMS(Index = 941)]
-        /* 0x6C50 */ public float HUDElementsOffsetHMDSide;
+        /* 0x6D00 */ public float HUDElementsOffsetHMDSide;
         [NMS(Index = 942)]
-        /* 0x6C54 */ public float HUDElementsOffsetHMDTop;
+        /* 0x6D04 */ public float HUDElementsOffsetHMDTop;
         [NMS(Index = 944)]
-        /* 0x6C58 */ public float HUDElementsOffsetX_0;
+        /* 0x6D08 */ public float HUDElementsOffsetX_0;
         [NMS(Index = 946)]
-        /* 0x6C5C */ public float HUDElementsOffsetX_1;
+        /* 0x6D0C */ public float HUDElementsOffsetX_1;
         [NMS(Index = 948)]
-        /* 0x6C60 */ public float HUDElementsOffsetX_2;
+        /* 0x6D10 */ public float HUDElementsOffsetX_2;
         [NMS(Index = 950)]
-        /* 0x6C64 */ public float HUDElementsOffsetX_3;
+        /* 0x6D14 */ public float HUDElementsOffsetX_3;
         [NMS(Index = 952)]
-        /* 0x6C68 */ public float HUDElementsOffsetX_4;
+        /* 0x6D18 */ public float HUDElementsOffsetX_4;
         [NMS(Index = 954)]
-        /* 0x6C6C */ public float HUDElementsOffsetX_5;
+        /* 0x6D1C */ public float HUDElementsOffsetX_5;
         [NMS(Index = 945)]
-        /* 0x6C70 */ public float HUDElementsOffsetY_0;
+        /* 0x6D20 */ public float HUDElementsOffsetY_0;
         [NMS(Index = 947)]
-        /* 0x6C74 */ public float HUDElementsOffsetY_1;
+        /* 0x6D24 */ public float HUDElementsOffsetY_1;
         [NMS(Index = 949)]
-        /* 0x6C78 */ public float HUDElementsOffsetY_2;
+        /* 0x6D28 */ public float HUDElementsOffsetY_2;
         [NMS(Index = 951)]
-        /* 0x6C7C */ public float HUDElementsOffsetY_3;
+        /* 0x6D2C */ public float HUDElementsOffsetY_3;
         [NMS(Index = 953)]
-        /* 0x6C80 */ public float HUDElementsOffsetY_4;
+        /* 0x6D30 */ public float HUDElementsOffsetY_4;
         [NMS(Index = 955)]
-        /* 0x6C84 */ public float HUDElementsOffsetY_5;
+        /* 0x6D34 */ public float HUDElementsOffsetY_5;
         [NMS(Index = 1338)]
-        /* 0x6C88 */ public float HUDMarkerActiveTime;
+        /* 0x6D38 */ public float HUDMarkerActiveTime;
         [NMS(Index = 1333)]
-        /* 0x6C8C */ public float HUDMarkerAlpha;
+        /* 0x6D3C */ public float HUDMarkerAlpha;
         [NMS(Index = 1308)]
-        /* 0x6C90 */ public float HUDMarkerAnimLoopTime;
+        /* 0x6D40 */ public float HUDMarkerAnimLoopTime;
         [NMS(Index = 1307)]
-        /* 0x6C94 */ public float HUDMarkerAnimOffset;
+        /* 0x6D44 */ public float HUDMarkerAnimOffset;
         [NMS(Index = 1306)]
-        /* 0x6C98 */ public float HUDMarkerAnimScale;
+        /* 0x6D48 */ public float HUDMarkerAnimScale;
         [NMS(Index = 1305)]
-        /* 0x6C9C */ public float HUDMarkerAnimSpeed;
+        /* 0x6D4C */ public float HUDMarkerAnimSpeed;
         [NMS(Index = 450)]
-        /* 0x6CA0 */ public float HUDMarkerDistanceOrTimeDistance;
+        /* 0x6D50 */ public float HUDMarkerDistanceOrTimeDistance;
         [NMS(Index = 1326)]
-        /* 0x6CA4 */ public float HUDMarkerFarDistance;
+        /* 0x6D54 */ public float HUDMarkerFarDistance;
         [NMS(Index = 1327)]
-        /* 0x6CA8 */ public float HUDMarkerFarFadeRange;
+        /* 0x6D58 */ public float HUDMarkerFarFadeRange;
         [NMS(Index = 1332)]
-        /* 0x6CAC */ public float HUDMarkerHorizonBlendRange;
+        /* 0x6D5C */ public float HUDMarkerHorizonBlendRange;
         [NMS(Index = 1314)]
-        /* 0x6CB0 */ public float HUDMarkerHoverAngleTestGround;
+        /* 0x6D60 */ public float HUDMarkerHoverAngleTestGround;
         [NMS(Index = 296)]
-        /* 0x6CB4 */ public float HUDMarkerHoverAngleTestGroundHmd;
+        /* 0x6D64 */ public float HUDMarkerHoverAngleTestGroundHmd;
         [NMS(Index = 1318)]
-        /* 0x6CB8 */ public float HUDMarkerHoverAngleTestShip;
+        /* 0x6D68 */ public float HUDMarkerHoverAngleTestShip;
         [NMS(Index = 1319)]
-        /* 0x6CBC */ public float HUDMarkerHoverShowLargeAngleTest;
+        /* 0x6D6C */ public float HUDMarkerHoverShowLargeAngleTest;
         [NMS(Index = 1340)]
-        /* 0x6CC0 */ public float HUDMarkerIconHoverMinScale;
+        /* 0x6D70 */ public float HUDMarkerIconHoverMinScale;
         [NMS(Index = 558)]
-        /* 0x6CC4 */ public float HUDMarkerLabelArriveDistance;
+        /* 0x6D74 */ public float HUDMarkerLabelArriveDistance;
         [NMS(Index = 557)]
-        /* 0x6CC8 */ public float HUDMarkerLabelBaseWidth;
+        /* 0x6D78 */ public float HUDMarkerLabelBaseWidth;
         [NMS(Index = 559)]
-        /* 0x6CCC */ public float HUDMarkerLabelDisplayDistance;
+        /* 0x6D7C */ public float HUDMarkerLabelDisplayDistance;
         [NMS(Index = 556)]
-        /* 0x6CD0 */ public float HUDMarkerLabelWidthMultiplier;
+        /* 0x6D80 */ public float HUDMarkerLabelWidthMultiplier;
         [NMS(Index = 1335)]
-        /* 0x6CD4 */ public float HUDMarkerModelFadeMinHeight;
+        /* 0x6D84 */ public float HUDMarkerModelFadeMinHeight;
         [NMS(Index = 1334)]
-        /* 0x6CD8 */ public float HUDMarkerModelFadeRange;
+        /* 0x6D88 */ public float HUDMarkerModelFadeRange;
         [NMS(Index = 1324)]
-        /* 0x6CDC */ public float HUDMarkerNearFadeDistance;
+        /* 0x6D8C */ public float HUDMarkerNearFadeDistance;
         [NMS(Index = 1325)]
-        /* 0x6CE0 */ public float HUDMarkerNearFadeRange;
+        /* 0x6D90 */ public float HUDMarkerNearFadeRange;
         [NMS(Index = 560)]
-        /* 0x6CE4 */ public float HUDMarkerNonActiveMissionAlpha;
+        /* 0x6D94 */ public float HUDMarkerNonActiveMissionAlpha;
         [NMS(Index = 449)]
-        /* 0x6CE8 */ public float HUDMarkerObjectMinScreenDistance;
+        /* 0x6D98 */ public float HUDMarkerObjectMinScreenDistance;
         [NMS(Index = 1288)]
-        /* 0x6CEC */ public float HUDMarkerOffset;
+        /* 0x6D9C */ public float HUDMarkerOffset;
         [NMS(Index = 1311)]
-        /* 0x6CF0 */ public float HUDMarkerPrimaryIndicatorSize;
+        /* 0x6DA0 */ public float HUDMarkerPrimaryIndicatorSize;
         [NMS(Index = 1328)]
-        /* 0x6CF4 */ public float HUDMarkerScalerMin;
+        /* 0x6DA4 */ public float HUDMarkerScalerMin;
         [NMS(Index = 1329)]
-        /* 0x6CF8 */ public float HUDMarkerScalerRange;
+        /* 0x6DA8 */ public float HUDMarkerScalerRange;
         [NMS(Index = 1331)]
-        /* 0x6CFC */ public float HUDMarkerScalerSizeMax;
+        /* 0x6DAC */ public float HUDMarkerScalerSizeMax;
         [NMS(Index = 1330)]
-        /* 0x6D00 */ public float HUDMarkerScalerSizeMin;
+        /* 0x6DB0 */ public float HUDMarkerScalerSizeMin;
         [NMS(Index = 1322)]
-        /* 0x6D04 */ public float HUDMarkerShipOffsetMaxDist;
+        /* 0x6DB4 */ public float HUDMarkerShipOffsetMaxDist;
         [NMS(Index = 1323)]
-        /* 0x6D08 */ public float HUDMarkerShipOffsetMinDist;
+        /* 0x6DB8 */ public float HUDMarkerShipOffsetMinDist;
         [NMS(Index = 1336)]
-        /* 0x6D0C */ public float HUDMarkerShowActualIconDistance;
+        /* 0x6DBC */ public float HUDMarkerShowActualIconDistance;
         [NMS(Index = 1337)]
-        /* 0x6D10 */ public float HUDMarkerShowActualSpaceIconDistance;
+        /* 0x6DC0 */ public float HUDMarkerShowActualSpaceIconDistance;
         [NMS(Index = 1317)]
-        /* 0x6D14 */ public float HUDMarkerWideHoverAngleTest;
+        /* 0x6DC4 */ public float HUDMarkerWideHoverAngleTest;
         [NMS(Index = 297)]
-        /* 0x6D18 */ public float HUDMarkerWideHoverAngleTestHmd;
+        /* 0x6DC8 */ public float HUDMarkerWideHoverAngleTestHmd;
         [NMS(Index = 1316)]
-        /* 0x6D1C */ public float HUDNetworkMarkerHoverAngleTestGround;
+        /* 0x6DCC */ public float HUDNetworkMarkerHoverAngleTestGround;
         [NMS(Index = 1321)]
-        /* 0x6D20 */ public float HUDNetworkMarkerHoverAngleVRMul;
+        /* 0x6DD0 */ public float HUDNetworkMarkerHoverAngleVRMul;
         [NMS(Index = 1320)]
-        /* 0x6D24 */ public float HUDNetworkMarkerHoverShowLargeAngleTest;
+        /* 0x6DD4 */ public float HUDNetworkMarkerHoverShowLargeAngleTest;
         [NMS(Index = 1315)]
-        /* 0x6D28 */ public float HUDPetCentreScreenAngle;
+        /* 0x6DD8 */ public float HUDPetCentreScreenAngle;
         [NMS(Index = 1312)]
-        /* 0x6D2C */ public float HUDPetMarkerAngleTest;
+        /* 0x6DDC */ public float HUDPetMarkerAngleTest;
         [NMS(Index = 1313)]
-        /* 0x6D30 */ public float HUDPetMarkerAngleVRMul;
+        /* 0x6DE0 */ public float HUDPetMarkerAngleVRMul;
         [NMS(Index = 482)]
-        /* 0x6D34 */ public float HUDPlayerPhonePulseScanFreq;
+        /* 0x6DE4 */ public float HUDPlayerPhonePulseScanFreq;
         [NMS(Index = 481)]
-        /* 0x6D38 */ public float HUDPlayerSentinelPulseScanFreq;
+        /* 0x6DE8 */ public float HUDPlayerSentinelPulseScanFreq;
         [NMS(Index = 479)]
-        /* 0x6D3C */ public float HUDPlayerSentinelPulseWidth;
+        /* 0x6DEC */ public float HUDPlayerSentinelPulseWidth;
         [NMS(Index = 480)]
-        /* 0x6D40 */ public float HUDPlayerSentinelRangeFactor;
+        /* 0x6DF0 */ public float HUDPlayerSentinelRangeFactor;
         [NMS(Index = 853)]
-        /* 0x6D44 */ public float HUDPlayerTrackArrowArrowSize;
+        /* 0x6DF4 */ public float HUDPlayerTrackArrowArrowSize;
         [NMS(Index = 822)]
-        /* 0x6D48 */ public float HUDPlayerTrackArrowDamageGlowHullHitCriticalOpacityScale;
+        /* 0x6DF8 */ public float HUDPlayerTrackArrowDamageGlowHullHitCriticalOpacityScale;
         [NMS(Index = 823)]
-        /* 0x6D4C */ public float HUDPlayerTrackArrowDamageGlowHullHitOpacityScale;
+        /* 0x6DFC */ public float HUDPlayerTrackArrowDamageGlowHullHitOpacityScale;
         [NMS(Index = 830)]
-        /* 0x6D50 */ public float HUDPlayerTrackArrowDamageGlowOffset;
+        /* 0x6E00 */ public float HUDPlayerTrackArrowDamageGlowOffset;
         [NMS(Index = 826)]
-        /* 0x6D54 */ public float HUDPlayerTrackArrowDamageGlowShieldHitCriticalOpacityScale;
+        /* 0x6E04 */ public float HUDPlayerTrackArrowDamageGlowShieldHitCriticalOpacityScale;
         [NMS(Index = 827)]
-        /* 0x6D58 */ public float HUDPlayerTrackArrowDamageGlowShieldHitOpacityScale;
+        /* 0x6E08 */ public float HUDPlayerTrackArrowDamageGlowShieldHitOpacityScale;
         [NMS(Index = 854)]
-        /* 0x6D5C */ public float HUDPlayerTrackArrowDotSize;
+        /* 0x6E0C */ public float HUDPlayerTrackArrowDotSize;
         [NMS(Index = 834)]
-        /* 0x6D60 */ public float HUDPlayerTrackArrowEnergyShieldDepletedGlowOpacityScale;
+        /* 0x6E10 */ public float HUDPlayerTrackArrowEnergyShieldDepletedGlowOpacityScale;
         [NMS(Index = 835)]
-        /* 0x6D64 */ public float HUDPlayerTrackArrowEnergyShieldDepletedTime;
+        /* 0x6E14 */ public float HUDPlayerTrackArrowEnergyShieldDepletedTime;
         [NMS(Index = 832)]
-        /* 0x6D68 */ public float HUDPlayerTrackArrowEnergyShieldGlowOffset;
+        /* 0x6E18 */ public float HUDPlayerTrackArrowEnergyShieldGlowOffset;
         [NMS(Index = 818)]
-        /* 0x6D6C */ public float HUDPlayerTrackArrowEnergyShieldLowThreshold;
+        /* 0x6E1C */ public float HUDPlayerTrackArrowEnergyShieldLowThreshold;
         [NMS(Index = 819)]
-        /* 0x6D70 */ public float HUDPlayerTrackArrowEnergyShieldOffset;
+        /* 0x6E20 */ public float HUDPlayerTrackArrowEnergyShieldOffset;
         [NMS(Index = 839)]
-        /* 0x6D74 */ public float HUDPlayerTrackArrowEnergyShieldStartChargeGlowOpacityScale;
+        /* 0x6E24 */ public float HUDPlayerTrackArrowEnergyShieldStartChargeGlowOpacityScale;
         [NMS(Index = 840)]
-        /* 0x6D78 */ public float HUDPlayerTrackArrowEnergyShieldStartChargeTime;
+        /* 0x6E28 */ public float HUDPlayerTrackArrowEnergyShieldStartChargeTime;
         [NMS(Index = 862)]
-        /* 0x6D7C */ public float HUDPlayerTrackArrowFadeRange;
+        /* 0x6E2C */ public float HUDPlayerTrackArrowFadeRange;
         [NMS(Index = 821)]
-        /* 0x6D80 */ public float HUDPlayerTrackArrowGlowBaseOpacity;
+        /* 0x6E30 */ public float HUDPlayerTrackArrowGlowBaseOpacity;
         [NMS(Index = 814)]
-        /* 0x6D84 */ public float HUDPlayerTrackArrowHealthOffset;
+        /* 0x6E34 */ public float HUDPlayerTrackArrowHealthOffset;
         [NMS(Index = 777)]
-        /* 0x6D88 */ public float HUDPlayerTrackArrowIconBorderReducerShip;
+        /* 0x6E38 */ public float HUDPlayerTrackArrowIconBorderReducerShip;
         [NMS(Index = 774)]
-        /* 0x6D8C */ public float HUDPlayerTrackArrowIconFadeDist;
+        /* 0x6E3C */ public float HUDPlayerTrackArrowIconFadeDist;
         [NMS(Index = 773)]
-        /* 0x6D90 */ public float HUDPlayerTrackArrowIconFadeDistDrone;
+        /* 0x6E40 */ public float HUDPlayerTrackArrowIconFadeDistDrone;
         [NMS(Index = 772)]
-        /* 0x6D94 */ public float HUDPlayerTrackArrowIconFadeDistShip;
+        /* 0x6E44 */ public float HUDPlayerTrackArrowIconFadeDistShip;
         [NMS(Index = 775)]
-        /* 0x6D98 */ public float HUDPlayerTrackArrowIconFadeRange;
+        /* 0x6E48 */ public float HUDPlayerTrackArrowIconFadeRange;
         [NMS(Index = 776)]
-        /* 0x6D9C */ public float HUDPlayerTrackArrowIconFadeRangeShip;
+        /* 0x6E4C */ public float HUDPlayerTrackArrowIconFadeRangeShip;
         [NMS(Index = 767)]
-        /* 0x6DA0 */ public float HUDPlayerTrackArrowIconFadeTime;
+        /* 0x6E50 */ public float HUDPlayerTrackArrowIconFadeTime;
         [NMS(Index = 771)]
-        /* 0x6DA4 */ public float HUDPlayerTrackArrowIconPulse2Alpha;
+        /* 0x6E54 */ public float HUDPlayerTrackArrowIconPulse2Alpha;
         [NMS(Index = 765)]
-        /* 0x6DA8 */ public float HUDPlayerTrackArrowIconPulseTime;
+        /* 0x6E58 */ public float HUDPlayerTrackArrowIconPulseTime;
         [NMS(Index = 769)]
-        /* 0x6DAC */ public float HUDPlayerTrackArrowIconPulseWidth1;
+        /* 0x6E5C */ public float HUDPlayerTrackArrowIconPulseWidth1;
         [NMS(Index = 770)]
-        /* 0x6DB0 */ public float HUDPlayerTrackArrowIconPulseWidth2;
+        /* 0x6E60 */ public float HUDPlayerTrackArrowIconPulseWidth2;
         [NMS(Index = 766)]
-        /* 0x6DB4 */ public float HUDPlayerTrackArrowIconShowTime;
+        /* 0x6E64 */ public float HUDPlayerTrackArrowIconShowTime;
         [NMS(Index = 851)]
-        /* 0x6DB8 */ public float HUDPlayerTrackArrowIconSize;
+        /* 0x6E68 */ public float HUDPlayerTrackArrowIconSize;
         [NMS(Index = 861)]
-        /* 0x6DBC */ public float HUDPlayerTrackArrowMinFadeDist;
+        /* 0x6E6C */ public float HUDPlayerTrackArrowMinFadeDist;
         [NMS(Index = 846)]
-        /* 0x6DC0 */ public float HUDPlayerTrackArrowOffset;
+        /* 0x6E70 */ public float HUDPlayerTrackArrowOffset;
         [NMS(Index = 778)]
-        /* 0x6DC4 */ public float HUDPlayerTrackArrowPulseOffset;
+        /* 0x6E74 */ public float HUDPlayerTrackArrowPulseOffset;
         [NMS(Index = 779)]
-        /* 0x6DC8 */ public float HUDPlayerTrackArrowPulseRate;
+        /* 0x6E78 */ public float HUDPlayerTrackArrowPulseRate;
         [NMS(Index = 847)]
-        /* 0x6DCC */ public float HUDPlayerTrackArrowScreenBorder;
+        /* 0x6E7C */ public float HUDPlayerTrackArrowScreenBorder;
         [NMS(Index = 764)]
-        /* 0x6DD0 */ public float HUDPlayerTrackArrowShipLabelOffset;
+        /* 0x6E80 */ public float HUDPlayerTrackArrowShipLabelOffset;
         [NMS(Index = 848)]
-        /* 0x6DD4 */ public float HUDPlayerTrackArrowSize;
+        /* 0x6E84 */ public float HUDPlayerTrackArrowSize;
         [NMS(Index = 850)]
-        /* 0x6DD8 */ public float HUDPlayerTrackArrowSizeMax;
+        /* 0x6E88 */ public float HUDPlayerTrackArrowSizeMax;
         [NMS(Index = 849)]
-        /* 0x6DDC */ public float HUDPlayerTrackArrowSizeMin;
+        /* 0x6E8C */ public float HUDPlayerTrackArrowSizeMin;
         [NMS(Index = 852)]
-        /* 0x6DE0 */ public float HUDPlayerTrackArrowSmallIconSize;
+        /* 0x6E90 */ public float HUDPlayerTrackArrowSmallIconSize;
         [NMS(Index = 845)]
-        /* 0x6DE4 */ public float HUDPlayerTrackArrowTargetDist;
+        /* 0x6E94 */ public float HUDPlayerTrackArrowTargetDist;
         [NMS(Index = 844)]
-        /* 0x6DE8 */ public float HUDPlayerTrackArrowTargetDistShip;
+        /* 0x6E98 */ public float HUDPlayerTrackArrowTargetDistShip;
         [NMS(Index = 810)]
-        /* 0x6DEC */ public float HUDPlayerTrackArrowTextExtraHeight;
+        /* 0x6E9C */ public float HUDPlayerTrackArrowTextExtraHeight;
         [NMS(Index = 811)]
-        /* 0x6DF0 */ public float HUDPlayerTrackArrowTextExtraOffsetX;
+        /* 0x6EA0 */ public float HUDPlayerTrackArrowTextExtraOffsetX;
         [NMS(Index = 812)]
-        /* 0x6DF4 */ public float HUDPlayerTrackArrowTextExtraOffsetY;
+        /* 0x6EA4 */ public float HUDPlayerTrackArrowTextExtraOffsetY;
         [NMS(Index = 808)]
-        /* 0x6DF8 */ public float HUDPlayerTrackArrowTextHeight;
+        /* 0x6EA8 */ public float HUDPlayerTrackArrowTextHeight;
         [NMS(Index = 807)]
-        /* 0x6DFC */ public float HUDPlayerTrackArrowTextOffset;
+        /* 0x6EAC */ public float HUDPlayerTrackArrowTextOffset;
         [NMS(Index = 806)]
-        /* 0x6E00 */ public float HUDPlayerTrackDangerPulse;
+        /* 0x6EB0 */ public float HUDPlayerTrackDangerPulse;
         [NMS(Index = 752)]
-        /* 0x6E04 */ public float HUDPlayerTrackNoSightPulse;
+        /* 0x6EB4 */ public float HUDPlayerTrackNoSightPulse;
         [NMS(Index = 755)]
-        /* 0x6E08 */ public float HUDPlayerTrackTimerEnd;
+        /* 0x6EB8 */ public float HUDPlayerTrackTimerEnd;
         [NMS(Index = 756)]
-        /* 0x6E0C */ public float HUDPlayerTrackTimerPulseRate;
+        /* 0x6EBC */ public float HUDPlayerTrackTimerPulseRate;
         [NMS(Index = 753)]
-        /* 0x6E10 */ public float HUDPlayerTrackTimerStart;
+        /* 0x6EC0 */ public float HUDPlayerTrackTimerStart;
         [NMS(Index = 754)]
-        /* 0x6E14 */ public float HUDPlayerTrackTimerStartFade;
+        /* 0x6EC4 */ public float HUDPlayerTrackTimerStartFade;
         [NMS(Index = 1283)]
-        /* 0x6E18 */ public float HUDTargetHealthDangerTime;
+        /* 0x6EC8 */ public float HUDTargetHealthDangerTime;
         [NMS(Index = 1282)]
-        /* 0x6E1C */ public float HUDTargetHealthIconSize;
+        /* 0x6ECC */ public float HUDTargetHealthIconSize;
         [NMS(Index = 1286)]
-        /* 0x6E20 */ public float HUDTargetIconOffset;
+        /* 0x6ED0 */ public float HUDTargetIconOffset;
         [NMS(Index = 1287)]
-        /* 0x6E24 */ public float HUDTargetIconSize;
+        /* 0x6ED4 */ public float HUDTargetIconSize;
         [NMS(Index = 1284)]
-        /* 0x6E28 */ public float HUDTargetMarkerOffset;
+        /* 0x6ED8 */ public float HUDTargetMarkerOffset;
         [NMS(Index = 1285)]
-        /* 0x6E2C */ public float HUDTargetMarkerSize;
+        /* 0x6EDC */ public float HUDTargetMarkerSize;
         [NMS(Index = 867)]
-        /* 0x6E30 */ public float IconBackgroundAlpha;
+        /* 0x6EE0 */ public float IconBackgroundAlpha;
         [NMS(Index = 402)]
-        /* 0x6E34 */ public float IconGlowStrengthActive;
+        /* 0x6EE4 */ public float IconGlowStrengthActive;
         [NMS(Index = 401)]
-        /* 0x6E38 */ public float IconGlowStrengthError;
+        /* 0x6EE8 */ public float IconGlowStrengthError;
         [NMS(Index = 404)]
-        /* 0x6E3C */ public float IconGlowStrengthHighlight;
+        /* 0x6EEC */ public float IconGlowStrengthHighlight;
         [NMS(Index = 403)]
-        /* 0x6E40 */ public float IconGlowStrengthNeutral;
+        /* 0x6EF0 */ public float IconGlowStrengthNeutral;
         [NMS(Index = 1048)]
-        /* 0x6E44 */ public float IconPulseRate;
+        /* 0x6EF4 */ public float IconPulseRate;
         [NMS(Index = 1434)]
-        /* 0x6E48 */ public float InfoPortalGuideCycleTime;
+        /* 0x6EF8 */ public float InfoPortalGuideCycleTime;
         [NMS(Index = 1435)]
-        /* 0x6E4C */ public float InfoPortalMilestonesCycleTime;
+        /* 0x6EFC */ public float InfoPortalMilestonesCycleTime;
         [NMS(Index = 1069)]
-        /* 0x6E50 */ public float InteractionIconInnerRadius;
+        /* 0x6F00 */ public float InteractionIconInnerRadius;
         [NMS(Index = 1070)]
-        /* 0x6E54 */ public float InteractionIconOuterRadius;
+        /* 0x6F04 */ public float InteractionIconOuterRadius;
         [NMS(Index = 300)]
-        /* 0x6E58 */ public float InteractionInWorldMinScreenDistance;
+        /* 0x6F08 */ public float InteractionInWorldMinScreenDistance;
         [NMS(Index = 301)]
-        /* 0x6E5C */ public float InteractionInWorldMinScreenDistanceV2;
+        /* 0x6F0C */ public float InteractionInWorldMinScreenDistanceV2;
         [NMS(Index = 299)]
-        /* 0x6E60 */ public float InteractionInWorldPitchDistance;
+        /* 0x6F10 */ public float InteractionInWorldPitchDistance;
         [NMS(Index = 302)]
-        /* 0x6E64 */ public float InteractionInWorldSeatedNPCHeightAdjust;
+        /* 0x6F14 */ public float InteractionInWorldSeatedNPCHeightAdjust;
         [NMS(Index = 303)]
-        /* 0x6E68 */ public float InteractionInWorldSeatedNPCHeightAdjustV2;
+        /* 0x6F18 */ public float InteractionInWorldSeatedNPCHeightAdjustV2;
         [NMS(Index = 1067)]
-        /* 0x6E6C */ public float InteractionLabelHeight;
+        /* 0x6F1C */ public float InteractionLabelHeight;
         [NMS(Index = 1060)]
-        /* 0x6E70 */ public float InteractionLabelHorizontalLineLength;
+        /* 0x6F20 */ public float InteractionLabelHorizontalLineLength;
         [NMS(Index = 1068)]
-        /* 0x6E74 */ public float InteractionLabelLineAlpha;
+        /* 0x6F24 */ public float InteractionLabelLineAlpha;
         [NMS(Index = 1072)]
-        /* 0x6E78 */ public float InteractionLabelPixelHeightMax;
+        /* 0x6F28 */ public float InteractionLabelPixelHeightMax;
         [NMS(Index = 1071)]
-        /* 0x6E7C */ public float InteractionLabelPixelHeightMin;
+        /* 0x6F2C */ public float InteractionLabelPixelHeightMin;
         [NMS(Index = 1066)]
-        /* 0x6E80 */ public float InteractionLabelRadiusScaler;
+        /* 0x6F30 */ public float InteractionLabelRadiusScaler;
         [NMS(Index = 1074)]
-        /* 0x6E84 */ public float InteractionLabelSpeedClose;
+        /* 0x6F34 */ public float InteractionLabelSpeedClose;
         [NMS(Index = 1073)]
-        /* 0x6E88 */ public float InteractionLabelSpeedOpen;
+        /* 0x6F38 */ public float InteractionLabelSpeedOpen;
         [NMS(Index = 975)]
-        /* 0x6E8C */ public float InteractionScanDisplayTime;
+        /* 0x6F3C */ public float InteractionScanDisplayTime;
         [NMS(Index = 974)]
-        /* 0x6E90 */ public float InteractionScanMinTime;
+        /* 0x6F40 */ public float InteractionScanMinTime;
         [NMS(Index = 973)]
-        /* 0x6E94 */ public float InteractionScanScanTime;
+        /* 0x6F44 */ public float InteractionScanScanTime;
         [NMS(Index = 978)]
-        /* 0x6E98 */ public float InteractionScanSlapOverallTime;
+        /* 0x6F48 */ public float InteractionScanSlapOverallTime;
         [NMS(Index = 977)]
-        /* 0x6E9C */ public float InteractionScanSlapScale;
+        /* 0x6F4C */ public float InteractionScanSlapScale;
         [NMS(Index = 976)]
-        /* 0x6EA0 */ public float InteractionScanSlapTime;
+        /* 0x6F50 */ public float InteractionScanSlapTime;
         [NMS(Index = 1004)]
-        /* 0x6EA4 */ public float InventoryFullMessageRepeatTime;
+        /* 0x6F54 */ public float InventoryFullMessageRepeatTime;
         [NMS(Index = 927)]
-        /* 0x6EA8 */ public float InventoryIconTime;
+        /* 0x6F58 */ public float InventoryIconTime;
         [NMS(Index = 70)]
-        /* 0x6EAC */ public float InvSlotGradientFactor;
+        /* 0x6F5C */ public float InvSlotGradientFactor;
         [NMS(Index = 69)]
-        /* 0x6EB0 */ public float InvSlotGradientFactorMin;
+        /* 0x6F60 */ public float InvSlotGradientFactorMin;
         [NMS(Index = 71)]
-        /* 0x6EB4 */ public float InvSlotGradientTime;
+        /* 0x6F64 */ public float InvSlotGradientTime;
         [NMS(Index = 246)]
-        /* 0x6EB8 */ public float InWorldInteractionScreenScale;
+        /* 0x6F68 */ public float InWorldInteractionScreenScale;
         [NMS(Index = 143)]
-        /* 0x6EBC */ public float InWorldInteractLabelFarDistance;
+        /* 0x6F6C */ public float InWorldInteractLabelFarDistance;
         [NMS(Index = 144)]
-        /* 0x6EC0 */ public float InWorldInteractLabelFarRange;
+        /* 0x6F70 */ public float InWorldInteractLabelFarRange;
         [NMS(Index = 199)]
-        /* 0x6EC4 */ public int InWorldInteractLabelHeight;
+        /* 0x6F74 */ public int InWorldInteractLabelHeight;
         [NMS(Index = 140)]
-        /* 0x6EC8 */ public float InWorldInteractLabelMinHeadOffset;
+        /* 0x6F78 */ public float InWorldInteractLabelMinHeadOffset;
         [NMS(Index = 141)]
-        /* 0x6ECC */ public float InWorldInteractLabelNearDistance;
+        /* 0x6F7C */ public float InWorldInteractLabelNearDistance;
         [NMS(Index = 142)]
-        /* 0x6ED0 */ public float InWorldInteractLabelNearRange;
+        /* 0x6F80 */ public float InWorldInteractLabelNearRange;
         [NMS(Index = 132)]
-        /* 0x6ED4 */ public float InWorldInteractLabelScale;
+        /* 0x6F84 */ public float InWorldInteractLabelScale;
         [NMS(Index = 133)]
-        /* 0x6ED8 */ public float InWorldInteractLabelScaleV2;
+        /* 0x6F88 */ public float InWorldInteractLabelScaleV2;
         [NMS(Index = 198)]
-        /* 0x6EDC */ public int InWorldInteractLabelWidth;
+        /* 0x6F8C */ public int InWorldInteractLabelWidth;
         [NMS(Index = 194)]
-        /* 0x6EE0 */ public float InWorldNGuiScreenScale;
+        /* 0x6F90 */ public float InWorldNGuiScreenScale;
         [NMS(Index = 247)]
-        /* 0x6EE4 */ public float InWorldNPCInteractionScreenScale;
+        /* 0x6F94 */ public float InWorldNPCInteractionScreenScale;
         [NMS(Index = 193)]
-        /* 0x6EE8 */ public float InWorldScreenForwardOffset;
+        /* 0x6F98 */ public float InWorldScreenForwardOffset;
         [NMS(Index = 192)]
-        /* 0x6EEC */ public float InWorldScreenMinScreenDistance;
+        /* 0x6F9C */ public float InWorldScreenMinScreenDistance;
         [NMS(Index = 134)]
-        /* 0x6EF0 */ public float InWorldScreenScaleDistance;
+        /* 0x6FA0 */ public float InWorldScreenScaleDistance;
         [NMS(Index = 43)]
-        /* 0x6EF4 */ public float InWorldUIInteractionDistanceWithEyeTrackingEnabled;
+        /* 0x6FA4 */ public float InWorldUIInteractionDistanceWithEyeTrackingEnabled;
         [NMS(Index = 930)]
-        /* 0x6EF8 */ public float ItemReceivedMessageTimeToAdd;
+        /* 0x6FA8 */ public float ItemReceivedMessageTimeToAdd;
         [NMS(Index = 968)]
-        /* 0x6EFC */ public float ItemSlotColourTechChargeRate;
+        /* 0x6FAC */ public float ItemSlotColourTechChargeRate;
         [NMS(Index = 1010)]
-        /* 0x6F00 */ public float KeepHazardBarActiveTime;
+        /* 0x6FB0 */ public float KeepHazardBarActiveTime;
         [NMS(Index = 1011)]
-        /* 0x6F04 */ public float KeepSecondHazardBarActiveTime;
+        /* 0x6FB4 */ public float KeepSecondHazardBarActiveTime;
         [NMS(Index = 905)]
-        /* 0x6F08 */ public float LandNotifyHeightThreshold;
+        /* 0x6FB8 */ public float LandNotifyHeightThreshold;
         [NMS(Index = 904)]
-        /* 0x6F0C */ public float LandNotifySpeedThreshold;
+        /* 0x6FBC */ public float LandNotifySpeedThreshold;
         [NMS(Index = 906)]
-        /* 0x6F10 */ public float LandNotifyTimeThreshold;
+        /* 0x6FC0 */ public float LandNotifyTimeThreshold;
         [NMS(Index = 718)]
-        /* 0x6F14 */ public float LargeSpaceIconSize;
+        /* 0x6FC4 */ public float LargeSpaceIconSize;
         [NMS(Index = 340)]
-        /* 0x6F18 */ public float LoadFadeInDefaultTime;
+        /* 0x6FC8 */ public float LoadFadeInDefaultTime;
         [NMS(Index = 127)]
-        /* 0x6F1C */ public float LoadingScreenTime;
+        /* 0x6FCC */ public float LoadingScreenTime;
         [NMS(Index = 126)]
-        /* 0x6F20 */ public float LoadingScreenTravelSpeed;
+        /* 0x6FD0 */ public float LoadingScreenTravelSpeed;
         [NMS(Index = 125)]
-        /* 0x6F24 */ public float LoadingTravelDistance;
+        /* 0x6FD4 */ public float LoadingTravelDistance;
         [NMS(Index = 1352)]
-        /* 0x6F28 */ public float LockOnMarkerSize;
+        /* 0x6FD8 */ public float LockOnMarkerSize;
         [NMS(Index = 1353)]
-        /* 0x6F2C */ public float LockOnMarkerSizeLock;
+        /* 0x6FDC */ public float LockOnMarkerSizeLock;
         [NMS(Index = 190)]
-        /* 0x6F30 */ public float LowerHelmetScreenPitch;
+        /* 0x6FE0 */ public float LowerHelmetScreenPitch;
         [NMS(Index = 189)]
-        /* 0x6F34 */ public float LowerHelmetScreenScale;
+        /* 0x6FE4 */ public float LowerHelmetScreenScale;
         [NMS(Index = 500)]
-        /* 0x6F38 */ public float LowHealthShieldFactor;
+        /* 0x6FE8 */ public float LowHealthShieldFactor;
         [NMS(Index = 499)]
-        /* 0x6F3C */ public float LowHealthShieldMin;
+        /* 0x6FEC */ public float LowHealthShieldMin;
         [NMS(Index = 453)]
-        /* 0x6F40 */ public float MaintenanceIconFadeStart;
+        /* 0x6FF0 */ public float MaintenanceIconFadeStart;
         [NMS(Index = 454)]
-        /* 0x6F44 */ public float MaintenanceIconFadeTime;
+        /* 0x6FF4 */ public float MaintenanceIconFadeTime;
         [NMS(Index = 925)]
-        /* 0x6F48 */ public float ManualNotificationPauseTime;
+        /* 0x6FF8 */ public float ManualNotificationPauseTime;
         [NMS(Index = 1433)]
-        /* 0x6F4C */ public float ManualScrollChangePerInputMax;
+        /* 0x6FFC */ public float ManualScrollChangePerInputMax;
         [NMS(Index = 1432)]
-        /* 0x6F50 */ public float ManualScrollChangePerInputMin;
+        /* 0x7000 */ public float ManualScrollChangePerInputMin;
         [NMS(Index = 451)]
-        /* 0x6F54 */ public float MarkerComponentOffset;
+        /* 0x7004 */ public float MarkerComponentOffset;
         [NMS(Index = 350)]
-        /* 0x6F58 */ public float MarkerHorizonApproachAngle;
+        /* 0x7008 */ public float MarkerHorizonApproachAngle;
         [NMS(Index = 349)]
-        /* 0x6F5C */ public float MarkerHorizonMinOffset;
+        /* 0x700C */ public float MarkerHorizonMinOffset;
         [NMS(Index = 356)]
-        /* 0x6F60 */ public float MarkerHorizonOffPlanetLightBeamAngle;
+        /* 0x7010 */ public float MarkerHorizonOffPlanetLightBeamAngle;
         [NMS(Index = 348)]
-        /* 0x6F64 */ public float MarkerHorizonOffsetAngle;
+        /* 0x7014 */ public float MarkerHorizonOffsetAngle;
         [NMS(Index = 357)]
-        /* 0x6F68 */ public float MarkerHorizonShipApproachOffset;
+        /* 0x7018 */ public float MarkerHorizonShipApproachOffset;
         [NMS(Index = 351)]
-        /* 0x6F6C */ public float MarkerOffsetTypeAngle;
+        /* 0x701C */ public float MarkerOffsetTypeAngle;
         [NMS(Index = 355)]
-        /* 0x6F70 */ public float MarkerOffsetTypeAngleAsteroid;
+        /* 0x7020 */ public float MarkerOffsetTypeAngleAsteroid;
         [NMS(Index = 352)]
-        /* 0x6F74 */ public float MarkerOffsetTypeAngleBattle;
+        /* 0x7024 */ public float MarkerOffsetTypeAngleBattle;
         [NMS(Index = 353)]
-        /* 0x6F78 */ public float MarkerOffsetTypeAngleBounty;
+        /* 0x7028 */ public float MarkerOffsetTypeAngleBounty;
         [NMS(Index = 354)]
-        /* 0x6F7C */ public float MarkerOffsetTypeAnglePlayerShip;
+        /* 0x702C */ public float MarkerOffsetTypeAnglePlayerShip;
         [NMS(Index = 437)]
-        /* 0x6F80 */ public float MarkerRingInnerRadius;
+        /* 0x7030 */ public float MarkerRingInnerRadius;
         [NMS(Index = 438)]
-        /* 0x6F84 */ public float MarkerRingOuterRadius;
+        /* 0x7034 */ public float MarkerRingOuterRadius;
         [NMS(Index = 366)]
-        /* 0x6F88 */ public float MarkerTagAppearDelay;
+        /* 0x7038 */ public float MarkerTagAppearDelay;
         [NMS(Index = 503)]
-        /* 0x6F8C */ public int MaxDialogCharSizeIdeographic;
+        /* 0x703C */ public int MaxDialogCharSizeIdeographic;
         [NMS(Index = 501)]
-        /* 0x6F90 */ public int MaxDialogCharSizeRoman;
+        /* 0x7040 */ public int MaxDialogCharSizeRoman;
         [NMS(Index = 361)]
-        /* 0x6F94 */ public int MaxNumMessageBeaconIcons;
+        /* 0x7044 */ public int MaxNumMessageBeaconIcons;
         [NMS(Index = 175)]
-        /* 0x6F98 */ public float MaxProjectorDistanceFromDefault;
+        /* 0x7048 */ public float MaxProjectorDistanceFromDefault;
         [NMS(Index = 178)]
-        /* 0x6F9C */ public float MaxProjectorGrabDistance;
+        /* 0x704C */ public float MaxProjectorGrabDistance;
         [NMS(Index = 84)]
-        /* 0x6FA0 */ public int MaxSubstanceMaxAmountForAmountFraction;
+        /* 0x7050 */ public int MaxSubstanceMaxAmountForAmountFraction;
         [NMS(Index = 928)]
-        /* 0x6FA4 */ public float MessageNotificationTime;
+        /* 0x7054 */ public float MessageNotificationTime;
         [NMS(Index = 929)]
-        /* 0x6FA8 */ public float MessageTimeQuick;
+        /* 0x7058 */ public float MessageTimeQuick;
         [NMS(Index = 108)]
-        /* 0x6FAC */ public float MilestoneStingDisplayTime;
+        /* 0x705C */ public float MilestoneStingDisplayTime;
         [NMS(Index = 1427)]
-        /* 0x6FB0 */ public float MinimumHoldFill;
+        /* 0x7060 */ public float MinimumHoldFill;
         [NMS(Index = 106)]
-        /* 0x6FB4 */ public float MinSeasonPlayTimeInDays;
+        /* 0x7064 */ public float MinSeasonPlayTimeInDays;
         [NMS(Index = 731)]
-        /* 0x6FB8 */ public float MissileCentreOffset;
+        /* 0x7068 */ public float MissileCentreOffset;
         [NMS(Index = 1358)]
-        /* 0x6FBC */ public float MissileIconAttackPulseAmount;
+        /* 0x706C */ public float MissileIconAttackPulseAmount;
         [NMS(Index = 1357)]
-        /* 0x6FC0 */ public float MissileIconAttackPulseTime;
+        /* 0x7070 */ public float MissileIconAttackPulseTime;
         [NMS(Index = 712)]
-        /* 0x6FC4 */ public float MissionCompassIconScaler;
+        /* 0x7074 */ public float MissionCompassIconScaler;
         [NMS(Index = 365)]
-        /* 0x6FC8 */ public float MissionDetailsPageBaseHeight;
+        /* 0x7078 */ public float MissionDetailsPageBaseHeight;
         [NMS(Index = 529)]
-        /* 0x6FCC */ public int MissionLoopCount;
+        /* 0x707C */ public int MissionLoopCount;
         [NMS(Index = 530)]
-        /* 0x6FD0 */ public int MissionLoopCountPirate;
+        /* 0x7080 */ public int MissionLoopCountPirate;
         [NMS(Index = 713)]
-        /* 0x6FD4 */ public float MissionMarkerSize;
+        /* 0x7084 */ public float MissionMarkerSize;
         [NMS(Index = 362)]
-        /* 0x6FD8 */ public float MissionObjectiveBaseHeight;
+        /* 0x7088 */ public float MissionObjectiveBaseHeight;
         [NMS(Index = 363)]
-        /* 0x6FDC */ public float MissionObjectiveDoneHeight;
+        /* 0x708C */ public float MissionObjectiveDoneHeight;
         [NMS(Index = 364)]
-        /* 0x6FE0 */ public float MissionObjectiveScrollingExtra;
+        /* 0x7090 */ public float MissionObjectiveScrollingExtra;
         [NMS(Index = 531)]
-        /* 0x6FE4 */ public int MissionSeedOffset;
+        /* 0x7094 */ public int MissionSeedOffset;
         [NMS(Index = 528)]
-        /* 0x6FE8 */ public int MissionSpecificMissionPercent;
+        /* 0x7098 */ public int MissionSpecificMissionPercent;
         [NMS(Index = 512)]
-        /* 0x6FEC */ public float MissionStartEndOSDTime;
+        /* 0x709C */ public float MissionStartEndOSDTime;
         [NMS(Index = 513)]
-        /* 0x6FF0 */ public float MissionStartEndOSDTimeProcedural;
+        /* 0x70A0 */ public float MissionStartEndOSDTimeProcedural;
         [NMS(Index = 511)]
-        /* 0x6FF4 */ public float MissionStartEndTime;
+        /* 0x70A4 */ public float MissionStartEndTime;
         [NMS(Index = 38)]
-        /* 0x6FF8 */ public float ModularCustomisationApplyTime;
+        /* 0x70A8 */ public float ModularCustomisationApplyTime;
         [NMS(Index = 1441)]
-        /* 0x6FFC */ public float MouseRotateCameraSensitivity;
+        /* 0x70AC */ public float MouseRotateCameraSensitivity;
         [NMS(Index = 1413)]
-        /* 0x7000 */ public float MultiplayerTeleportEffectAppearTime;
+        /* 0x70B0 */ public float MultiplayerTeleportEffectAppearTime;
         [NMS(Index = 1412)]
-        /* 0x7004 */ public float MultiplayerTeleportEffectDisappearTime;
+        /* 0x70B4 */ public float MultiplayerTeleportEffectDisappearTime;
         [NMS(Index = 1378)]
-        /* 0x7008 */ public float NGuiActiveAreaOffsetTime;
+        /* 0x70B8 */ public float NGuiActiveAreaOffsetTime;
         [NMS(Index = 1369)]
-        /* 0x700C */ public float NGuiAltPlacementDistanceScrollSpeed;
+        /* 0x70BC */ public float NGuiAltPlacementDistanceScrollSpeed;
         [NMS(Index = 1377)]
-        /* 0x7010 */ public float NGuiCursorOffsetMultiplier;
+        /* 0x70C0 */ public float NGuiCursorOffsetMultiplier;
         [NMS(Index = 288)]
-        /* 0x7014 */ public float NGuiHmdOffset;
+        /* 0x70C4 */ public float NGuiHmdOffset;
         [NMS(Index = 1359)]
-        /* 0x7018 */ public float NGuiModelRotationDegreesX;
+        /* 0x70C8 */ public float NGuiModelRotationDegreesX;
         [NMS(Index = 1360)]
-        /* 0x701C */ public float NGuiModelRotationDegreesY;
+        /* 0x70CC */ public float NGuiModelRotationDegreesY;
         [NMS(Index = 1361)]
-        /* 0x7020 */ public float NGuiModelRotationDegreesZ;
+        /* 0x70D0 */ public float NGuiModelRotationDegreesZ;
         [NMS(Index = 1368)]
-        /* 0x7024 */ public float NGuiModelViewCdSmoothTime;
+        /* 0x70D4 */ public float NGuiModelViewCdSmoothTime;
         [NMS(Index = 1366)]
-        /* 0x7028 */ public float NGuiModelViewDistanceDiscoveryPage;
+        /* 0x70D8 */ public float NGuiModelViewDistanceDiscoveryPage;
         [NMS(Index = 1362)]
-        /* 0x702C */ public float NGuiModelViewDistanceGlobal;
+        /* 0x70DC */ public float NGuiModelViewDistanceGlobal;
         [NMS(Index = 1365)]
-        /* 0x7030 */ public float NGuiModelViewDistanceShipPage;
+        /* 0x70E0 */ public float NGuiModelViewDistanceShipPage;
         [NMS(Index = 1363)]
-        /* 0x7034 */ public float NGuiModelViewDistanceSuitPage;
+        /* 0x70E4 */ public float NGuiModelViewDistanceSuitPage;
         [NMS(Index = 1364)]
-        /* 0x7038 */ public float NGuiModelViewDistanceWeaponPage;
+        /* 0x70E8 */ public float NGuiModelViewDistanceWeaponPage;
         [NMS(Index = 1386)]
-        /* 0x703C */ public float NGuiModelViewFadeInAfterRenderTime;
+        /* 0x70EC */ public float NGuiModelViewFadeInAfterRenderTime;
         [NMS(Index = 1367)]
-        /* 0x7040 */ public float NGuiModelViewFov;
+        /* 0x70F0 */ public float NGuiModelViewFov;
         [NMS(Index = 1371)]
-        /* 0x7044 */ public float NGuiModelViewFractionOfBBHeightAboveReflectivePlane;
+        /* 0x70F4 */ public float NGuiModelViewFractionOfBBHeightAboveReflectivePlane;
         [NMS(Index = 1196)]
-        /* 0x7048 */ public float NGuiMouseSensitivity;
+        /* 0x70F8 */ public float NGuiMouseSensitivity;
         [NMS(Index = 1195)]
-        /* 0x704C */ public float NGuiPadSensitivity;
+        /* 0x70FC */ public float NGuiPadSensitivity;
         [NMS(Index = 1370)]
-        /* 0x7050 */ public float NGuiPlacementAngleScrollSpeed;
+        /* 0x7100 */ public float NGuiPlacementAngleScrollSpeed;
         [NMS(Index = 1375)]
-        /* 0x7054 */ public float NGuiThumbnailModelRotationDegreesY;
+        /* 0x7104 */ public float NGuiThumbnailModelRotationDegreesY;
         [NMS(Index = 1376)]
-        /* 0x7058 */ public float NGuiThumbnailModelViewDistance;
+        /* 0x7108 */ public float NGuiThumbnailModelViewDistance;
         [NMS(Index = 880)]
-        /* 0x705C */ public float NotificationBackgroundGradientAlphaInShip;
+        /* 0x710C */ public float NotificationBackgroundGradientAlphaInShip;
         [NMS(Index = 879)]
-        /* 0x7060 */ public float NotificationBackgroundGradientEndOffsetPercentInShip;
+        /* 0x7110 */ public float NotificationBackgroundGradientEndOffsetPercentInShip;
         [NMS(Index = 913)]
-        /* 0x7064 */ public float NotificationBridgeReachDistance;
+        /* 0x7114 */ public float NotificationBridgeReachDistance;
         [NMS(Index = 887)]
-        /* 0x7068 */ public float NotificationBuildHintStartTime;
+        /* 0x7118 */ public float NotificationBuildHintStartTime;
         [NMS(Index = 892)]
-        /* 0x706C */ public float NotificationCantFireTime;
+        /* 0x711C */ public float NotificationCantFireTime;
         [NMS(Index = 893)]
-        /* 0x7070 */ public float NotificationDangerTime;
+        /* 0x7120 */ public float NotificationDangerTime;
         [NMS(Index = 918)]
-        /* 0x7074 */ public float NotificationDeviceIdleTime;
+        /* 0x7124 */ public float NotificationDeviceIdleTime;
         [NMS(Index = 914)]
-        /* 0x7078 */ public float NotificationDiscoveryIdleTime;
+        /* 0x7128 */ public float NotificationDiscoveryIdleTime;
         [NMS(Index = 911)]
-        /* 0x707C */ public float NotificationFinalMissionWait;
+        /* 0x712C */ public float NotificationFinalMissionWait;
         [NMS(Index = 909)]
-        /* 0x7080 */ public float NotificationGoToSpaceStationWait;
+        /* 0x7130 */ public float NotificationGoToSpaceStationWait;
         [NMS(Index = 339)]
-        /* 0x7084 */ public float NotificationHazardMinTimeAfterRecharge;
+        /* 0x7134 */ public float NotificationHazardMinTimeAfterRecharge;
         [NMS(Index = 884)]
-        /* 0x7088 */ public float NotificationHazardSafeThreshold;
+        /* 0x7138 */ public float NotificationHazardSafeThreshold;
         [NMS(Index = 885)]
-        /* 0x708C */ public float NotificationHazardTimer;
+        /* 0x713C */ public float NotificationHazardTimer;
         [NMS(Index = 915)]
-        /* 0x7090 */ public float NotificationInfoIdleTime;
+        /* 0x7140 */ public float NotificationInfoIdleTime;
         [NMS(Index = 886)]
-        /* 0x7094 */ public float NotificationInteractHintStartTime;
+        /* 0x7144 */ public float NotificationInteractHintStartTime;
         [NMS(Index = 888)]
-        /* 0x7098 */ public float NotificationJetpackTime;
+        /* 0x7148 */ public float NotificationJetpackTime;
         [NMS(Index = 897)]
-        /* 0x709C */ public float NotificationMaxPageHintTime;
+        /* 0x714C */ public float NotificationMaxPageHintTime;
         [NMS(Index = 896)]
-        /* 0x70A0 */ public float NotificationMessageCycleTime;
+        /* 0x7150 */ public float NotificationMessageCycleTime;
         [NMS(Index = 883)]
-        /* 0x70A4 */ public float NotificationMinVisibleTime;
+        /* 0x7154 */ public float NotificationMinVisibleTime;
         [NMS(Index = 919)]
-        /* 0x70A8 */ public float NotificationMissionHintTime;
+        /* 0x7158 */ public float NotificationMissionHintTime;
         [NMS(Index = 920)]
-        /* 0x70AC */ public float NotificationMissionHintTimeCritical;
+        /* 0x715C */ public float NotificationMissionHintTimeCritical;
         [NMS(Index = 921)]
-        /* 0x70B0 */ public float NotificationMissionHintTimeSecondary;
+        /* 0x7160 */ public float NotificationMissionHintTimeSecondary;
         [NMS(Index = 910)]
-        /* 0x70B4 */ public float NotificationMonolithMissionWait;
+        /* 0x7164 */ public float NotificationMonolithMissionWait;
         [NMS(Index = 916)]
-        /* 0x70B8 */ public float NotificationNewTechIdleTime;
+        /* 0x7168 */ public float NotificationNewTechIdleTime;
         [NMS(Index = 917)]
-        /* 0x70BC */ public float NotificationScanEventMissionIdleTime;
+        /* 0x716C */ public float NotificationScanEventMissionIdleTime;
         [NMS(Index = 894)]
-        /* 0x70C0 */ public float NotificationScanTime;
+        /* 0x7170 */ public float NotificationScanTime;
         [NMS(Index = 895)]
-        /* 0x70C4 */ public float NotificationScanTimeCutoff;
+        /* 0x7174 */ public float NotificationScanTimeCutoff;
         [NMS(Index = 889)]
-        /* 0x70C8 */ public float NotificationShieldTime;
+        /* 0x7178 */ public float NotificationShieldTime;
         [NMS(Index = 901)]
-        /* 0x70CC */ public float NotificationShipBoostMinTime;
+        /* 0x717C */ public float NotificationShipBoostMinTime;
         [NMS(Index = 902)]
-        /* 0x70D0 */ public float NotificationShipBoostReminderTime;
+        /* 0x7180 */ public float NotificationShipBoostReminderTime;
         [NMS(Index = 903)]
-        /* 0x70D4 */ public float NotificationShipBoostReminderTimeTutorial;
+        /* 0x7184 */ public float NotificationShipBoostReminderTimeTutorial;
         [NMS(Index = 890)]
-        /* 0x70D8 */ public float NotificationShipBoostTime;
+        /* 0x7188 */ public float NotificationShipBoostTime;
         [NMS(Index = 891)]
-        /* 0x70DC */ public float NotificationShipBoostTimeVR;
+        /* 0x718C */ public float NotificationShipBoostTimeVR;
         [NMS(Index = 898)]
-        /* 0x70E0 */ public float NotificationShipJumpMinTime;
+        /* 0x7190 */ public float NotificationShipJumpMinTime;
         [NMS(Index = 899)]
-        /* 0x70E4 */ public float NotificationShipJumpReminderTime;
+        /* 0x7194 */ public float NotificationShipJumpReminderTime;
         [NMS(Index = 900)]
-        /* 0x70E8 */ public float NotificationShipJumpReminderTutorial;
+        /* 0x7198 */ public float NotificationShipJumpReminderTutorial;
         [NMS(Index = 881)]
-        /* 0x70EC */ public int NotificationsResourceExtractHintCount;
+        /* 0x719C */ public int NotificationsResourceExtractHintCount;
         [NMS(Index = 882)]
-        /* 0x70F0 */ public float NotificationStaminaHintDistanceWalked;
+        /* 0x71A0 */ public float NotificationStaminaHintDistanceWalked;
         [NMS(Index = 907)]
-        /* 0x70F4 */ public float NotificationTimeBeforeHeridiumMarker;
+        /* 0x71A4 */ public float NotificationTimeBeforeHeridiumMarker;
         [NMS(Index = 908)]
-        /* 0x70F8 */ public float NotificationUrgentMessageTime;
+        /* 0x71A8 */ public float NotificationUrgentMessageTime;
         [NMS(Index = 912)]
-        /* 0x70FC */ public float NotificationWaypointReachDistance;
+        /* 0x71AC */ public float NotificationWaypointReachDistance;
         [NMS(Index = 801)]
-        /* 0x7100 */ public int NumDeathQuotes;
+        /* 0x71B0 */ public int NumDeathQuotes;
         [NMS(Index = 523)]
-        /* 0x7104 */ public float OnFootDamageDirectionIndicatorFadeRange;
+        /* 0x71B4 */ public float OnFootDamageDirectionIndicatorFadeRange;
         [NMS(Index = 522)]
-        /* 0x7108 */ public float OnFootDamageDirectionIndicatorRadius;
+        /* 0x71B8 */ public float OnFootDamageDirectionIndicatorRadius;
         [NMS(Index = 128)]
-        /* 0x710C */ public float OSDMessagePauseOffscreenAngle;
+        /* 0x71BC */ public float OSDMessagePauseOffscreenAngle;
         [NMS(Index = 328)]
-        /* 0x7110 */ public int OSDMessageQueueMax;
+        /* 0x71C0 */ public int OSDMessageQueueMax;
         [NMS(Index = 327)]
-        /* 0x7114 */ public int OSDMessageQueueMin;
+        /* 0x71C4 */ public int OSDMessageQueueMin;
         [NMS(Index = 326)]
-        /* 0x7118 */ public float OSDMessageQueueSpeedMultiplier;
+        /* 0x71C8 */ public float OSDMessageQueueSpeedMultiplier;
         [NMS(Index = 1091)]
-        /* 0x711C */ public float PadCursorAcceleration;
+        /* 0x71CC */ public float PadCursorAcceleration;
         [NMS(Index = 1092)]
-        /* 0x7120 */ public float PadCursorMaxSpeedModifier;
+        /* 0x71D0 */ public float PadCursorMaxSpeedModifier;
         [NMS(Index = 81)]
-        /* 0x7124 */ public float PadCursorUICurveStrength;
+        /* 0x71D4 */ public float PadCursorUICurveStrength;
         [NMS(Index = 1440)]
-        /* 0x7128 */ public float PadRotateCameraSensitivity;
+        /* 0x71D8 */ public float PadRotateCameraSensitivity;
         [NMS(Index = 496)]
-        /* 0x712C */ public float PageTurnTime;
+        /* 0x71DC */ public float PageTurnTime;
         [NMS(Index = 96)]
-        /* 0x7130 */ public float ParagraphAutoScrollSpeed;
+        /* 0x71E0 */ public float ParagraphAutoScrollSpeed;
         [NMS(Index = 957)]
-        /* 0x7134 */ public float PauseMenuHoldTime;
+        /* 0x71E4 */ public float PauseMenuHoldTime;
         [NMS(Index = 720)]
-        /* 0x7138 */ public float PetHoverIconSize;
+        /* 0x71E8 */ public float PetHoverIconSize;
         [NMS(Index = 150)]
-        /* 0x713C */ public float PetHUDMarkerExtraFollowInfoDistance;
+        /* 0x71EC */ public float PetHUDMarkerExtraFollowInfoDistance;
         [NMS(Index = 151)]
-        /* 0x7140 */ public float PetHUDMarkerHideDistance;
+        /* 0x71F0 */ public float PetHUDMarkerHideDistance;
         [NMS(Index = 152)]
-        /* 0x7144 */ public float PetHUDMarkerHideDistanceShort;
+        /* 0x71F4 */ public float PetHUDMarkerHideDistanceShort;
         [NMS(Index = 153)]
-        /* 0x7148 */ public float PetHUDMarkerOffset;
+        /* 0x71F8 */ public float PetHUDMarkerOffset;
         [NMS(Index = 721)]
-        /* 0x714C */ public float PetIconSize;
+        /* 0x71FC */ public float PetIconSize;
         [NMS(Index = 154)]
-        /* 0x7150 */ public float PetMoodMarkerOffset;
+        /* 0x7200 */ public float PetMoodMarkerOffset;
         [NMS(Index = 149)]
-        /* 0x7154 */ public float PetSlotUnlockBounceTime;
+        /* 0x7204 */ public float PetSlotUnlockBounceTime;
         [NMS(Index = 624)]
-        /* 0x7158 */ public float PhotoModeTimeofDayChange;
+        /* 0x7208 */ public float PhotoModeTimeofDayChange;
         [NMS(Index = 623)]
-        /* 0x715C */ public float PhotoModeValueAlpha;
+        /* 0x720C */ public float PhotoModeValueAlpha;
         [NMS(Index = 653)]
-        /* 0x7160 */ public float PirateAttackIndicatorRadius;
+        /* 0x7210 */ public float PirateAttackIndicatorRadius;
         [NMS(Index = 652)]
-        /* 0x7164 */ public float PirateAttackIndicatorWidth;
+        /* 0x7214 */ public float PirateAttackIndicatorWidth;
         [NMS(Index = 654)]
-        /* 0x7168 */ public float PirateAttackProbeDisplayFinishFactor;
+        /* 0x7218 */ public float PirateAttackProbeDisplayFinishFactor;
         [NMS(Index = 651)]
-        /* 0x716C */ public float PirateCountdownTime;
+        /* 0x721C */ public float PirateCountdownTime;
         [NMS(Index = 636)]
-        /* 0x7170 */ public float PirateFreighterSummonAtOffset;
+        /* 0x7220 */ public float PirateFreighterSummonAtOffset;
         [NMS(Index = 634)]
-        /* 0x7174 */ public float PirateFreighterSummonOffset;
+        /* 0x7224 */ public float PirateFreighterSummonOffset;
         [NMS(Index = 635)]
-        /* 0x7178 */ public float PirateFreighterSummonOffsetPulse;
+        /* 0x7228 */ public float PirateFreighterSummonOffsetPulse;
         [NMS(Index = 124)]
-        /* 0x717C */ public float PlacedMarkerFadeTime;
+        /* 0x722C */ public float PlacedMarkerFadeTime;
         [NMS(Index = 116)]
-        /* 0x7180 */ public float PlanetDataExtraRadius;
+        /* 0x7230 */ public float PlanetDataExtraRadius;
         [NMS(Index = 962)]
-        /* 0x7184 */ public float PlanetLabelAngle;
+        /* 0x7234 */ public float PlanetLabelAngle;
         [NMS(Index = 961)]
-        /* 0x7188 */ public float PlanetLabelTime;
+        /* 0x7238 */ public float PlanetLabelTime;
         [NMS(Index = 1210)]
-        /* 0x718C */ public float PlanetPoleEastWestDistanceFromPlayer;
+        /* 0x723C */ public float PlanetPoleEastWestDistanceFromPlayer;
         [NMS(Index = 1209)]
-        /* 0x7190 */ public float PlanetPoleMaxDotProduct;
+        /* 0x7240 */ public float PlanetPoleMaxDotProduct;
         [NMS(Index = 494)]
-        /* 0x7194 */ public float PlanetRaidMarkerOffset;
+        /* 0x7244 */ public float PlanetRaidMarkerOffset;
         [NMS(Index = 666)]
-        /* 0x7198 */ public float PlanetScanDelayTime;
+        /* 0x7248 */ public float PlanetScanDelayTime;
         [NMS(Index = 1116)]
-        /* 0x719C */ public float PopupActivateTime;
+        /* 0x724C */ public float PopupActivateTime;
         [NMS(Index = 1117)]
-        /* 0x71A0 */ public float PopupDeactivateTime;
+        /* 0x7250 */ public float PopupDeactivateTime;
         [NMS(Index = 1115)]
-        /* 0x71A4 */ public float PopupDebounceTime;
+        /* 0x7254 */ public float PopupDebounceTime;
         [NMS(Index = 1104)]
-        /* 0x71A8 */ public float PopupSlotWidthOffset;
+        /* 0x7258 */ public float PopupSlotWidthOffset;
         [NMS(Index = 72)]
-        /* 0x71AC */ public float PopupTitleGradientFactor;
+        /* 0x725C */ public float PopupTitleGradientFactor;
         [NMS(Index = 329)]
-        /* 0x71B0 */ public float PopupValueSectionBaseHeight;
+        /* 0x7260 */ public float PopupValueSectionBaseHeight;
         [NMS(Index = 330)]
-        /* 0x71B4 */ public float PopupValueSectionHeight;
+        /* 0x7264 */ public float PopupValueSectionHeight;
         [NMS(Index = 1102)]
-        /* 0x71B8 */ public float PopupXClampOffset;
+        /* 0x7268 */ public float PopupXClampOffset;
         [NMS(Index = 1103)]
-        /* 0x71BC */ public float PopupXClampOffsetRightAligned;
+        /* 0x726C */ public float PopupXClampOffsetRightAligned;
         [NMS(Index = 180)]
-        /* 0x71C0 */ public float ProjectorGrabBorderPercent;
+        /* 0x7270 */ public float ProjectorGrabBorderPercent;
         [NMS(Index = 179)]
-        /* 0x71C4 */ public float ProjectorGrabDistanceBias;
+        /* 0x7274 */ public float ProjectorGrabDistanceBias;
         [NMS(Index = 176)]
-        /* 0x71C8 */ public float ProjectorGrabResetTime;
+        /* 0x7278 */ public float ProjectorGrabResetTime;
         [NMS(Index = 174)]
-        /* 0x71CC */ public float ProjectorScale;
+        /* 0x727C */ public float ProjectorScale;
         [NMS(Index = 220)]
-        /* 0x71D0 */ public float QuickMenuAlpha;
+        /* 0x7280 */ public float QuickMenuAlpha;
         [NMS(Index = 129)]
-        /* 0x71D4 */ public float QuickMenuCentrePos;
+        /* 0x7284 */ public float QuickMenuCentrePos;
         [NMS(Index = 131)]
-        /* 0x71D8 */ public float QuickMenuCentreSideOffset;
+        /* 0x7288 */ public float QuickMenuCentreSideOffset;
         [NMS(Index = 564)]
-        /* 0x71DC */ public float QuickMenuCloseTime;
+        /* 0x728C */ public float QuickMenuCloseTime;
         [NMS(Index = 219)]
-        /* 0x71E0 */ public float QuickMenuCursorScale;
+        /* 0x7290 */ public float QuickMenuCursorScale;
         [NMS(Index = 565)]
-        /* 0x71E4 */ public float QuickMenuErrorTime;
+        /* 0x7294 */ public float QuickMenuErrorTime;
         [NMS(Index = 259)]
-        /* 0x71E8 */ public float QuickMenuHighlightRate;
+        /* 0x7298 */ public float QuickMenuHighlightRate;
         [NMS(Index = 260)]
-        /* 0x71EC */ public float QuickMenuHoldNavTime;
+        /* 0x729C */ public float QuickMenuHoldNavTime;
         [NMS(Index = 255)]
-        /* 0x71F0 */ public float QuickMenuInteractAdjustX;
+        /* 0x72A0 */ public float QuickMenuInteractAdjustX;
         [NMS(Index = 256)]
-        /* 0x71F4 */ public float QuickMenuInteractAdjustY;
+        /* 0x72A4 */ public float QuickMenuInteractAdjustY;
         [NMS(Index = 258)]
-        /* 0x71F8 */ public int QuickMenuScreenHeight;
+        /* 0x72A8 */ public int QuickMenuScreenHeight;
         [NMS(Index = 257)]
-        /* 0x71FC */ public int QuickMenuScreenWidth;
+        /* 0x72AC */ public int QuickMenuScreenWidth;
         [NMS(Index = 130)]
-        /* 0x7200 */ public float QuickMenuSideOffset;
+        /* 0x72B0 */ public float QuickMenuSideOffset;
         [NMS(Index = 251)]
-        /* 0x7204 */ public float QuickMenuSwipeHeightMax;
+        /* 0x72B4 */ public float QuickMenuSwipeHeightMax;
         [NMS(Index = 250)]
-        /* 0x7208 */ public float QuickMenuSwipeHeightMin;
+        /* 0x72B8 */ public float QuickMenuSwipeHeightMin;
         [NMS(Index = 1171)]
-        /* 0x720C */ public float RadialMenuInnerRadius;
+        /* 0x72BC */ public float RadialMenuInnerRadius;
         [NMS(Index = 1172)]
-        /* 0x7210 */ public float RadialMenuInnerRadiusCursor;
+        /* 0x72C0 */ public float RadialMenuInnerRadiusCursor;
         [NMS(Index = 1173)]
-        /* 0x7214 */ public float RadialMenuWedgeOffset;
+        /* 0x72C4 */ public float RadialMenuWedgeOffset;
         [NMS(Index = 483)]
-        /* 0x7218 */ public float RefinerAutoCloseTime;
+        /* 0x72C8 */ public float RefinerAutoCloseTime;
         [NMS(Index = 471)]
-        /* 0x721C */ public float RefinerBeginDialInnerRadius;
+        /* 0x72CC */ public float RefinerBeginDialInnerRadius;
         [NMS(Index = 470)]
-        /* 0x7220 */ public float RefinerPadStartDecayTime;
+        /* 0x72D0 */ public float RefinerPadStartDecayTime;
         [NMS(Index = 469)]
-        /* 0x7224 */ public float RefinerPadStartTime;
+        /* 0x72D4 */ public float RefinerPadStartTime;
         [NMS(Index = 472)]
-        /* 0x7228 */ public float RefinerProgressDialInnerRadius;
+        /* 0x72D8 */ public float RefinerProgressDialInnerRadius;
         [NMS(Index = 452)]
-        /* 0x722C */ public float RepairTechLabelOffset;
+        /* 0x72DC */ public float RepairTechLabelOffset;
         [NMS(Index = 442)]
-        /* 0x7230 */ public float RepairTechRepairedMessageTime;
+        /* 0x72E0 */ public float RepairTechRepairedMessageTime;
         [NMS(Index = 440)]
-        /* 0x7234 */ public float RepairTechRepairedWaitTime1;
+        /* 0x72E4 */ public float RepairTechRepairedWaitTime1;
         [NMS(Index = 441)]
-        /* 0x7238 */ public float RepairTechRepairedWaitTime2;
+        /* 0x72E8 */ public float RepairTechRepairedWaitTime2;
         [NMS(Index = 1403)]
-        /* 0x723C */ public float ReportBaseFlashDelay;
+        /* 0x72EC */ public float ReportBaseFlashDelay;
         [NMS(Index = 1402)]
-        /* 0x7240 */ public float ReportBaseFlashIntensity;
+        /* 0x72F0 */ public float ReportBaseFlashIntensity;
         [NMS(Index = 1401)]
-        /* 0x7244 */ public float ReportBaseFlashTime;
+        /* 0x72F4 */ public float ReportBaseFlashTime;
         [NMS(Index = 1404)]
-        /* 0x7248 */ public float ReportCameraSpeed;
+        /* 0x72F8 */ public float ReportCameraSpeed;
         [NMS(Index = 789)]
-        /* 0x724C */ public float ScanEventArrowOffsetMultiplier;
+        /* 0x72FC */ public float ScanEventArrowOffsetMultiplier;
         [NMS(Index = 791)]
-        /* 0x7250 */ public float ScanEventArrowOffsetMultiplierFresh;
+        /* 0x7300 */ public float ScanEventArrowOffsetMultiplierFresh;
         [NMS(Index = 792)]
-        /* 0x7254 */ public float ScanEventArrowOffsetMultiplierLerpTime;
+        /* 0x7304 */ public float ScanEventArrowOffsetMultiplierLerpTime;
         [NMS(Index = 790)]
-        /* 0x7258 */ public float ScanEventArrowOffsetMultiplierOneEvent;
+        /* 0x7308 */ public float ScanEventArrowOffsetMultiplierOneEvent;
         [NMS(Index = 788)]
-        /* 0x725C */ public float ScanEventArrowPlayerFadeDistance;
+        /* 0x730C */ public float ScanEventArrowPlayerFadeDistance;
         [NMS(Index = 787)]
-        /* 0x7260 */ public float ScanEventArrowPlayerFadeRange;
+        /* 0x7310 */ public float ScanEventArrowPlayerFadeRange;
         [NMS(Index = 793)]
-        /* 0x7264 */ public float ScanEventArrowSecondaryAlpha;
+        /* 0x7314 */ public float ScanEventArrowSecondaryAlpha;
         [NMS(Index = 786)]
-        /* 0x7268 */ public float ScanEventArrowShipFadeDistance;
+        /* 0x7318 */ public float ScanEventArrowShipFadeDistance;
         [NMS(Index = 785)]
-        /* 0x726C */ public float ScanEventArrowShipFadeRange;
+        /* 0x731C */ public float ScanEventArrowShipFadeRange;
         [NMS(Index = 794)]
-        /* 0x7270 */ public GcAudioWwiseEvents ScanEventIconAudio;
+        /* 0x7320 */ public GcAudioWwiseEvents ScanEventIconAudio;
         [NMS(Index = 359)]
-        /* 0x7274 */ public float ScannableIconMergeAngle;
+        /* 0x7324 */ public float ScannableIconMergeAngle;
         [NMS(Index = 1075)]
-        /* 0x7278 */ public float ScanTime;
+        /* 0x7328 */ public float ScanTime;
         [NMS(Index = 105)]
-        /* 0x727C */ public float SeasonalRingChangeTime;
+        /* 0x732C */ public float SeasonalRingChangeTime;
         [NMS(Index = 103)]
-        /* 0x7280 */ public float SeasonalRingMultiplier;
+        /* 0x7330 */ public float SeasonalRingMultiplier;
         [NMS(Index = 104)]
-        /* 0x7284 */ public float SeasonalRingPulseTime;
+        /* 0x7334 */ public float SeasonalRingPulseTime;
         [NMS(Index = 36)]
-        /* 0x7288 */ public float SeasonEndAutoHighlightDuration;
+        /* 0x7338 */ public float SeasonEndAutoHighlightDuration;
         [NMS(Index = 37)]
-        /* 0x728C */ public float SeasonEndAutoHighlightDurationMilestone;
+        /* 0x733C */ public float SeasonEndAutoHighlightDurationMilestone;
         [NMS(Index = 35)]
-        /* 0x7290 */ public GcAudioWwiseEvents SeasonEndAutoHighlightSFX;
+        /* 0x7340 */ public GcAudioWwiseEvents SeasonEndAutoHighlightSFX;
         [NMS(Index = 34)]
-        /* 0x7294 */ public float SeasonEndRewardsMaxScrollRate;
+        /* 0x7344 */ public float SeasonEndRewardsMaxScrollRate;
         [NMS(Index = 33)]
-        /* 0x7298 */ public float SeasonEndRewardsPageOpenDelayTime;
+        /* 0x7348 */ public float SeasonEndRewardsPageOpenDelayTime;
         [NMS(Index = 101)]
-        /* 0x729C */ public int SeasonFinalStageIndex;
+        /* 0x734C */ public int SeasonFinalStageIndex;
         [NMS(Index = 877)]
-        /* 0x72A0 */ public float SeasonMessageDelayTime;
+        /* 0x7350 */ public float SeasonMessageDelayTime;
         [NMS(Index = 94)]
-        /* 0x72A4 */ public float SentinelsDisabledHUDMessageTime;
+        /* 0x7354 */ public float SentinelsDisabledHUDMessageTime;
         [NMS(Index = 1418)]
-        /* 0x72A8 */ public float SettlementStatInnerRadius;
+        /* 0x7358 */ public float SettlementStatInnerRadius;
         [NMS(Index = 1419)]
-        /* 0x72AC */ public float SettlementStatOuterRadius;
+        /* 0x735C */ public float SettlementStatOuterRadius;
         [NMS(Index = 1020)]
-        /* 0x72B0 */ public float ShieldHazardPulseRate;
+        /* 0x7360 */ public float ShieldHazardPulseRate;
         [NMS(Index = 1022)]
-        /* 0x72B4 */ public float ShieldHazardPulseThreshold;
+        /* 0x7364 */ public float ShieldHazardPulseThreshold;
         [NMS(Index = 1019)]
-        /* 0x72B8 */ public float ShieldPulseTime;
+        /* 0x7368 */ public float ShieldPulseTime;
         [NMS(Index = 1018)]
-        /* 0x72BC */ public float ShieldSpringTime;
+        /* 0x736C */ public float ShieldSpringTime;
         [NMS(Index = 2)]
-        /* 0x72C0 */ public float ShipBuilderBarTime;
+        /* 0x7370 */ public float ShipBuilderBarTime;
         [NMS(Index = 9)]
-        /* 0x72C4 */ public float ShipBuilderEndCircleRadius;
+        /* 0x7374 */ public float ShipBuilderEndCircleRadius;
         [NMS(Index = 13)]
-        /* 0x72C8 */ public float ShipBuilderLineLengthFadeMax;
+        /* 0x7378 */ public float ShipBuilderLineLengthFadeMax;
         [NMS(Index = 12)]
-        /* 0x72CC */ public float ShipBuilderLineLengthFadeMin;
+        /* 0x737C */ public float ShipBuilderLineLengthFadeMin;
         [NMS(Index = 11)]
-        /* 0x72D0 */ public float ShipBuilderLineMinFade;
+        /* 0x7380 */ public float ShipBuilderLineMinFade;
         [NMS(Index = 10)]
-        /* 0x72D4 */ public float ShipBuilderLineWidth;
+        /* 0x7384 */ public float ShipBuilderLineWidth;
         [NMS(Index = 7)]
-        /* 0x72D8 */ public float ShipBuilderSlotDropLength;
+        /* 0x7388 */ public float ShipBuilderSlotDropLength;
         [NMS(Index = 3)]
-        /* 0x72DC */ public float ShipBuilderSlotLineDefaultWidthFactor;
+        /* 0x738C */ public float ShipBuilderSlotLineDefaultWidthFactor;
         [NMS(Index = 5)]
-        /* 0x72E0 */ public float ShipBuilderSlotLineMaxFactor;
+        /* 0x7390 */ public float ShipBuilderSlotLineMaxFactor;
         [NMS(Index = 4)]
-        /* 0x72E4 */ public float ShipBuilderSlotLineMinFactor;
+        /* 0x7394 */ public float ShipBuilderSlotLineMinFactor;
         [NMS(Index = 6)]
-        /* 0x72E8 */ public float ShipBuilderSlotStartOffset;
+        /* 0x7398 */ public float ShipBuilderSlotStartOffset;
         [NMS(Index = 8)]
-        /* 0x72EC */ public float ShipBuilderStartCircleRadius;
+        /* 0x739C */ public float ShipBuilderStartCircleRadius;
         [NMS(Index = 521)]
-        /* 0x72F0 */ public float ShipDamageDirectionIndicatorFadeRange;
+        /* 0x73A0 */ public float ShipDamageDirectionIndicatorFadeRange;
         [NMS(Index = 520)]
-        /* 0x72F4 */ public float ShipDamageDirectionIndicatorRadius;
+        /* 0x73A4 */ public float ShipDamageDirectionIndicatorRadius;
         [NMS(Index = 783)]
-        /* 0x72F8 */ public float ShipDesatDamper;
+        /* 0x73A8 */ public float ShipDesatDamper;
         [NMS(Index = 782)]
-        /* 0x72FC */ public float ShipFullscreenDamper;
+        /* 0x73AC */ public float ShipFullscreenDamper;
         [NMS(Index = 781)]
-        /* 0x7300 */ public float ShipFullscreenDamperMin;
+        /* 0x73B0 */ public float ShipFullscreenDamperMin;
         [NMS(Index = 673)]
-        /* 0x7304 */ public float ShipHeadsUpDisplayDistance;
+        /* 0x73B4 */ public float ShipHeadsUpDisplayDistance;
         [NMS(Index = 674)]
-        /* 0x7308 */ public float ShipHeadsUpLineFadeTime;
+        /* 0x73B8 */ public float ShipHeadsUpLineFadeTime;
         [NMS(Index = 304)]
-        /* 0x730C */ public float ShipHologramInWorldUIHeightAdjust;
+        /* 0x73BC */ public float ShipHologramInWorldUIHeightAdjust;
         [NMS(Index = 305)]
-        /* 0x7310 */ public float ShipHologramInWorldUIHeightAdjustV2;
+        /* 0x73C0 */ public float ShipHologramInWorldUIHeightAdjustV2;
         [NMS(Index = 1000)]
-        /* 0x7314 */ public float ShipHUDHitPointSize;
+        /* 0x73C4 */ public float ShipHUDHitPointSize;
         [NMS(Index = 999)]
-        /* 0x7318 */ public float ShipHUDHitPointTime;
+        /* 0x73C8 */ public float ShipHUDHitPointTime;
         [NMS(Index = 145)]
-        /* 0x731C */ public float ShipHUDMarkerHideDistance;
+        /* 0x73CC */ public float ShipHUDMarkerHideDistance;
         [NMS(Index = 146)]
-        /* 0x7320 */ public float ShipHUDMarkerOffset;
+        /* 0x73D0 */ public float ShipHUDMarkerOffset;
         [NMS(Index = 984)]
-        /* 0x7324 */ public float ShipHUDMaxOffscreenTargetDist;
+        /* 0x73D4 */ public float ShipHUDMaxOffscreenTargetDist;
         [NMS(Index = 981)]
-        /* 0x7328 */ public float ShipHUDMissileLockSizeMax;
+        /* 0x73D8 */ public float ShipHUDMissileLockSizeMax;
         [NMS(Index = 980)]
-        /* 0x732C */ public float ShipHUDMissileLockSizeMin;
+        /* 0x73DC */ public float ShipHUDMissileLockSizeMin;
         [NMS(Index = 983)]
-        /* 0x7330 */ public float ShipHUDMissileLockSpringFast;
+        /* 0x73E0 */ public float ShipHUDMissileLockSpringFast;
         [NMS(Index = 982)]
-        /* 0x7334 */ public float ShipHUDMissileLockSpringSlow;
+        /* 0x73E4 */ public float ShipHUDMissileLockSpringSlow;
         [NMS(Index = 987)]
-        /* 0x7338 */ public float ShipHUDTargetAlpha;
+        /* 0x73E8 */ public float ShipHUDTargetAlpha;
         [NMS(Index = 988)]
-        /* 0x733C */ public float ShipHUDTargetArrowLength;
+        /* 0x73EC */ public float ShipHUDTargetArrowLength;
         [NMS(Index = 992)]
-        /* 0x7340 */ public float ShipHUDTargetArrowsRotationRate;
+        /* 0x73F0 */ public float ShipHUDTargetArrowsRotationRate;
         [NMS(Index = 989)]
-        /* 0x7344 */ public float ShipHUDTargetMinDist;
+        /* 0x73F4 */ public float ShipHUDTargetMinDist;
         [NMS(Index = 985)]
-        /* 0x7348 */ public float ShipHUDTargetRadius;
+        /* 0x73F8 */ public float ShipHUDTargetRadius;
         [NMS(Index = 990)]
-        /* 0x734C */ public float ShipHUDTargetRange;
+        /* 0x73FC */ public float ShipHUDTargetRange;
         [NMS(Index = 991)]
-        /* 0x7350 */ public float ShipHUDTargetScale;
+        /* 0x7400 */ public float ShipHUDTargetScale;
         [NMS(Index = 986)]
-        /* 0x7354 */ public float ShipHUDTargetTriangleRadius;
+        /* 0x7404 */ public float ShipHUDTargetTriangleRadius;
         [NMS(Index = 506)]
-        /* 0x7358 */ public float ShipOverheatSwitchMessageTime;
+        /* 0x7408 */ public float ShipOverheatSwitchMessageTime;
         [NMS(Index = 505)]
-        /* 0x735C */ public float ShipOverheatSwitchMessageWait;
+        /* 0x740C */ public float ShipOverheatSwitchMessageWait;
         [NMS(Index = 1411)]
-        /* 0x7360 */ public float ShipScreenTexScale;
+        /* 0x7410 */ public float ShipScreenTexScale;
         [NMS(Index = 242)]
-        /* 0x7364 */ public float ShipSideScreenHeight;
+        /* 0x7414 */ public float ShipSideScreenHeight;
         [NMS(Index = 306)]
-        /* 0x7368 */ public float ShopInteractionInWorldForcedOffset;
+        /* 0x7418 */ public float ShopInteractionInWorldForcedOffset;
         [NMS(Index = 307)]
-        /* 0x736C */ public float ShopInteractionInWorldForcedOffsetV2;
+        /* 0x741C */ public float ShopInteractionInWorldForcedOffsetV2;
         [NMS(Index = 112)]
-        /* 0x7370 */ public int ShowDaysIfLessThan;
+        /* 0x7420 */ public int ShowDaysIfLessThan;
         [NMS(Index = 111)]
-        /* 0x7374 */ public int ShowHoursIfLessThan;
+        /* 0x7424 */ public int ShowHoursIfLessThan;
         [NMS(Index = 113)]
-        /* 0x7378 */ public int ShowWeeksIfLessThan;
+        /* 0x7428 */ public int ShowWeeksIfLessThan;
         [NMS(Index = 719)]
-        /* 0x737C */ public float SmallSpaceIconSize;
+        /* 0x742C */ public float SmallSpaceIconSize;
         [NMS(Index = 244)]
-        /* 0x7380 */ public float SolidPointerLengthScale;
+        /* 0x7430 */ public float SolidPointerLengthScale;
         [NMS(Index = 245)]
-        /* 0x7384 */ public float SolidPointerMaxLength;
+        /* 0x7434 */ public float SolidPointerMaxLength;
         [NMS(Index = 243)]
-        /* 0x7388 */ public float SolidPointerScale;
+        /* 0x7438 */ public float SolidPointerScale;
         [NMS(Index = 1244)]
-        /* 0x738C */ public float SpaceMapActionScale;
+        /* 0x743C */ public float SpaceMapActionScale;
         [NMS(Index = 1240)]
-        /* 0x7390 */ public float SpaceMapAnomalyScale;
+        /* 0x7440 */ public float SpaceMapAnomalyScale;
         [NMS(Index = 1230)]
-        /* 0x7394 */ public float SpaceMapAspectRatio;
+        /* 0x7444 */ public float SpaceMapAspectRatio;
         [NMS(Index = 1256)]
-        /* 0x7398 */ public float SpaceMapCamAngle;
+        /* 0x7448 */ public float SpaceMapCamAngle;
         [NMS(Index = 1257)]
-        /* 0x739C */ public float SpaceMapCamDistance;
+        /* 0x744C */ public float SpaceMapCamDistance;
         [NMS(Index = 1255)]
-        /* 0x73A0 */ public float SpaceMapCamHeight;
+        /* 0x7450 */ public float SpaceMapCamHeight;
         [NMS(Index = 542)]
-        /* 0x73A4 */ public float SpaceMapCockpitAngle;
+        /* 0x7454 */ public float SpaceMapCockpitAngle;
         [NMS(Index = 533)]
-        /* 0x73A8 */ public float SpaceMapCockpitScale;
+        /* 0x7458 */ public float SpaceMapCockpitScale;
         [NMS(Index = 540)]
-        /* 0x73AC */ public float SpaceMapCockpitScaleAdjustAlien;
+        /* 0x745C */ public float SpaceMapCockpitScaleAdjustAlien;
         [NMS(Index = 534)]
-        /* 0x73B0 */ public float SpaceMapCockpitScaleAdjustDropShip;
+        /* 0x7460 */ public float SpaceMapCockpitScaleAdjustDropShip;
         [NMS(Index = 535)]
-        /* 0x73B4 */ public float SpaceMapCockpitScaleAdjustFighter;
+        /* 0x7464 */ public float SpaceMapCockpitScaleAdjustFighter;
         [NMS(Index = 541)]
-        /* 0x73B8 */ public float SpaceMapCockpitScaleAdjustRobot;
+        /* 0x7468 */ public float SpaceMapCockpitScaleAdjustRobot;
         [NMS(Index = 538)]
-        /* 0x73BC */ public float SpaceMapCockpitScaleAdjustRoyal;
+        /* 0x746C */ public float SpaceMapCockpitScaleAdjustRoyal;
         [NMS(Index = 539)]
-        /* 0x73C0 */ public float SpaceMapCockpitScaleAdjustSail;
+        /* 0x7470 */ public float SpaceMapCockpitScaleAdjustSail;
         [NMS(Index = 536)]
-        /* 0x73C4 */ public float SpaceMapCockpitScaleAdjustScientific;
+        /* 0x7474 */ public float SpaceMapCockpitScaleAdjustScientific;
         [NMS(Index = 537)]
-        /* 0x73C8 */ public float SpaceMapCockpitScaleAdjustShuttle;
+        /* 0x7478 */ public float SpaceMapCockpitScaleAdjustShuttle;
         [NMS(Index = 1249)]
-        /* 0x73CC */ public float SpaceMapDistance;
+        /* 0x747C */ public float SpaceMapDistance;
         [NMS(Index = 1232)]
-        /* 0x73D0 */ public float SpaceMapDistanceLogScaler;
+        /* 0x7480 */ public float SpaceMapDistanceLogScaler;
         [NMS(Index = 1251)]
-        /* 0x73D4 */ public float SpaceMapDistanceMultiplier;
+        /* 0x7484 */ public float SpaceMapDistanceMultiplier;
         [NMS(Index = 1231)]
-        /* 0x73D8 */ public float SpaceMapDistanceScale;
+        /* 0x7488 */ public float SpaceMapDistanceScale;
         [NMS(Index = 1254)]
-        /* 0x73DC */ public float SpaceMapFadeAngleMax;
+        /* 0x748C */ public float SpaceMapFadeAngleMax;
         [NMS(Index = 1253)]
-        /* 0x73E0 */ public float SpaceMapFadeAngleMin;
+        /* 0x7490 */ public float SpaceMapFadeAngleMin;
         [NMS(Index = 1229)]
-        /* 0x73E4 */ public float SpaceMapFoV;
+        /* 0x7494 */ public float SpaceMapFoV;
         [NMS(Index = 1238)]
-        /* 0x73E8 */ public float SpaceMapFreighterScale;
+        /* 0x7498 */ public float SpaceMapFreighterScale;
         [NMS(Index = 1252)]
-        /* 0x73EC */ public float SpaceMapHorizonThickness;
+        /* 0x749C */ public float SpaceMapHorizonThickness;
         [NMS(Index = 1259)]
-        /* 0x73F0 */ public float SpaceMapLightPitch;
+        /* 0x74A0 */ public float SpaceMapLightPitch;
         [NMS(Index = 1260)]
-        /* 0x73F4 */ public float SpaceMapLightYaw;
+        /* 0x74A4 */ public float SpaceMapLightYaw;
         [NMS(Index = 1213)]
-        /* 0x73F8 */ public float SpaceMapLineBaseFade;
+        /* 0x74A8 */ public float SpaceMapLineBaseFade;
         [NMS(Index = 1212)]
-        /* 0x73FC */ public float SpaceMapLineBaseScale;
+        /* 0x74AC */ public float SpaceMapLineBaseScale;
         [NMS(Index = 1211)]
-        /* 0x7400 */ public float SpaceMapLineWidth;
+        /* 0x74B0 */ public float SpaceMapLineWidth;
         [NMS(Index = 1248)]
-        /* 0x7404 */ public float SpaceMapMarkerScale;
+        /* 0x74B4 */ public float SpaceMapMarkerScale;
         [NMS(Index = 1250)]
-        /* 0x7408 */ public float SpaceMapMaxTraderDistance;
+        /* 0x74B8 */ public float SpaceMapMaxTraderDistance;
         [NMS(Index = 1243)]
-        /* 0x740C */ public float SpaceMapMoonScale;
+        /* 0x74BC */ public float SpaceMapMoonScale;
         [NMS(Index = 1237)]
-        /* 0x7410 */ public float SpaceMapObjectScale;
+        /* 0x74C0 */ public float SpaceMapObjectScale;
         [NMS(Index = 1247)]
-        /* 0x7414 */ public float SpaceMapPirateFreighterScale;
+        /* 0x74C4 */ public float SpaceMapPirateFreighterScale;
         [NMS(Index = 1246)]
-        /* 0x7418 */ public float SpaceMapPirateFrigateScale;
+        /* 0x74C8 */ public float SpaceMapPirateFrigateScale;
         [NMS(Index = 1242)]
-        /* 0x741C */ public float SpaceMapPlanetLineOffset;
+        /* 0x74CC */ public float SpaceMapPlanetLineOffset;
         [NMS(Index = 1241)]
-        /* 0x7420 */ public float SpaceMapPlanetScale;
+        /* 0x74D0 */ public float SpaceMapPlanetScale;
         [NMS(Index = 1234)]
-        /* 0x7424 */ public float SpaceMapScaleMin;
+        /* 0x74D4 */ public float SpaceMapScaleMin;
         [NMS(Index = 1236)]
-        /* 0x7428 */ public float SpaceMapScaleRangeMax;
+        /* 0x74D8 */ public float SpaceMapScaleRangeMax;
         [NMS(Index = 1235)]
-        /* 0x742C */ public float SpaceMapScaleRangeMin;
+        /* 0x74DC */ public float SpaceMapScaleRangeMin;
         [NMS(Index = 1214)]
-        /* 0x7430 */ public float SpaceMapShipCombineDistance;
+        /* 0x74E0 */ public float SpaceMapShipCombineDistance;
         [NMS(Index = 1245)]
-        /* 0x7434 */ public float SpaceMapShipScale;
+        /* 0x74E4 */ public float SpaceMapShipScale;
         [NMS(Index = 1258)]
-        /* 0x7438 */ public float SpaceMapShipScaleMin;
+        /* 0x74E8 */ public float SpaceMapShipScaleMin;
         [NMS(Index = 1239)]
-        /* 0x743C */ public float SpaceMapStationScale;
+        /* 0x74EC */ public float SpaceMapStationScale;
         [NMS(Index = 717)]
-        /* 0x7440 */ public float SpaceMarkersBattleOffset;
+        /* 0x74F0 */ public float SpaceMarkersBattleOffset;
         [NMS(Index = 716)]
-        /* 0x7444 */ public float SpaceMarkersOffset;
+        /* 0x74F4 */ public float SpaceMarkersOffset;
         [NMS(Index = 119)]
-        /* 0x7448 */ public float StackSizeChangeMaxRate;
+        /* 0x74F8 */ public float StackSizeChangeMaxRate;
         [NMS(Index = 118)]
-        /* 0x744C */ public float StackSizeChangeMinRate;
+        /* 0x74FC */ public float StackSizeChangeMinRate;
         [NMS(Index = 117)]
-        /* 0x7450 */ public float StackSizeRateChangeRate;
+        /* 0x7500 */ public float StackSizeRateChangeRate;
         [NMS(Index = 109)]
-        /* 0x7454 */ public float StageStingDisplayTime;
+        /* 0x7504 */ public float StageStingDisplayTime;
         [NMS(Index = 514)]
-        /* 0x7458 */ public float StandingRewardOSDTime;
+        /* 0x7508 */ public float StandingRewardOSDTime;
         [NMS(Index = 876)]
-        /* 0x745C */ public float StatsMessageDelayTime;
+        /* 0x750C */ public float StatsMessageDelayTime;
         [NMS(Index = 23)]
-        /* 0x7460 */ public float StoreDialDecayTime;
+        /* 0x7510 */ public float StoreDialDecayTime;
         [NMS(Index = 22)]
-        /* 0x7464 */ public float StoreDialHoldTime;
+        /* 0x7514 */ public float StoreDialHoldTime;
         [NMS(Index = 24)]
-        /* 0x7468 */ public float StoreDialInnerRadius;
+        /* 0x7518 */ public float StoreDialInnerRadius;
         [NMS(Index = 25)]
-        /* 0x746C */ public float StoreDialOuterRadius;
+        /* 0x751C */ public float StoreDialOuterRadius;
         [NMS(Index = 78)]
-        /* 0x7470 */ public float SuperchargeGradientFactor;
+        /* 0x7520 */ public float SuperchargeGradientFactor;
         [NMS(Index = 77)]
-        /* 0x7474 */ public float SuperchargeGradientFactorMin;
+        /* 0x7524 */ public float SuperchargeGradientFactorMin;
         [NMS(Index = 79)]
-        /* 0x7478 */ public float SuperchargeGradientTime;
+        /* 0x7528 */ public float SuperchargeGradientTime;
         [NMS(Index = 784)]
-        /* 0x747C */ public float SurveyObjectArrowOffsetMultiplier;
+        /* 0x752C */ public float SurveyObjectArrowOffsetMultiplier;
         [NMS(Index = 347)]
-        /* 0x7480 */ public float TakeoffFuelMessageTime;
+        /* 0x7530 */ public float TakeoffFuelMessageTime;
         [NMS(Index = 573)]
-        /* 0x7484 */ public float TalkBoxAlienTextSpeed;
+        /* 0x7534 */ public float TalkBoxAlienTextSpeed;
         [NMS(Index = 575)]
-        /* 0x7488 */ public float TalkBoxAlienTextTimeMax;
+        /* 0x7538 */ public float TalkBoxAlienTextTimeMax;
         [NMS(Index = 574)]
-        /* 0x748C */ public float TalkBoxAlienTextTimeMin;
+        /* 0x753C */ public float TalkBoxAlienTextTimeMin;
         [NMS(Index = 548)]
-        /* 0x7490 */ public float TargetDisplayDamageFlashTime;
+        /* 0x7540 */ public float TargetDisplayDamageFlashTime;
         [NMS(Index = 543)]
-        /* 0x7494 */ public float TargetDisplayScale;
+        /* 0x7544 */ public float TargetDisplayScale;
         [NMS(Index = 545)]
-        /* 0x7498 */ public float TargetDisplayShipScale;
+        /* 0x7548 */ public float TargetDisplayShipScale;
         [NMS(Index = 544)]
-        /* 0x749C */ public float TargetDisplayTorpedoScale;
+        /* 0x754C */ public float TargetDisplayTorpedoScale;
         [NMS(Index = 1202)]
-        /* 0x74A0 */ public float TargetMarkerFadeAngleMin;
+        /* 0x7550 */ public float TargetMarkerFadeAngleMin;
         [NMS(Index = 1203)]
-        /* 0x74A4 */ public float TargetMarkerFadeAngleRange;
+        /* 0x7554 */ public float TargetMarkerFadeAngleRange;
         [NMS(Index = 1201)]
-        /* 0x74A8 */ public float TargetMarkerScaleEnd;
+        /* 0x7558 */ public float TargetMarkerScaleEnd;
         [NMS(Index = 1200)]
-        /* 0x74AC */ public float TargetMarkerScaleStart;
+        /* 0x755C */ public float TargetMarkerScaleStart;
         [NMS(Index = 1385)]
-        /* 0x74B0 */ public float TargetParallaxMaintenancePageMultiplier;
+        /* 0x7560 */ public float TargetParallaxMaintenancePageMultiplier;
         [NMS(Index = 1384)]
-        /* 0x74B4 */ public float TargetParallaxMouseMultiplier;
+        /* 0x7564 */ public float TargetParallaxMouseMultiplier;
         [NMS(Index = 1002)]
-        /* 0x74B8 */ public float TargetScreenDistance;
+        /* 0x7568 */ public float TargetScreenDistance;
         [NMS(Index = 1001)]
-        /* 0x74BC */ public float TargetScreenFoV;
+        /* 0x756C */ public float TargetScreenFoV;
         [NMS(Index = 799)]
-        /* 0x74C0 */ public float TechDisplayDelayTime;
+        /* 0x7570 */ public float TechDisplayDelayTime;
         [NMS(Index = 444)]
-        /* 0x74C4 */ public float TechPopupBuildLayerHeight;
+        /* 0x7574 */ public float TechPopupBuildLayerHeight;
         [NMS(Index = 443)]
-        /* 0x74C8 */ public float TechPopupRepairLayerHeight;
+        /* 0x7578 */ public float TechPopupRepairLayerHeight;
         [NMS(Index = 445)]
-        /* 0x74CC */ public float TechPopupRequirementHeight;
+        /* 0x757C */ public float TechPopupRequirementHeight;
         [NMS(Index = 1408)]
-        /* 0x74D0 */ public float TextChatMaxDisplayTime;
+        /* 0x7580 */ public float TextChatMaxDisplayTime;
         [NMS(Index = 1409)]
-        /* 0x74D4 */ public float TextChatStayBigAfterTextInput;
+        /* 0x7584 */ public float TextChatStayBigAfterTextInput;
         [NMS(Index = 183)]
-        /* 0x74D8 */ public float TextPrintoutMultiplier;
+        /* 0x7588 */ public float TextPrintoutMultiplier;
         [NMS(Index = 184)]
-        /* 0x74DC */ public float TextPrintoutMultiplierAlien;
+        /* 0x758C */ public float TextPrintoutMultiplierAlien;
         [NMS(Index = 18)]
-        /* 0x74E0 */ public float TextTouchScrollCap;
+        /* 0x7590 */ public float TextTouchScrollCap;
         [NMS(Index = 762)]
-        /* 0x74E4 */ public float ThirdPersonCrosshairCircle1Distance;
+        /* 0x7594 */ public float ThirdPersonCrosshairCircle1Distance;
         [NMS(Index = 763)]
-        /* 0x74E8 */ public float ThirdPersonCrosshairCircle2Distance;
+        /* 0x7598 */ public float ThirdPersonCrosshairCircle2Distance;
         [NMS(Index = 761)]
-        /* 0x74EC */ public float ThirdPersonCrosshairDistance;
+        /* 0x759C */ public float ThirdPersonCrosshairDistance;
         [NMS(Index = 588)]
-        /* 0x74F0 */ public float TimedEventLookTime;
+        /* 0x75A0 */ public float TimedEventLookTime;
         [NMS(Index = 926)]
-        /* 0x74F4 */ public float TooltipTime;
+        /* 0x75A4 */ public float TooltipTime;
         [NMS(Index = 19)]
-        /* 0x74F8 */ public float TouchScrollChangePageThreshold;
+        /* 0x75A8 */ public float TouchScrollChangePageThreshold;
         [NMS(Index = 16)]
-        /* 0x74FC */ public float TouchScrollMaxDelta;
+        /* 0x75AC */ public float TouchScrollMaxDelta;
         [NMS(Index = 17)]
-        /* 0x7500 */ public float TouchScrollSpeedMul;
+        /* 0x75B0 */ public float TouchScrollSpeedMul;
         [NMS(Index = 759)]
-        /* 0x7504 */ public float TrackCriticalHitSize;
+        /* 0x75B4 */ public float TrackCriticalHitSize;
         [NMS(Index = 760)]
-        /* 0x7508 */ public float TrackCriticalPulseTime;
+        /* 0x75B8 */ public float TrackCriticalPulseTime;
         [NMS(Index = 735)]
-        /* 0x750C */ public float TrackLeadTargetInScale;
+        /* 0x75BC */ public float TrackLeadTargetInScale;
         [NMS(Index = 732)]
-        /* 0x7510 */ public float TrackMissileTargetPulseRate;
+        /* 0x75C0 */ public float TrackMissileTargetPulseRate;
         [NMS(Index = 725)]
-        /* 0x7514 */ public float TrackPoliceFreighterCentreOffset;
+        /* 0x75C4 */ public float TrackPoliceFreighterCentreOffset;
         [NMS(Index = 724)]
-        /* 0x7518 */ public float TrackPrimaryCentreOffset;
+        /* 0x75C8 */ public float TrackPrimaryCentreOffset;
         [NMS(Index = 737)]
-        /* 0x751C */ public float TrackReticuleAngle;
+        /* 0x75CC */ public float TrackReticuleAngle;
         [NMS(Index = 739)]
-        /* 0x7520 */ public float TrackReticuleInactiveTime;
+        /* 0x75D0 */ public float TrackReticuleInactiveTime;
         [NMS(Index = 738)]
-        /* 0x7524 */ public float TrackReticuleInTime;
+        /* 0x75D4 */ public float TrackReticuleInTime;
         [NMS(Index = 741)]
-        /* 0x7528 */ public float TrackReticuleRandomDelay;
+        /* 0x75D8 */ public float TrackReticuleRandomDelay;
         [NMS(Index = 740)]
-        /* 0x752C */ public float TrackReticuleRandomTime;
+        /* 0x75DC */ public float TrackReticuleRandomTime;
         [NMS(Index = 736)]
-        /* 0x7530 */ public float TrackReticuleScale;
+        /* 0x75E0 */ public float TrackReticuleScale;
         [NMS(Index = 733)]
-        /* 0x7534 */ public float TrackScaleCritical;
+        /* 0x75E4 */ public float TrackScaleCritical;
         [NMS(Index = 734)]
-        /* 0x7538 */ public float TrackScaleHit;
+        /* 0x75E8 */ public float TrackScaleHit;
         [NMS(Index = 726)]
-        /* 0x753C */ public float TrackTimerAlpha;
+        /* 0x75EC */ public float TrackTimerAlpha;
         [NMS(Index = 730)]
-        /* 0x7540 */ public float TrackTimerIconExclaimRadius;
+        /* 0x75F0 */ public float TrackTimerIconExclaimRadius;
         [NMS(Index = 729)]
-        /* 0x7544 */ public float TrackTimerIconInnerRadius;
+        /* 0x75F4 */ public float TrackTimerIconInnerRadius;
         [NMS(Index = 728)]
-        /* 0x7548 */ public float TrackTimerIconOuterRadius;
+        /* 0x75F8 */ public float TrackTimerIconOuterRadius;
         [NMS(Index = 727)]
-        /* 0x754C */ public float TrackTimerRadarPulseSize;
+        /* 0x75FC */ public float TrackTimerRadarPulseSize;
         [NMS(Index = 723)]
-        /* 0x7550 */ public float TrackTypeIconSize;
+        /* 0x7600 */ public float TrackTypeIconSize;
         [NMS(Index = 21)]
-        /* 0x7554 */ public float TradePageNotifyOffset;
+        /* 0x7604 */ public float TradePageNotifyOffset;
         [NMS(Index = 358)]
-        /* 0x7558 */ public float TransferPopupCursorOffsetFactor;
+        /* 0x7608 */ public float TransferPopupCursorOffsetFactor;
         [NMS(Index = 587)]
-        /* 0x755C */ public float TransferSendOffscreenBorder;
+        /* 0x760C */ public float TransferSendOffscreenBorder;
         [NMS(Index = 495)]
-        /* 0x7560 */ public float TransitionOffset;
+        /* 0x7610 */ public float TransitionOffset;
         [NMS(Index = 309)]
-        /* 0x7564 */ public float TravelLineThickness;
+        /* 0x7614 */ public float TravelLineThickness;
         [NMS(Index = 308)]
-        /* 0x7568 */ public float TravelTargetRadius;
+        /* 0x7618 */ public float TravelTargetRadius;
         [NMS(Index = 28)]
-        /* 0x756C */ public float TrialUpsellDeclineDecayTimeQuick;
+        /* 0x761C */ public float TrialUpsellDeclineDecayTimeQuick;
         [NMS(Index = 30)]
-        /* 0x7570 */ public float TrialUpsellDeclineDecayTimeSlow;
+        /* 0x7620 */ public float TrialUpsellDeclineDecayTimeSlow;
         [NMS(Index = 31)]
-        /* 0x7574 */ public float TrialUpsellDeclineDialInnerRadius;
+        /* 0x7624 */ public float TrialUpsellDeclineDialInnerRadius;
         [NMS(Index = 32)]
-        /* 0x7578 */ public float TrialUpsellDeclineDialOuterRadius;
+        /* 0x7628 */ public float TrialUpsellDeclineDialOuterRadius;
         [NMS(Index = 27)]
-        /* 0x757C */ public float TrialUpsellDeclineHoldTimeQuick;
+        /* 0x762C */ public float TrialUpsellDeclineHoldTimeQuick;
         [NMS(Index = 29)]
-        /* 0x7580 */ public float TrialUpsellDeclineHoldTimeSlow;
+        /* 0x7630 */ public float TrialUpsellDeclineHoldTimeSlow;
         [NMS(Index = 92)]
-        /* 0x7584 */ public int UnknownWordsToShowInCatalogue;
+        /* 0x7634 */ public int UnknownWordsToShowInCatalogue;
         [NMS(Index = 95)]
-        /* 0x7588 */ public float UseZoomedOutBuildCamRadius;
+        /* 0x7638 */ public float UseZoomedOutBuildCamRadius;
         [NMS(Index = 204)]
-        /* 0x758C */ public int VRFaceLockedScreenHeight;
+        /* 0x763C */ public int VRFaceLockedScreenHeight;
         [NMS(Index = 203)]
-        /* 0x7590 */ public int VRFaceLockedScreenWidth;
+        /* 0x7640 */ public int VRFaceLockedScreenWidth;
         [NMS(Index = 345)]
-        /* 0x7594 */ public float WantedDetectMessageTime;
+        /* 0x7644 */ public float WantedDetectMessageTime;
         [NMS(Index = 346)]
-        /* 0x7598 */ public float WantedDetectMinTimeout;
+        /* 0x7648 */ public float WantedDetectMinTimeout;
         [NMS(Index = 872)]
-        /* 0x759C */ public float WantedLevelScanAlpha;
+        /* 0x764C */ public float WantedLevelScanAlpha;
         [NMS(Index = 873)]
-        /* 0x75A0 */ public float WantedLevelScannedRate;
+        /* 0x7650 */ public float WantedLevelScannedRate;
         [NMS(Index = 870)]
-        /* 0x75A4 */ public float WantedLevelTimeoutPulseRate;
+        /* 0x7654 */ public float WantedLevelTimeoutPulseRate;
         [NMS(Index = 871)]
-        /* 0x75A8 */ public float WantedLevelWitnessAlpha;
+        /* 0x7658 */ public float WantedLevelWitnessAlpha;
         [NMS(Index = 869)]
-        /* 0x75AC */ public float WantedLevelWitnessOffset;
+        /* 0x765C */ public float WantedLevelWitnessOffset;
         [NMS(Index = 868)]
-        /* 0x75B0 */ public float WantedLevelWitnessPulseRate;
+        /* 0x7660 */ public float WantedLevelWitnessPulseRate;
         [NMS(Index = 122)]
-        /* 0x75B4 */ public float ZoomFactorOverride;
+        /* 0x7664 */ public float ZoomFactorOverride;
         [NMS(Index = 938)]
-        /* 0x75B8 */ public float ZoomHUDElementsOffsetX;
+        /* 0x7668 */ public float ZoomHUDElementsOffsetX;
         [NMS(Index = 939)]
-        /* 0x75BC */ public float ZoomHUDElementsOffsetY;
+        /* 0x766C */ public float ZoomHUDElementsOffsetY;
         [NMS(Index = 940)]
-        /* 0x75C0 */ public float ZoomHUDElementTime;
+        /* 0x7670 */ public float ZoomHUDElementTime;
         [NMS(Index = 1304)]
-        /* 0x75C4 */ public NMSString0x100 HUDCircleAnimIcon;
+        /* 0x7674 */ public NMSString0x100 HUDCircleAnimIcon;
         [NMS(Index = 1302)]
-        /* 0x76C4 */ public NMSString0x100 HUDDeathPointIcon;
+        /* 0x7774 */ public NMSString0x100 HUDDeathPointIcon;
         [NMS(Index = 1303)]
-        /* 0x77C4 */ public NMSString0x100 HUDHexAnimIcon;
+        /* 0x7874 */ public NMSString0x100 HUDHexAnimIcon;
         [NMS(Index = 1298)]
-        /* 0x78C4 */ public NMSString0x100 HUDMarkerColourIcon;
+        /* 0x7974 */ public NMSString0x100 HUDMarkerColourIcon;
         [NMS(Index = 1296)]
-        /* 0x79C4 */ public NMSString0x100 HUDMarkerIcon;
+        /* 0x7A74 */ public NMSString0x100 HUDMarkerIcon;
         [NMS(Index = 1297)]
-        /* 0x7AC4 */ public NMSString0x100 HUDMarkerPrimaryIndicatorIcon;
+        /* 0x7B74 */ public NMSString0x100 HUDMarkerPrimaryIndicatorIcon;
         [NMS(Index = 1299)]
-        /* 0x7BC4 */ public NMSString0x100 HUDPointIcon;
+        /* 0x7C74 */ public NMSString0x100 HUDPointIcon;
         [NMS(Index = 1301)]
-        /* 0x7CC4 */ public NMSString0x100 HUDSaveIcon;
+        /* 0x7D74 */ public NMSString0x100 HUDSaveIcon;
         [NMS(Index = 1300)]
-        /* 0x7DC4 */ public NMSString0x100 HUDSpaceshipIcon;
+        /* 0x7E74 */ public NMSString0x100 HUDSpaceshipIcon;
         [NMS(Index = 936)]
-        /* 0x7EC4 */ public NMSString0x20 DistanceUnitKM;
+        /* 0x7F74 */ public NMSString0x20 DistanceUnitKM;
         [NMS(Index = 935)]
-        /* 0x7EE4 */ public NMSString0x20 DistanceUnitM;
+        /* 0x7F94 */ public NMSString0x20 DistanceUnitM;
         [NMS(Index = 937)]
-        /* 0x7F04 */ public NMSString0x20 DistanceUnitMpS;
+        /* 0x7FB4 */ public NMSString0x20 DistanceUnitMpS;
         [NMS(Index = 504)]
-        /* 0x7F24 */ public NMSString0x20 MaxDialogCharSizeIdeographicString;
+        /* 0x7FD4 */ public NMSString0x20 MaxDialogCharSizeIdeographicString;
         [NMS(Index = 502)]
-        /* 0x7F44 */ public NMSString0x20 MaxDialogCharSizeRomanString;
+        /* 0x7FF4 */ public NMSString0x20 MaxDialogCharSizeRomanString;
         [NMS(Index = 200)]
-        /* 0x7F64 */ public NMSString0x20 VRDistanceWarningUIFile;
+        /* 0x8014 */ public NMSString0x20 VRDistanceWarningUIFile;
         [NMS(Index = 392, Size = 0x10, EnumType = typeof(GcBuildMenuOption.BuildMenuOptionEnum))]
-        /* 0x7F84 */ public bool[] BuildMenuUseSmallIconOnPad;
+        /* 0x8034 */ public bool[] BuildMenuUseSmallIconOnPad;
         [NMS(Index = 1442)]
-        /* 0x7F94 */ public bool AllowInventorySorting;
+        /* 0x8044 */ public bool AllowInventorySorting;
         [NMS(Index = 186)]
-        /* 0x7F95 */ public bool AllowInWorldDebugBorders;
+        /* 0x8045 */ public bool AllowInWorldDebugBorders;
         [NMS(Index = 177)]
-        /* 0x7F96 */ public bool AllowProjectorRepositioning;
+        /* 0x8046 */ public bool AllowProjectorRepositioning;
         [NMS(Index = 316)]
-        /* 0x7F97 */ public bool AlwaysCloseQuickMenu;
+        /* 0x8047 */ public bool AlwaysCloseQuickMenu;
         [NMS(Index = 665)]
-        /* 0x7F98 */ public TkCurveType ArrowBounceLeftCurve;
+        /* 0x8048 */ public TkCurveType ArrowBounceLeftCurve;
         [NMS(Index = 661)]
-        /* 0x7F99 */ public TkCurveType ArrowBounceRightCurve;
+        /* 0x8049 */ public TkCurveType ArrowBounceRightCurve;
         [NMS(Index = 97)]
-        /* 0x7F9A */ public bool AutoScrollParagraphs;
+        /* 0x804A */ public bool AutoScrollParagraphs;
         [NMS(Index = 420)]
-        /* 0x7F9B */ public bool BaseBuildingSmoothMenuWhileSnapped;
+        /* 0x804B */ public bool BaseBuildingSmoothMenuWhileSnapped;
         [NMS(Index = 86)]
-        /* 0x7F9C */ public bool BigPicking;
+        /* 0x804C */ public bool BigPicking;
         [NMS(Index = 87)]
-        /* 0x7F9D */ public bool BigPickingUsesNumbers;
+        /* 0x804D */ public bool BigPickingUsesNumbers;
         [NMS(Index = 161)]
-        /* 0x7F9E */ public bool BinocularScanScreen;
+        /* 0x804E */ public bool BinocularScanScreen;
         [NMS(Index = 381)]
-        /* 0x7F9F */ public TkCurveType CompassCurve;
+        /* 0x804F */ public TkCurveType CompassCurve;
         [NMS(Index = 747)]
-        /* 0x7FA0 */ public bool CreatureInteractLabelUseBB;
+        /* 0x8050 */ public bool CreatureInteractLabelUseBB;
         [NMS(Index = 746)]
-        /* 0x7FA1 */ public TkCurveType CreatureReticuleAlphaCurve;
+        /* 0x8051 */ public TkCurveType CreatureReticuleAlphaCurve;
         [NMS(Index = 745)]
-        /* 0x7FA2 */ public TkCurveType CreatureReticuleScaleCurve;
+        /* 0x8052 */ public TkCurveType CreatureReticuleScaleCurve;
         [NMS(Index = 686)]
-        /* 0x7FA3 */ public TkCurveType CrosshairLeadScaleCurve;
+        /* 0x8053 */ public TkCurveType CrosshairLeadScaleCurve;
         [NMS(Index = 704)]
-        /* 0x7FA4 */ public TkCurveType CrosshairTargetLockAlphaCurve;
+        /* 0x8054 */ public TkCurveType CrosshairTargetLockAlphaCurve;
         [NMS(Index = 703)]
-        /* 0x7FA5 */ public TkCurveType CrosshairTargetLockCurve;
+        /* 0x8055 */ public TkCurveType CrosshairTargetLockCurve;
         [NMS(Index = 616)]
-        /* 0x7FA6 */ public TkCurveType DamageNumberUpCurve;
+        /* 0x8056 */ public TkCurveType DamageNumberUpCurve;
         [NMS(Index = 322)]
-        /* 0x7FA7 */ public bool DebugInventoryIndices;
+        /* 0x8057 */ public bool DebugInventoryIndices;
         [NMS(Index = 561)]
-        /* 0x7FA8 */ public bool DebugMarkerLabels;
+        /* 0x8058 */ public bool DebugMarkerLabels;
         [NMS(Index = 319)]
-        /* 0x7FA9 */ public bool DebugMissionLogText;
+        /* 0x8059 */ public bool DebugMissionLogText;
         [NMS(Index = 321)]
-        /* 0x7FAA */ public bool DebugPopupSizes;
+        /* 0x805A */ public bool DebugPopupSizes;
         [NMS(Index = 320)]
-        /* 0x7FAB */ public bool DebugShowMaintenanceScreenCentre;
+        /* 0x805B */ public bool DebugShowMaintenanceScreenCentre;
         [NMS(Index = 1428)]
-        /* 0x7FAC */ public bool EnableAccessibleUIOnSwitch;
+        /* 0x805C */ public bool EnableAccessibleUIOnSwitch;
         [NMS(Index = 448)]
-        /* 0x7FAD */ public bool EnableBlackouts;
+        /* 0x805D */ public bool EnableBlackouts;
         [NMS(Index = 803)]
-        /* 0x7FAE */ public bool EnableBuilderRobotGreekConversion;
+        /* 0x805E */ public bool EnableBuilderRobotGreekConversion;
         [NMS(Index = 248)]
-        /* 0x7FAF */ public bool EnableCraftingTree;
+        /* 0x805F */ public bool EnableCraftingTree;
         [NMS(Index = 185)]
-        /* 0x7FB0 */ public bool EnableHandMenuButtons;
+        /* 0x8060 */ public bool EnableHandMenuButtons;
         [NMS(Index = 217)]
-        /* 0x7FB1 */ public bool EnableHandMenuDebug;
+        /* 0x8061 */ public bool EnableHandMenuDebug;
         [NMS(Index = 804)]
-        /* 0x7FB2 */ public bool EnableKanaConversion;
+        /* 0x8062 */ public bool EnableKanaConversion;
         [NMS(Index = 90)]
-        /* 0x7FB3 */ public bool EnablePopupUses;
+        /* 0x8063 */ public bool EnablePopupUses;
         [NMS(Index = 323)]
-        /* 0x7FB4 */ public bool FixedInventoryIconPositions;
+        /* 0x8064 */ public bool FixedInventoryIconPositions;
         [NMS(Index = 1114)]
-        /* 0x7FB5 */ public TkCurveType FrontendBootBarCurve;
+        /* 0x8065 */ public TkCurveType FrontendBootBarCurve;
         [NMS(Index = 1099)]
-        /* 0x7FB6 */ public TkCurveType FrontendConfirmCurve;
+        /* 0x8066 */ public TkCurveType FrontendConfirmCurve;
         [NMS(Index = 1190)]
-        /* 0x7FB7 */ public TkCurveType FrontendDoFCurve;
+        /* 0x8067 */ public TkCurveType FrontendDoFCurve;
         [NMS(Index = 1189)]
-        /* 0x7FB8 */ public bool FrontendDoFEnableBokeh;
+        /* 0x8068 */ public bool FrontendDoFEnableBokeh;
         [NMS(Index = 878)]
-        /* 0x7FB9 */ public bool HideExtremePlanetNotifications;
+        /* 0x8069 */ public bool HideExtremePlanetNotifications;
         [NMS(Index = 1406)]
-        /* 0x7FBA */ public bool HideQuickMenuControls;
+        /* 0x806A */ public bool HideQuickMenuControls;
         [NMS(Index = 1339)]
-        /* 0x7FBB */ public TkCurveType HUDMarkerActiveCurve;
+        /* 0x806B */ public TkCurveType HUDMarkerActiveCurve;
         [NMS(Index = 1309)]
-        /* 0x7FBC */ public TkCurveType HUDMarkerAnimAlphaCurve;
+        /* 0x806C */ public TkCurveType HUDMarkerAnimAlphaCurve;
         [NMS(Index = 1310)]
-        /* 0x7FBD */ public TkCurveType HUDMarkerAnimCurve;
+        /* 0x806D */ public TkCurveType HUDMarkerAnimCurve;
         [NMS(Index = 836)]
-        /* 0x7FBE */ public TkCurveType HUDPlayerTrackArrowEnergyShieldDepletedCurve;
+        /* 0x806E */ public TkCurveType HUDPlayerTrackArrowEnergyShieldDepletedCurve;
         [NMS(Index = 841)]
-        /* 0x7FBF */ public TkCurveType HUDPlayerTrackArrowEnergyShieldStartChargeCurve;
+        /* 0x806F */ public TkCurveType HUDPlayerTrackArrowEnergyShieldStartChargeCurve;
         [NMS(Index = 298)]
-        /* 0x7FC0 */ public bool InteractionInWorldPlayerCamAlways;
+        /* 0x8070 */ public bool InteractionInWorldPlayerCamAlways;
         [NMS(Index = 979)]
-        /* 0x7FC1 */ public TkCurveType InteractionScanSlapCurve;
+        /* 0x8071 */ public TkCurveType InteractionScanSlapCurve;
         [NMS(Index = 507)]
-        /* 0x7FC2 */ public bool LeadTargetEnabled;
+        /* 0x8072 */ public bool LeadTargetEnabled;
         [NMS(Index = 1006)]
-        /* 0x7FC3 */ public bool ModelRendererBGPass;
+        /* 0x8073 */ public bool ModelRendererBGPass;
         [NMS(Index = 1007)]
-        /* 0x7FC4 */ public bool ModelRendererPass1;
+        /* 0x8074 */ public bool ModelRendererPass1;
         [NMS(Index = 1008)]
-        /* 0x7FC5 */ public bool ModelRendererPass2;
+        /* 0x8075 */ public bool ModelRendererPass2;
         [NMS(Index = 1387)]
-        /* 0x7FC6 */ public TkCurveType NGuiModelViewFadeInAfterRenderCurve;
+        /* 0x8076 */ public TkCurveType NGuiModelViewFadeInAfterRenderCurve;
         [NMS(Index = 1388)]
-        /* 0x7FC7 */ public bool NGuiUseSeparateLayersForModelAndReflection;
+        /* 0x8077 */ public bool NGuiUseSeparateLayersForModelAndReflection;
         [NMS(Index = 205)]
-        /* 0x7FC8 */ public bool OnlyShowEjectHandlesInVR;
+        /* 0x8078 */ public bool OnlyShowEjectHandlesInVR;
         [NMS(Index = 66)]
-        /* 0x7FC9 */ public TkCurveType PadCursorUICurve;
+        /* 0x8079 */ public TkCurveType PadCursorUICurve;
         [NMS(Index = 497)]
-        /* 0x7FCA */ public TkCurveType PageTurnCurve;
+        /* 0x807A */ public TkCurveType PageTurnCurve;
         [NMS(Index = 498)]
-        /* 0x7FCB */ public TkCurveType PageTurnFadeCurve;
+        /* 0x807B */ public TkCurveType PageTurnFadeCurve;
         [NMS(Index = 1118)]
-        /* 0x7FCC */ public TkCurveType PopupActivateCurve1;
+        /* 0x807C */ public TkCurveType PopupActivateCurve1;
         [NMS(Index = 1119)]
-        /* 0x7FCD */ public TkCurveType PopupActivateCurve2;
+        /* 0x807D */ public TkCurveType PopupActivateCurve2;
         [NMS(Index = 550)]
-        /* 0x7FCE */ public bool ProgressiveDialogStyle;
+        /* 0x807E */ public bool ProgressiveDialogStyle;
         [NMS(Index = 1407)]
-        /* 0x7FCF */ public bool QuickMenuAllowCycle;
+        /* 0x807F */ public bool QuickMenuAllowCycle;
         [NMS(Index = 249)]
-        /* 0x7FD0 */ public bool QuickMenuEnableSwipe;
+        /* 0x8080 */ public bool QuickMenuEnableSwipe;
         [NMS(Index = 318)]
-        /* 0x7FD1 */ public bool RepairTechUseTechIcon;
+        /* 0x8081 */ public bool RepairTechUseTechIcon;
         [NMS(Index = 82)]
-        /* 0x7FD2 */ public bool ReplaceItemBarWithNumbers;
+        /* 0x8082 */ public bool ReplaceItemBarWithNumbers;
         [NMS(Index = 1021)]
-        /* 0x7FD3 */ public bool ShieldHUDAlwaysOn;
+        /* 0x8083 */ public bool ShieldHUDAlwaysOn;
         [NMS(Index = 563)]
-        /* 0x7FD4 */ public bool ShowDamageNumbers;
+        /* 0x8084 */ public bool ShowDamageNumbers;
         [NMS(Index = 51)]
-        /* 0x7FD5 */ public bool ShowDifficultyForBases;
+        /* 0x8085 */ public bool ShowDifficultyForBases;
         [NMS(Index = 875)]
-        /* 0x7FD6 */ public bool ShowJetpackNotificationForNonTerrain;
+        /* 0x8086 */ public bool ShowJetpackNotificationForNonTerrain;
         [NMS(Index = 595)]
-        /* 0x7FD7 */ public bool ShowOnscreenPredatorMarkers;
+        /* 0x8087 */ public bool ShowOnscreenPredatorMarkers;
         [NMS(Index = 52)]
-        /* 0x7FD8 */ public bool ShowPadlockForLockedSettings;
+        /* 0x8088 */ public bool ShowPadlockForLockedSettings;
         [NMS(Index = 201)]
-        /* 0x7FD9 */ public bool ShowVRDistanceWarning;
+        /* 0x8089 */ public bool ShowVRDistanceWarning;
         [NMS(Index = 121)]
-        /* 0x7FDA */ public bool SkipShopIntro;
+        /* 0x808A */ public bool SkipShopIntro;
         [NMS(Index = 1233)]
-        /* 0x7FDB */ public TkCurveType SpaceMapDistanceCurve;
+        /* 0x808B */ public TkCurveType SpaceMapDistanceCurve;
         [NMS(Index = 1219)]
-        /* 0x7FDC */ public bool SpaceMapShowAnomaly;
+        /* 0x808C */ public bool SpaceMapShowAnomaly;
         [NMS(Index = 1220)]
-        /* 0x7FDD */ public bool SpaceMapShowAnomalyLines;
+        /* 0x808D */ public bool SpaceMapShowAnomalyLines;
         [NMS(Index = 1226)]
-        /* 0x7FDE */ public bool SpaceMapShowFrieghterLines;
+        /* 0x808E */ public bool SpaceMapShowFrieghterLines;
         [NMS(Index = 1225)]
-        /* 0x7FDF */ public bool SpaceMapShowFrieghters;
+        /* 0x808F */ public bool SpaceMapShowFrieghters;
         [NMS(Index = 1221)]
-        /* 0x7FE0 */ public bool SpaceMapShowNexus;
+        /* 0x8090 */ public bool SpaceMapShowNexus;
         [NMS(Index = 1222)]
-        /* 0x7FE1 */ public bool SpaceMapShowNexusLines;
+        /* 0x8091 */ public bool SpaceMapShowNexusLines;
         [NMS(Index = 1216)]
-        /* 0x7FE2 */ public bool SpaceMapShowPlanetLines;
+        /* 0x8092 */ public bool SpaceMapShowPlanetLines;
         [NMS(Index = 1215)]
-        /* 0x7FE3 */ public bool SpaceMapShowPlanets;
+        /* 0x8093 */ public bool SpaceMapShowPlanets;
         [NMS(Index = 1228)]
-        /* 0x7FE4 */ public bool SpaceMapShowPulseEncounterLines;
+        /* 0x8094 */ public bool SpaceMapShowPulseEncounterLines;
         [NMS(Index = 1227)]
-        /* 0x7FE5 */ public bool SpaceMapShowPulseEncounters;
+        /* 0x8095 */ public bool SpaceMapShowPulseEncounters;
         [NMS(Index = 1224)]
-        /* 0x7FE6 */ public bool SpaceMapShowShipLines;
+        /* 0x8096 */ public bool SpaceMapShowShipLines;
         [NMS(Index = 1223)]
-        /* 0x7FE7 */ public bool SpaceMapShowShips;
+        /* 0x8097 */ public bool SpaceMapShowShips;
         [NMS(Index = 1217)]
-        /* 0x7FE8 */ public bool SpaceMapShowStation;
+        /* 0x8098 */ public bool SpaceMapShowStation;
         [NMS(Index = 1218)]
-        /* 0x7FE9 */ public bool SpaceMapShowStationLines;
+        /* 0x8099 */ public bool SpaceMapShowStationLines;
         [NMS(Index = 508)]
-        /* 0x7FEA */ public bool SpaceOnlyLeadTargetEnabled;
+        /* 0x809A */ public bool SpaceOnlyLeadTargetEnabled;
         [NMS(Index = 91)]
-        /* 0x7FEB */ public bool TechBoxesCanStack;
+        /* 0x809B */ public bool TechBoxesCanStack;
         [NMS(Index = 757)]
-        /* 0x7FEC */ public TkCurveType TrackCritCurve;
+        /* 0x809C */ public TkCurveType TrackCritCurve;
         [NMS(Index = 743)]
-        /* 0x7FED */ public TkCurveType TrackReticuleInAngleCurve;
+        /* 0x809D */ public TkCurveType TrackReticuleInAngleCurve;
         [NMS(Index = 742)]
-        /* 0x7FEE */ public TkCurveType TrackReticuleInCurve;
+        /* 0x809E */ public TkCurveType TrackReticuleInCurve;
         [NMS(Index = 1088)]
-        /* 0x7FEF */ public bool UseCursorHoverSlowFixedValue;
+        /* 0x809F */ public bool UseCursorHoverSlowFixedValue;
         [NMS(Index = 93)]
-        /* 0x7FF0 */ public bool UseIntermediateMissionGiverOptions;
+        /* 0x80A0 */ public bool UseIntermediateMissionGiverOptions;
         [NMS(Index = 809)]
-        /* 0x7FF1 */ public bool UseNamesOnShipHUD;
+        /* 0x80A1 */ public bool UseNamesOnShipHUD;
         [NMS(Index = 85)]
-        /* 0x7FF2 */ public bool UseSquareSlots;
+        /* 0x80A2 */ public bool UseSquareSlots;
         [NMS(Index = 317)]
-        /* 0x7FF3 */ public bool UseWorldNodesForRepair;
+        /* 0x80A3 */ public bool UseWorldNodesForRepair;
     }
 }

--- a/libMBIN/Source/NMS/Globals/GcVehicleGlobals.cs
+++ b/libMBIN/Source/NMS/Globals/GcVehicleGlobals.cs
@@ -4,12 +4,12 @@ using System.Collections.Generic;
 
 namespace libMBIN.NMS.Globals
 {
-    [NMS(GUID = 0xCE0C56502150A165, NameHash = 0x6C7923EF)]
+    [NMS(GUID = 0xA033E06F10A38244, NameHash = 0x6C7923EF)]
     public class GcVehicleGlobals : NMSTemplate
     {
-        [NMS(Index = 232)]
-        /* 0x000 */ public Colour CheckpointBeamColourActive;
         [NMS(Index = 233)]
+        /* 0x000 */ public Colour CheckpointBeamColourActive;
+        [NMS(Index = 234)]
         /* 0x010 */ public Colour CheckpointBeamColourNormal;
         [NMS(Index = 34)]
         /* 0x020 */ public Colour DefaultBoosterColour;
@@ -19,7 +19,7 @@ namespace libMBIN.NMS.Globals
         /* 0x040 */ public Vector3f MechWalkBackwardsCoGOffset;
         [NMS(Index = 157, Size = 0x5, EnumType = typeof(GcVehicleWeaponMode.VehicleWeaponModeEnum))]
         /* 0x050 */ public GcExoMechWeaponData[] MechWeaponData;
-        [NMS(Index = 286, Size = 0x7, EnumType = typeof(GcVehicleType.VehicleTypeEnum))]
+        [NMS(Index = 287, Size = 0x7, EnumType = typeof(GcVehicleType.VehicleTypeEnum))]
         /* 0x2D0 */ public GcVehicleMuzzleData[] VehicleWeaponMuzzleFlash;
         [NMS(Index = 158)]
         /* 0x500 */ public GcMechMeshPartTable MechMeshPartsTable;
@@ -33,11 +33,11 @@ namespace libMBIN.NMS.Globals
         /* 0x840 */ public NMSString0x10 BugMechLeftArmTech;
         [NMS(Index = 7)]
         /* 0x850 */ public NMSString0x10 BugMechRightArmTech;
-        [NMS(Index = 235)]
-        /* 0x860 */ public List<NMSString0x10> DefaultBikeLoadout;
-        [NMS(Index = 234)]
-        /* 0x870 */ public List<NMSString0x10> DefaultBuggyLoadout;
         [NMS(Index = 236)]
+        /* 0x860 */ public List<NMSString0x10> DefaultBikeLoadout;
+        [NMS(Index = 235)]
+        /* 0x870 */ public List<NMSString0x10> DefaultBuggyLoadout;
+        [NMS(Index = 237)]
         /* 0x880 */ public List<NMSString0x10> DefaultTruckLoadout;
         [NMS(Index = 59)]
         /* 0x890 */ public NMSString0x10 MechArmPitchAnimLeft;
@@ -59,19 +59,19 @@ namespace libMBIN.NMS.Globals
         /* 0x910 */ public NMSString0x10 SentinelRightArmTech;
         [NMS(Index = 11)]
         /* 0x920 */ public NMSString0x10 SentinelRightLeftArmLaserData;
-        [NMS(Index = 187)]
+        [NMS(Index = 188)]
         /* 0x930 */ public List<Vector3f> UnderwaterBubbleOffset;
-        [NMS(Index = 288)]
+        [NMS(Index = 289)]
         /* 0x940 */ public List<GcVehicleData> VehicleDataTable;
-        [NMS(Index = 285)]
+        [NMS(Index = 286)]
         /* 0x950 */ public NMSString0x10 VehicleLocalScan;
-        [NMS(Index = 284)]
+        [NMS(Index = 285)]
         /* 0x960 */ public NMSString0x10 VehicleScan;
         [NMS(Index = 3)]
         /* 0x970 */ public NMSString0x10 VehicleStrongLaser;
-        [NMS(Index = 287)]
+        [NMS(Index = 288)]
         /* 0x980 */ public List<GcVehicleWeaponMuzzleData> VehicleWeaponMuzzleDataTable;
-        [NMS(Index = 186)]
+        [NMS(Index = 187)]
         /* 0x990 */ public GcSpaceshipAvoidanceData UnderwaterAvoidance;
         [NMS(Index = 37)]
         /* 0x9B4 */ public Vector2f MechLookStickSpeedLimit;
@@ -103,487 +103,489 @@ namespace libMBIN.NMS.Globals
         /* 0x9F0 */ public int AIMechStunGunNumShotsMax;
         [NMS(Index = 149)]
         /* 0x9F4 */ public int AIMechStunGunNumShotsMin;
-        [NMS(Index = 219)]
-        /* 0x9F8 */ public float AttractAlign;
-        [NMS(Index = 217)]
-        /* 0x9FC */ public float AttractAmount;
         [NMS(Index = 220)]
-        /* 0xA00 */ public float AttractDirectionBrakeThresholdSq;
+        /* 0x9F8 */ public float AttractAlign;
         [NMS(Index = 218)]
-        /* 0xA04 */ public float AttractMaxSpeed;
-        [NMS(Index = 200)]
-        /* 0xA08 */ public float BoostPadStrength;
-        [NMS(Index = 199)]
-        /* 0xA0C */ public float BoostPadTime;
-        [NMS(Index = 239)]
-        /* 0xA10 */ public float CheckpointBeamOffset;
-        [NMS(Index = 238)]
-        /* 0xA14 */ public float CheckpointBeamSizeActive;
-        [NMS(Index = 237)]
-        /* 0xA18 */ public float CheckpointBeamSizeNormal;
-        [NMS(Index = 198)]
-        /* 0xA1C */ public float CheckpointDeleteAngle;
-        [NMS(Index = 197)]
-        /* 0xA20 */ public float CheckpointDeleteDistance;
-        [NMS(Index = 230)]
-        /* 0xA24 */ public float CheckpointFlashDuration;
-        [NMS(Index = 231)]
-        /* 0xA28 */ public float CheckpointFlashIntensity;
-        [NMS(Index = 195)]
-        /* 0xA2C */ public float CheckpointPlacementOffset;
-        [NMS(Index = 196)]
-        /* 0xA30 */ public float CheckpointPlacementRayLength;
-        [NMS(Index = 225)]
-        /* 0xA34 */ public float CheckpointRadius;
-        [NMS(Index = 15)]
-        /* 0xA38 */ public float ControlStickRecenterSpeedDegPerSec;
-        [NMS(Index = 39)]
-        /* 0xA3C */ public float DamageTechMinHitIntervalSeconds;
-        [NMS(Index = 38)]
-        /* 0xA40 */ public int DamageTechNumHitsRequired;
-        [NMS(Index = 201)]
-        /* 0xA44 */ public float DisablePhysicsRange;
-        [NMS(Index = 222)]
-        /* 0xA48 */ public float ExitStopForce;
+        /* 0x9FC */ public float AttractAmount;
         [NMS(Index = 221)]
-        /* 0xA4C */ public float ExitStopTime;
-        [NMS(Index = 164)]
-        /* 0xA50 */ public float FirstPersonSteeringAdditionalForward;
-        [NMS(Index = 165)]
-        /* 0xA54 */ public float FirstPersonSteeringAdditionalForwardThreshold;
-        [NMS(Index = 166)]
-        /* 0xA58 */ public float FirstPersonSteeringAdditionalReverseThreshold;
-        [NMS(Index = 168)]
-        /* 0xA5C */ public float FirstPersonSteeringLowSpeedTurnDamping;
-        [NMS(Index = 167)]
-        /* 0xA60 */ public float FirstPersonSteeringMinThrottleHardLeftRight;
-        [NMS(Index = 246)]
-        /* 0xA64 */ public int GunBaseDamage;
-        [NMS(Index = 249)]
-        /* 0xA68 */ public int GunBaseMiningDamage;
-        [NMS(Index = 223)]
-        /* 0xA6C */ public float GunFireRate;
-        [NMS(Index = 188)]
-        /* 0xA70 */ public float HeadlightIntensitySpringTime;
-        [NMS(Index = 215)]
-        /* 0xA74 */ public float HornScareFleeRadius;
-        [NMS(Index = 214)]
-        /* 0xA78 */ public float HornScareRadius;
-        [NMS(Index = 216)]
-        /* 0xA7C */ public float HornScareTime;
-        [NMS(Index = 13)]
-        /* 0xA80 */ public float LevelVehicleCameraFactor;
-        [NMS(Index = 54)]
-        /* 0xA84 */ public float MechAIGroundTurnSpeed;
-        [NMS(Index = 42)]
-        /* 0xA88 */ public float MechAIResummonMinSpawnDistance;
-        [NMS(Index = 43)]
-        /* 0xA8C */ public float MechAIResummonMinSpeedForVelBasedSpawnPos;
-        [NMS(Index = 41)]
-        /* 0xA90 */ public float MechAIResummonTriggerDistance;
-        [NMS(Index = 44)]
-        /* 0xA94 */ public float MechAIResummonVelBasedSpawnSpeedMultiplier;
-        [NMS(Index = 57)]
-        /* 0xA98 */ public float MechArmPitchAngleMax;
-        [NMS(Index = 56)]
-        /* 0xA9C */ public float MechArmPitchAngleMin;
-        [NMS(Index = 58)]
-        /* 0xAA0 */ public float MechArmPitchLerpSpeed;
-        [NMS(Index = 79)]
-        /* 0xAA4 */ public float MechArmSwingAngleFastWalk;
-        [NMS(Index = 76)]
-        /* 0xAA8 */ public float MechArmSwingAngleWalk;
-        [NMS(Index = 80)]
-        /* 0xAAC */ public float MechArmSwingPhaseFastWalk;
-        [NMS(Index = 77)]
-        /* 0xAB0 */ public float MechArmSwingPhaseWalk;
-        [NMS(Index = 97)]
-        /* 0xAB4 */ public float MechCameraOffsetAmount;
-        [NMS(Index = 96)]
-        /* 0xAB8 */ public float MechCameraOffsetTime;
-        [NMS(Index = 127)]
-        /* 0xABC */ public float MechCockPitBobPitch;
-        [NMS(Index = 128)]
-        /* 0xAC0 */ public float MechCockPitBobRoll;
-        [NMS(Index = 125)]
-        /* 0xAC4 */ public float MechCockPitBobX;
-        [NMS(Index = 126)]
-        /* 0xAC8 */ public float MechCockPitBobY;
-        [NMS(Index = 129)]
-        /* 0xACC */ public float MechCockPitBobYaw;
-        [NMS(Index = 130)]
-        /* 0xAD0 */ public float MechCockPowerDownY;
-        [NMS(Index = 71)]
-        /* 0xAD4 */ public float MechCoGAdjustTimeAir;
-        [NMS(Index = 72)]
-        /* 0xAD8 */ public float MechCoGAdjustTimeLand;
-        [NMS(Index = 70)]
-        /* 0xADC */ public float MechCoGAdjustTimeWindUp;
-        [NMS(Index = 47)]
-        /* 0xAE0 */ public float MechContrailAlpha;
-        [NMS(Index = 73)]
-        /* 0xAE4 */ public float MechCrouchTime;
-        [NMS(Index = 100)]
-        /* 0xAE8 */ public float MechDefaultBlendTime;
-        [NMS(Index = 123)]
-        /* 0xAEC */ public float MechFirstPersonCrouchAmount;
-        [NMS(Index = 119)]
-        /* 0xAF0 */ public float MechFirstPersonDamping;
-        [NMS(Index = 114)]
-        /* 0xAF4 */ public float MechFirstPersonIgnoreReverseThreshold;
-        [NMS(Index = 122)]
-        /* 0xAF8 */ public float MechFirstPersonMaxLookTurret;
-        [NMS(Index = 121)]
-        /* 0xAFC */ public float MechFirstPersonMaxTurnTurret;
-        [NMS(Index = 120)]
-        /* 0xB00 */ public float MechFirstPersonStickXModerator;
-        [NMS(Index = 118)]
-        /* 0xB04 */ public float MechFirstPersonTurretAngleThrottleStrength;
-        [NMS(Index = 117)]
-        /* 0xB08 */ public float MechFirstPersonTurretAngleThrottleThreshold;
-        [NMS(Index = 113)]
-        /* 0xB0C */ public float MechFirstPersonTurretBaseThrottleThreshold;
-        [NMS(Index = 116)]
-        /* 0xB10 */ public float MechFirstPersonTurretBaseTurnThreshold;
-        [NMS(Index = 110)]
-        /* 0xB14 */ public float MechFirstPersonTurretPitchModerator;
-        [NMS(Index = 112)]
-        /* 0xB18 */ public float MechFirstPersonTurretShootTimer;
-        [NMS(Index = 115)]
-        /* 0xB1C */ public float MechFirstPersonTurretThrottleLookThreshold;
-        [NMS(Index = 109)]
-        /* 0xB20 */ public float MechFirstPersonTurretTurnModerator;
-        [NMS(Index = 140)]
-        /* 0xB24 */ public float MechFootprintFadeDist;
-        [NMS(Index = 139)]
-        /* 0xB28 */ public float MechFootprintFadeTime;
-        [NMS(Index = 106)]
-        /* 0xB2C */ public float MechIdleLowBlendTime;
-        [NMS(Index = 107)]
-        /* 0xB30 */ public float MechIdleLowDelay;
-        [NMS(Index = 108)]
-        /* 0xB34 */ public float MechIdleStopDelay;
-        [NMS(Index = 90)]
-        /* 0xB38 */ public float MechJetpackAvoidGroundForce;
-        [NMS(Index = 92)]
-        /* 0xB3C */ public float MechJetpackAvoidGroundProbeLength;
-        [NMS(Index = 86)]
-        /* 0xB40 */ public float MechJetpackBrake;
-        [NMS(Index = 98)]
-        /* 0xB44 */ public float MechJetpackDrainRate;
-        [NMS(Index = 91)]
-        /* 0xB48 */ public float MechJetpackFallForce;
-        [NMS(Index = 99)]
-        /* 0xB4C */ public float MechJetpackFillRate;
-        [NMS(Index = 85)]
-        /* 0xB50 */ public float MechJetpackForce;
-        [NMS(Index = 93)]
-        /* 0xB54 */ public float MechJetpackIgnitionForce;
-        [NMS(Index = 94)]
-        /* 0xB58 */ public float MechJetpackIgnitionTime;
-        [NMS(Index = 48)]
-        /* 0xB5C */ public float MechJetpackJetScaleTime;
-        [NMS(Index = 84)]
-        /* 0xB60 */ public float MechJetpackLandTime;
-        [NMS(Index = 95)]
-        /* 0xB64 */ public float MechJetpackMaxCoGAdjustX;
-        [NMS(Index = 87)]
-        /* 0xB68 */ public float MechJetpackMaxSpeed;
-        [NMS(Index = 88)]
-        /* 0xB6C */ public float MechJetpackMaxUpSpeed;
-        [NMS(Index = 83)]
-        /* 0xB70 */ public float MechJetpackStrafeStrength;
-        [NMS(Index = 55)]
-        /* 0xB74 */ public float MechJetpackTurnSpeed;
-        [NMS(Index = 89)]
-        /* 0xB78 */ public float MechJetpackUpForce;
-        [NMS(Index = 103)]
-        /* 0xB7C */ public float MechJumpBlendTime;
-        [NMS(Index = 105)]
-        /* 0xB80 */ public float MechJumpDownBlendTime;
-        [NMS(Index = 104)]
-        /* 0xB84 */ public float MechJumpFlyBlendTime;
-        [NMS(Index = 102)]
-        /* 0xB88 */ public float MechLandBlendTime;
-        [NMS(Index = 82)]
-        /* 0xB8C */ public float MechLandBrake;
-        [NMS(Index = 138)]
-        /* 0xB90 */ public float MechLandCameraShakeDist;
-        [NMS(Index = 61)]
-        /* 0xB94 */ public float MechMaxTurnAngleWhileStationary;
-        [NMS(Index = 53)]
-        /* 0xB98 */ public float MechPlayerGroundTurnSpeed;
-        [NMS(Index = 124)]
-        /* 0xB9C */ public float MechPowerUpTime;
-        [NMS(Index = 241)]
-        /* 0xBA0 */ public float MechSpawnRotation;
-        [NMS(Index = 101)]
-        /* 0xBA4 */ public float MechSpeedBlendTime;
-        [NMS(Index = 137)]
-        /* 0xBA8 */ public float MechTitanFallCameraShakeDist;
-        [NMS(Index = 131)]
-        /* 0xBAC */ public float MechTitanFallHeight;
-        [NMS(Index = 135)]
-        /* 0xBB0 */ public float MechTitanFallLandIdleTime;
-        [NMS(Index = 136)]
-        /* 0xBB4 */ public float MechTitanFallLandIntroTime;
-        [NMS(Index = 134)]
-        /* 0xBB8 */ public float MechTitanFallTerrainEditOffset;
-        [NMS(Index = 133)]
-        /* 0xBBC */ public float MechTitanFallTerrainEditSize;
-        [NMS(Index = 66)]
-        /* 0xBC0 */ public float MechTurretMaxAngleAir;
-        [NMS(Index = 63)]
-        /* 0xBC4 */ public float MechTurretMaxAngleGround;
-        [NMS(Index = 67)]
-        /* 0xBC8 */ public float MechTurretTimeVRModifier;
-        [NMS(Index = 65)]
-        /* 0xBCC */ public float MechTurretTurnTimeAir;
-        [NMS(Index = 62)]
-        /* 0xBD0 */ public float MechTurretTurnTimeGround;
-        [NMS(Index = 64)]
-        /* 0xBD4 */ public float MechTurretTurnTimeGroundPlayerCombat;
-        [NMS(Index = 74)]
-        /* 0xBD8 */ public float MechWalkToRunTimeIdle;
-        [NMS(Index = 75)]
-        /* 0xBDC */ public float MechWalkToRunTimeSkid;
-        [NMS(Index = 155)]
-        /* 0xBE0 */ public float MechWeaponInterpSpeed;
-        [NMS(Index = 244)]
-        /* 0xBE4 */ public int MiningLaserDamage;
-        [NMS(Index = 204)]
-        /* 0xBE8 */ public float MiningLaserDrainSpeed;
-        [NMS(Index = 243)]
-        /* 0xBEC */ public int MiningLaserMiningDamage;
-        [NMS(Index = 242)]
-        /* 0xBF0 */ public float MiningLaserRadius;
-        [NMS(Index = 245)]
-        /* 0xBF4 */ public float MiningLaserSpeed;
-        [NMS(Index = 205)]
-        /* 0xBF8 */ public float ProjectileDrainPerShot;
-        [NMS(Index = 226)]
-        /* 0xBFC */ public float RaceCooldown;
-        [NMS(Index = 207)]
-        /* 0xC00 */ public float RaceInteractRespawnOffset;
-        [NMS(Index = 208)]
-        /* 0xC04 */ public float RaceInteractRespawnUpOffset;
-        [NMS(Index = 203)]
-        /* 0xC08 */ public float RaceMultipleStartCaptureRange;
-        [NMS(Index = 202)]
-        /* 0xC0C */ public float RaceMultipleStartOffset;
-        [NMS(Index = 228)]
-        /* 0xC10 */ public float RaceResetFlashDuration;
-        [NMS(Index = 229)]
-        /* 0xC14 */ public float RaceResetFlashIntensity;
-        [NMS(Index = 206)]
-        /* 0xC18 */ public float RaceStartSpawnUpOffset;
-        [NMS(Index = 22)]
-        /* 0xC1C */ public float RemoteBoostingEffectTimeout;
-        [NMS(Index = 250)]
-        /* 0xC20 */ public float ResourceCollectOffset;
-        [NMS(Index = 240)]
-        /* 0xC24 */ public float SpawnRotation;
-        [NMS(Index = 20)]
-        /* 0xC28 */ public float SteeringWheelCentreOffset;
-        [NMS(Index = 17)]
-        /* 0xC2C */ public float SteeringWheelPitchAngle;
-        [NMS(Index = 16)]
-        /* 0xC30 */ public float SteeringWheelPushRange;
-        [NMS(Index = 18)]
-        /* 0xC34 */ public float SteeringWheelSpringBothHands;
-        [NMS(Index = 19)]
-        /* 0xC38 */ public float SteeringWheelSpringOneHand;
-        [NMS(Index = 283)]
-        /* 0xC3C */ public float StickReverseTurnStiffness;
-        [NMS(Index = 282)]
-        /* 0xC40 */ public float StickReverseTurnThreshold;
-        [NMS(Index = 209)]
-        /* 0xC44 */ public float StickTurnReducer;
-        [NMS(Index = 212)]
-        /* 0xC48 */ public float StickTurnReducerAltNonVR;
-        [NMS(Index = 211)]
-        /* 0xC4C */ public float StickTurnReducerVR;
-        [NMS(Index = 210)]
-        /* 0xC50 */ public float StickTurnReducerWater;
-        [NMS(Index = 247)]
-        /* 0xC54 */ public int StunGunBaseDamage;
-        [NMS(Index = 248)]
-        /* 0xC58 */ public float StunGunFireRate;
-        [NMS(Index = 162)]
-        /* 0xC5C */ public float SubmarineEjectDownOffset;
-        [NMS(Index = 161)]
-        /* 0xC60 */ public float SubmarineEjectRadius;
-        [NMS(Index = 163)]
-        /* 0xC64 */ public float SubmarineFirstPersonSteeringSensitivity;
-        [NMS(Index = 160)]
-        /* 0xC68 */ public float SubmarineMinSummonDepth;
-        [NMS(Index = 224)]
-        /* 0xC6C */ public float SummoningRange;
-        [NMS(Index = 254)]
-        /* 0xC70 */ public float SuspensionDamping;
-        [NMS(Index = 255)]
-        /* 0xC74 */ public float SuspensionDampingAngularFactor;
-        [NMS(Index = 27)]
-        /* 0xC78 */ public float TestAnimBoost;
-        [NMS(Index = 26)]
-        /* 0xC7C */ public float TestAnimThrust;
-        [NMS(Index = 28)]
-        /* 0xC80 */ public float TestAnimTurn;
-        [NMS(Index = 23)]
-        /* 0xC84 */ public float TestFrictionStat;
-        [NMS(Index = 24)]
-        /* 0xC88 */ public float TestSkidFrictionStat;
-        [NMS(Index = 213)]
-        /* 0xC8C */ public float TravelSpeedReportReducer;
-        [NMS(Index = 171)]
-        /* 0xC90 */ public float UnderwaterBuoyancyRangeMax;
+        /* 0xA00 */ public float AttractDirectionBrakeThresholdSq;
+        [NMS(Index = 219)]
+        /* 0xA04 */ public float AttractMaxSpeed;
+        [NMS(Index = 201)]
+        /* 0xA08 */ public float BoostPadStrength;
+        [NMS(Index = 200)]
+        /* 0xA0C */ public float BoostPadTime;
         [NMS(Index = 170)]
-        /* 0xC94 */ public float UnderwaterBuoyancyRangeMin;
-        [NMS(Index = 175)]
-        /* 0xC98 */ public float UnderwaterBuoyancyRiseTime;
-        [NMS(Index = 169)]
-        /* 0xC9C */ public float UnderwaterBuoyancySurfaceOffset;
-        [NMS(Index = 185)]
-        /* 0xCA0 */ public float UnderwaterDiveForce;
-        [NMS(Index = 178)]
-        /* 0xCA4 */ public float UnderwaterFlattenMinDepth;
-        [NMS(Index = 179)]
-        /* 0xCA8 */ public float UnderwaterFlattenRange;
-        [NMS(Index = 184)]
-        /* 0xCAC */ public float UnderwaterJumpForce;
+        /* 0xA10 */ public float BuoyancyMaxDownForce;
+        [NMS(Index = 171)]
+        /* 0xA14 */ public float BuoyancyMaxUpForce;
         [NMS(Index = 173)]
-        /* 0xCB0 */ public float UnderwaterMaxSpeedAddedByBuoyancy;
-        [NMS(Index = 1)]
-        /* 0xCB4 */ public float UnderwaterScannerIconRangeBoost;
-        [NMS(Index = 174)]
-        /* 0xCB8 */ public float UnderwaterSummonSurfaceOffset;
-        [NMS(Index = 180)]
-        /* 0xCBC */ public float UnderwaterSurfaceForceFlatteningAngleMin;
-        [NMS(Index = 181)]
-        /* 0xCC0 */ public float UnderwaterSurfaceForceFlatteningAngleRange;
-        [NMS(Index = 177)]
-        /* 0xCC4 */ public float UnderwaterSurfaceGravity;
-        [NMS(Index = 176)]
-        /* 0xCC8 */ public float UnderwaterSurfaceOffset;
-        [NMS(Index = 182)]
-        /* 0xCCC */ public float UnderwaterSurfaceSplashdownForce;
-        [NMS(Index = 183)]
-        /* 0xCD0 */ public float UnderwaterSurfaceSplashdownMinSpeed;
-        [NMS(Index = 190)]
-        /* 0xCD4 */ public float VehicleAltControlStickSmoothInTime;
-        [NMS(Index = 191)]
-        /* 0xCD8 */ public float VehicleAltControlStickSmoothOutTime;
-        [NMS(Index = 272)]
-        /* 0xCDC */ public float VehicleBoostFuelRate;
-        [NMS(Index = 273)]
-        /* 0xCE0 */ public float VehicleBoostFuelRateSurvival;
-        [NMS(Index = 192)]
-        /* 0xCE4 */ public float VehicleBoostSpeedMultiplierPercent;
-        [NMS(Index = 0)]
-        /* 0xCE8 */ public float VehicleCollisionScaleFactor;
-        [NMS(Index = 271)]
-        /* 0xCEC */ public float VehicleDeactivateRange;
-        [NMS(Index = 267)]
-        /* 0xCF0 */ public float VehicleFadeTime;
-        [NMS(Index = 274)]
-        /* 0xCF4 */ public float VehicleFuelRate;
-        [NMS(Index = 275)]
-        /* 0xCF8 */ public float VehicleFuelRateTruckMultiplier;
-        [NMS(Index = 194)]
-        /* 0xCFC */ public float VehicleGarageHologramFadeRange;
-        [NMS(Index = 193)]
-        /* 0xD00 */ public float VehicleGarageHologramMinFadeRange;
-        [NMS(Index = 278)]
-        /* 0xD04 */ public float VehicleJumpCooldown;
-        [NMS(Index = 277)]
-        /* 0xD08 */ public float VehicleJumpTimeMax;
-        [NMS(Index = 276)]
-        /* 0xD0C */ public float VehicleJumpTimeMin;
-        [NMS(Index = 269)]
-        /* 0xD10 */ public float VehicleMaxSummonDistance;
-        [NMS(Index = 270)]
-        /* 0xD14 */ public float VehicleMaxSummonDistanceUnderwater;
-        [NMS(Index = 268)]
-        /* 0xD18 */ public float VehicleMinSummonDistance;
-        [NMS(Index = 279)]
-        /* 0xD1C */ public float VehicleMotionDeadZone;
-        [NMS(Index = 2)]
-        /* 0xD20 */ public float VehicleSolarRegenFactor;
-        [NMS(Index = 264)]
-        /* 0xD24 */ public float VehicleSuspensionAudioDelay;
-        [NMS(Index = 265)]
-        /* 0xD28 */ public float VehicleSuspensionAudioScale;
-        [NMS(Index = 263)]
-        /* 0xD2C */ public float VehicleSuspensionAudioSpacing;
-        [NMS(Index = 266)]
-        /* 0xD30 */ public float VehicleSuspensionAudioTrigger;
-        [NMS(Index = 260)]
-        /* 0xD34 */ public float VehicleTextSize;
-        [NMS(Index = 251)]
-        /* 0xD38 */ public float VehicleWheelNoise;
-        [NMS(Index = 252)]
-        /* 0xD3C */ public float VehicleWheelNoiseScale;
-        [NMS(Index = 32)]
-        /* 0xD40 */ public float VignetteAmountAcceleration;
-        [NMS(Index = 33)]
-        /* 0xD44 */ public float VignetteAmountTurning;
-        [NMS(Index = 30)]
-        /* 0xD48 */ public float VisualRollUnderwaterSpring;
-        [NMS(Index = 31)]
-        /* 0xD4C */ public float VisualTurnSpring;
-        [NMS(Index = 29)]
-        /* 0xD50 */ public float VisualTurnUnderwaterSpring;
-        [NMS(Index = 159)]
-        /* 0xD54 */ public float WeaponInterpSpeed;
-        [NMS(Index = 35)]
-        /* 0xD58 */ public float WheelDustColourLightFactor;
-        [NMS(Index = 280)]
-        /* 0xD5C */ public float WheelForceHalflife;
-        [NMS(Index = 253)]
-        /* 0xD60 */ public float WheelSideVerticalFactor;
-        [NMS(Index = 156, Size = 0x5, EnumType = typeof(GcMechWeaponLocation.MechWeaponLocationEnum))]
-        /* 0xD64 */ public NMSString0x20[] MechWeaponLocatorNames;
-        [NMS(Index = 46)]
-        /* 0xE04 */ public bool MechAltJumpMode;
-        [NMS(Index = 81)]
-        /* 0xE05 */ public TkCurveType MechArmSwingCurveFastWalk;
-        [NMS(Index = 78)]
-        /* 0xE06 */ public TkCurveType MechArmSwingCurveWalk;
-        [NMS(Index = 40)]
-        /* 0xE07 */ public bool MechCanUpdateMeshWhileMaintenanceUIActive;
-        [NMS(Index = 111)]
-        /* 0xE08 */ public bool MechFirstPersonTurretTweaksEnabled;
-        [NMS(Index = 45)]
-        /* 0xE09 */ public bool MechStrafeEnabled;
-        [NMS(Index = 132)]
-        /* 0xE0A */ public bool MechTitanFallTerrainEditEnabled;
-        [NMS(Index = 227)]
-        /* 0xE0B */ public bool RaceFinishAtStart;
-        [NMS(Index = 14)]
-        /* 0xE0C */ public bool ShowAllCheckpoints;
-        [NMS(Index = 256)]
-        /* 0xE0D */ public bool ShowTempVehicleMesh;
-        [NMS(Index = 257)]
-        /* 0xE0E */ public bool ShowVehicleDebugging;
-        [NMS(Index = 261)]
-        /* 0xE0F */ public bool ShowVehicleParticleDebug;
-        [NMS(Index = 259)]
-        /* 0xE10 */ public bool ShowVehicleText;
-        [NMS(Index = 258)]
-        /* 0xE11 */ public bool ShowVehicleWheelGuards;
-        [NMS(Index = 21)]
-        /* 0xE12 */ public TkCurveType SteeringWheelOutputCurve;
-        [NMS(Index = 25)]
-        /* 0xE13 */ public bool TestAnims;
-        [NMS(Index = 281)]
-        /* 0xE14 */ public bool ThrottleButtonCamRelative;
+        /* 0xA18 */ public float BuoyancySurfaceFudge;
         [NMS(Index = 172)]
-        /* 0xE15 */ public TkCurveType UnderwaterBuoyancyDepthCurve;
-        [NMS(Index = 12)]
-        /* 0xE16 */ public bool UseFirstPersonCamera;
+        /* 0xA1C */ public float BuoyancySurfacingTime;
+        [NMS(Index = 169)]
+        /* 0xA20 */ public float BuoyancyUnderwaterSphereRadius;
+        [NMS(Index = 240)]
+        /* 0xA24 */ public float CheckpointBeamOffset;
+        [NMS(Index = 239)]
+        /* 0xA28 */ public float CheckpointBeamSizeActive;
+        [NMS(Index = 238)]
+        /* 0xA2C */ public float CheckpointBeamSizeNormal;
+        [NMS(Index = 199)]
+        /* 0xA30 */ public float CheckpointDeleteAngle;
+        [NMS(Index = 198)]
+        /* 0xA34 */ public float CheckpointDeleteDistance;
+        [NMS(Index = 231)]
+        /* 0xA38 */ public float CheckpointFlashDuration;
+        [NMS(Index = 232)]
+        /* 0xA3C */ public float CheckpointFlashIntensity;
+        [NMS(Index = 196)]
+        /* 0xA40 */ public float CheckpointPlacementOffset;
+        [NMS(Index = 197)]
+        /* 0xA44 */ public float CheckpointPlacementRayLength;
+        [NMS(Index = 226)]
+        /* 0xA48 */ public float CheckpointRadius;
+        [NMS(Index = 15)]
+        /* 0xA4C */ public float ControlStickRecenterSpeedDegPerSec;
+        [NMS(Index = 39)]
+        /* 0xA50 */ public float DamageTechMinHitIntervalSeconds;
+        [NMS(Index = 38)]
+        /* 0xA54 */ public int DamageTechNumHitsRequired;
+        [NMS(Index = 202)]
+        /* 0xA58 */ public float DisablePhysicsRange;
+        [NMS(Index = 223)]
+        /* 0xA5C */ public float ExitStopForce;
+        [NMS(Index = 222)]
+        /* 0xA60 */ public float ExitStopTime;
+        [NMS(Index = 164)]
+        /* 0xA64 */ public float FirstPersonSteeringAdditionalForward;
+        [NMS(Index = 165)]
+        /* 0xA68 */ public float FirstPersonSteeringAdditionalForwardThreshold;
+        [NMS(Index = 166)]
+        /* 0xA6C */ public float FirstPersonSteeringAdditionalReverseThreshold;
+        [NMS(Index = 168)]
+        /* 0xA70 */ public float FirstPersonSteeringLowSpeedTurnDamping;
+        [NMS(Index = 167)]
+        /* 0xA74 */ public float FirstPersonSteeringMinThrottleHardLeftRight;
+        [NMS(Index = 247)]
+        /* 0xA78 */ public int GunBaseDamage;
+        [NMS(Index = 250)]
+        /* 0xA7C */ public int GunBaseMiningDamage;
+        [NMS(Index = 224)]
+        /* 0xA80 */ public float GunFireRate;
         [NMS(Index = 189)]
-        /* 0xE17 */ public bool VehicleAltControlScheme;
+        /* 0xA84 */ public float HeadlightIntensitySpringTime;
+        [NMS(Index = 216)]
+        /* 0xA88 */ public float HornScareFleeRadius;
+        [NMS(Index = 215)]
+        /* 0xA8C */ public float HornScareRadius;
+        [NMS(Index = 217)]
+        /* 0xA90 */ public float HornScareTime;
+        [NMS(Index = 13)]
+        /* 0xA94 */ public float LevelVehicleCameraFactor;
+        [NMS(Index = 54)]
+        /* 0xA98 */ public float MechAIGroundTurnSpeed;
+        [NMS(Index = 42)]
+        /* 0xA9C */ public float MechAIResummonMinSpawnDistance;
+        [NMS(Index = 43)]
+        /* 0xAA0 */ public float MechAIResummonMinSpeedForVelBasedSpawnPos;
+        [NMS(Index = 41)]
+        /* 0xAA4 */ public float MechAIResummonTriggerDistance;
+        [NMS(Index = 44)]
+        /* 0xAA8 */ public float MechAIResummonVelBasedSpawnSpeedMultiplier;
+        [NMS(Index = 57)]
+        /* 0xAAC */ public float MechArmPitchAngleMax;
+        [NMS(Index = 56)]
+        /* 0xAB0 */ public float MechArmPitchAngleMin;
+        [NMS(Index = 58)]
+        /* 0xAB4 */ public float MechArmPitchLerpSpeed;
+        [NMS(Index = 79)]
+        /* 0xAB8 */ public float MechArmSwingAngleFastWalk;
+        [NMS(Index = 76)]
+        /* 0xABC */ public float MechArmSwingAngleWalk;
+        [NMS(Index = 80)]
+        /* 0xAC0 */ public float MechArmSwingPhaseFastWalk;
+        [NMS(Index = 77)]
+        /* 0xAC4 */ public float MechArmSwingPhaseWalk;
+        [NMS(Index = 97)]
+        /* 0xAC8 */ public float MechCameraOffsetAmount;
+        [NMS(Index = 96)]
+        /* 0xACC */ public float MechCameraOffsetTime;
+        [NMS(Index = 127)]
+        /* 0xAD0 */ public float MechCockPitBobPitch;
+        [NMS(Index = 128)]
+        /* 0xAD4 */ public float MechCockPitBobRoll;
+        [NMS(Index = 125)]
+        /* 0xAD8 */ public float MechCockPitBobX;
+        [NMS(Index = 126)]
+        /* 0xADC */ public float MechCockPitBobY;
+        [NMS(Index = 129)]
+        /* 0xAE0 */ public float MechCockPitBobYaw;
+        [NMS(Index = 130)]
+        /* 0xAE4 */ public float MechCockPowerDownY;
+        [NMS(Index = 71)]
+        /* 0xAE8 */ public float MechCoGAdjustTimeAir;
+        [NMS(Index = 72)]
+        /* 0xAEC */ public float MechCoGAdjustTimeLand;
+        [NMS(Index = 70)]
+        /* 0xAF0 */ public float MechCoGAdjustTimeWindUp;
+        [NMS(Index = 47)]
+        /* 0xAF4 */ public float MechContrailAlpha;
+        [NMS(Index = 73)]
+        /* 0xAF8 */ public float MechCrouchTime;
+        [NMS(Index = 100)]
+        /* 0xAFC */ public float MechDefaultBlendTime;
+        [NMS(Index = 123)]
+        /* 0xB00 */ public float MechFirstPersonCrouchAmount;
+        [NMS(Index = 119)]
+        /* 0xB04 */ public float MechFirstPersonDamping;
+        [NMS(Index = 114)]
+        /* 0xB08 */ public float MechFirstPersonIgnoreReverseThreshold;
+        [NMS(Index = 122)]
+        /* 0xB0C */ public float MechFirstPersonMaxLookTurret;
+        [NMS(Index = 121)]
+        /* 0xB10 */ public float MechFirstPersonMaxTurnTurret;
+        [NMS(Index = 120)]
+        /* 0xB14 */ public float MechFirstPersonStickXModerator;
+        [NMS(Index = 118)]
+        /* 0xB18 */ public float MechFirstPersonTurretAngleThrottleStrength;
+        [NMS(Index = 117)]
+        /* 0xB1C */ public float MechFirstPersonTurretAngleThrottleThreshold;
+        [NMS(Index = 113)]
+        /* 0xB20 */ public float MechFirstPersonTurretBaseThrottleThreshold;
+        [NMS(Index = 116)]
+        /* 0xB24 */ public float MechFirstPersonTurretBaseTurnThreshold;
+        [NMS(Index = 110)]
+        /* 0xB28 */ public float MechFirstPersonTurretPitchModerator;
+        [NMS(Index = 112)]
+        /* 0xB2C */ public float MechFirstPersonTurretShootTimer;
+        [NMS(Index = 115)]
+        /* 0xB30 */ public float MechFirstPersonTurretThrottleLookThreshold;
+        [NMS(Index = 109)]
+        /* 0xB34 */ public float MechFirstPersonTurretTurnModerator;
+        [NMS(Index = 140)]
+        /* 0xB38 */ public float MechFootprintFadeDist;
+        [NMS(Index = 139)]
+        /* 0xB3C */ public float MechFootprintFadeTime;
+        [NMS(Index = 106)]
+        /* 0xB40 */ public float MechIdleLowBlendTime;
+        [NMS(Index = 107)]
+        /* 0xB44 */ public float MechIdleLowDelay;
+        [NMS(Index = 108)]
+        /* 0xB48 */ public float MechIdleStopDelay;
+        [NMS(Index = 90)]
+        /* 0xB4C */ public float MechJetpackAvoidGroundForce;
+        [NMS(Index = 92)]
+        /* 0xB50 */ public float MechJetpackAvoidGroundProbeLength;
+        [NMS(Index = 86)]
+        /* 0xB54 */ public float MechJetpackBrake;
+        [NMS(Index = 98)]
+        /* 0xB58 */ public float MechJetpackDrainRate;
+        [NMS(Index = 91)]
+        /* 0xB5C */ public float MechJetpackFallForce;
+        [NMS(Index = 99)]
+        /* 0xB60 */ public float MechJetpackFillRate;
+        [NMS(Index = 85)]
+        /* 0xB64 */ public float MechJetpackForce;
+        [NMS(Index = 93)]
+        /* 0xB68 */ public float MechJetpackIgnitionForce;
+        [NMS(Index = 94)]
+        /* 0xB6C */ public float MechJetpackIgnitionTime;
+        [NMS(Index = 48)]
+        /* 0xB70 */ public float MechJetpackJetScaleTime;
+        [NMS(Index = 84)]
+        /* 0xB74 */ public float MechJetpackLandTime;
+        [NMS(Index = 95)]
+        /* 0xB78 */ public float MechJetpackMaxCoGAdjustX;
+        [NMS(Index = 87)]
+        /* 0xB7C */ public float MechJetpackMaxSpeed;
+        [NMS(Index = 88)]
+        /* 0xB80 */ public float MechJetpackMaxUpSpeed;
+        [NMS(Index = 83)]
+        /* 0xB84 */ public float MechJetpackStrafeStrength;
+        [NMS(Index = 55)]
+        /* 0xB88 */ public float MechJetpackTurnSpeed;
+        [NMS(Index = 89)]
+        /* 0xB8C */ public float MechJetpackUpForce;
+        [NMS(Index = 103)]
+        /* 0xB90 */ public float MechJumpBlendTime;
+        [NMS(Index = 105)]
+        /* 0xB94 */ public float MechJumpDownBlendTime;
+        [NMS(Index = 104)]
+        /* 0xB98 */ public float MechJumpFlyBlendTime;
+        [NMS(Index = 102)]
+        /* 0xB9C */ public float MechLandBlendTime;
+        [NMS(Index = 82)]
+        /* 0xBA0 */ public float MechLandBrake;
+        [NMS(Index = 138)]
+        /* 0xBA4 */ public float MechLandCameraShakeDist;
+        [NMS(Index = 61)]
+        /* 0xBA8 */ public float MechMaxTurnAngleWhileStationary;
+        [NMS(Index = 53)]
+        /* 0xBAC */ public float MechPlayerGroundTurnSpeed;
+        [NMS(Index = 124)]
+        /* 0xBB0 */ public float MechPowerUpTime;
+        [NMS(Index = 242)]
+        /* 0xBB4 */ public float MechSpawnRotation;
+        [NMS(Index = 101)]
+        /* 0xBB8 */ public float MechSpeedBlendTime;
+        [NMS(Index = 137)]
+        /* 0xBBC */ public float MechTitanFallCameraShakeDist;
+        [NMS(Index = 131)]
+        /* 0xBC0 */ public float MechTitanFallHeight;
+        [NMS(Index = 135)]
+        /* 0xBC4 */ public float MechTitanFallLandIdleTime;
+        [NMS(Index = 136)]
+        /* 0xBC8 */ public float MechTitanFallLandIntroTime;
+        [NMS(Index = 134)]
+        /* 0xBCC */ public float MechTitanFallTerrainEditOffset;
+        [NMS(Index = 133)]
+        /* 0xBD0 */ public float MechTitanFallTerrainEditSize;
+        [NMS(Index = 66)]
+        /* 0xBD4 */ public float MechTurretMaxAngleAir;
+        [NMS(Index = 63)]
+        /* 0xBD8 */ public float MechTurretMaxAngleGround;
+        [NMS(Index = 67)]
+        /* 0xBDC */ public float MechTurretTimeVRModifier;
+        [NMS(Index = 65)]
+        /* 0xBE0 */ public float MechTurretTurnTimeAir;
+        [NMS(Index = 62)]
+        /* 0xBE4 */ public float MechTurretTurnTimeGround;
+        [NMS(Index = 64)]
+        /* 0xBE8 */ public float MechTurretTurnTimeGroundPlayerCombat;
+        [NMS(Index = 74)]
+        /* 0xBEC */ public float MechWalkToRunTimeIdle;
+        [NMS(Index = 75)]
+        /* 0xBF0 */ public float MechWalkToRunTimeSkid;
+        [NMS(Index = 155)]
+        /* 0xBF4 */ public float MechWeaponInterpSpeed;
+        [NMS(Index = 245)]
+        /* 0xBF8 */ public int MiningLaserDamage;
+        [NMS(Index = 205)]
+        /* 0xBFC */ public float MiningLaserDrainSpeed;
+        [NMS(Index = 244)]
+        /* 0xC00 */ public int MiningLaserMiningDamage;
+        [NMS(Index = 243)]
+        /* 0xC04 */ public float MiningLaserRadius;
+        [NMS(Index = 246)]
+        /* 0xC08 */ public float MiningLaserSpeed;
+        [NMS(Index = 206)]
+        /* 0xC0C */ public float ProjectileDrainPerShot;
+        [NMS(Index = 227)]
+        /* 0xC10 */ public float RaceCooldown;
+        [NMS(Index = 208)]
+        /* 0xC14 */ public float RaceInteractRespawnOffset;
+        [NMS(Index = 209)]
+        /* 0xC18 */ public float RaceInteractRespawnUpOffset;
+        [NMS(Index = 204)]
+        /* 0xC1C */ public float RaceMultipleStartCaptureRange;
+        [NMS(Index = 203)]
+        /* 0xC20 */ public float RaceMultipleStartOffset;
+        [NMS(Index = 229)]
+        /* 0xC24 */ public float RaceResetFlashDuration;
+        [NMS(Index = 230)]
+        /* 0xC28 */ public float RaceResetFlashIntensity;
+        [NMS(Index = 207)]
+        /* 0xC2C */ public float RaceStartSpawnUpOffset;
+        [NMS(Index = 22)]
+        /* 0xC30 */ public float RemoteBoostingEffectTimeout;
+        [NMS(Index = 251)]
+        /* 0xC34 */ public float ResourceCollectOffset;
+        [NMS(Index = 241)]
+        /* 0xC38 */ public float SpawnRotation;
+        [NMS(Index = 20)]
+        /* 0xC3C */ public float SteeringWheelCentreOffset;
+        [NMS(Index = 17)]
+        /* 0xC40 */ public float SteeringWheelPitchAngle;
+        [NMS(Index = 16)]
+        /* 0xC44 */ public float SteeringWheelPushRange;
+        [NMS(Index = 18)]
+        /* 0xC48 */ public float SteeringWheelSpringBothHands;
+        [NMS(Index = 19)]
+        /* 0xC4C */ public float SteeringWheelSpringOneHand;
+        [NMS(Index = 284)]
+        /* 0xC50 */ public float StickReverseTurnStiffness;
+        [NMS(Index = 283)]
+        /* 0xC54 */ public float StickReverseTurnThreshold;
+        [NMS(Index = 210)]
+        /* 0xC58 */ public float StickTurnReducer;
+        [NMS(Index = 213)]
+        /* 0xC5C */ public float StickTurnReducerAltNonVR;
+        [NMS(Index = 212)]
+        /* 0xC60 */ public float StickTurnReducerVR;
+        [NMS(Index = 211)]
+        /* 0xC64 */ public float StickTurnReducerWater;
+        [NMS(Index = 248)]
+        /* 0xC68 */ public int StunGunBaseDamage;
+        [NMS(Index = 249)]
+        /* 0xC6C */ public float StunGunFireRate;
+        [NMS(Index = 162)]
+        /* 0xC70 */ public float SubmarineEjectDownOffset;
+        [NMS(Index = 161)]
+        /* 0xC74 */ public float SubmarineEjectRadius;
+        [NMS(Index = 163)]
+        /* 0xC78 */ public float SubmarineFirstPersonSteeringSensitivity;
+        [NMS(Index = 160)]
+        /* 0xC7C */ public float SubmarineMinSummonDepth;
+        [NMS(Index = 225)]
+        /* 0xC80 */ public float SummoningRange;
+        [NMS(Index = 255)]
+        /* 0xC84 */ public float SuspensionDamping;
+        [NMS(Index = 256)]
+        /* 0xC88 */ public float SuspensionDampingAngularFactor;
+        [NMS(Index = 27)]
+        /* 0xC8C */ public float TestAnimBoost;
+        [NMS(Index = 26)]
+        /* 0xC90 */ public float TestAnimThrust;
+        [NMS(Index = 28)]
+        /* 0xC94 */ public float TestAnimTurn;
+        [NMS(Index = 23)]
+        /* 0xC98 */ public float TestFrictionStat;
+        [NMS(Index = 24)]
+        /* 0xC9C */ public float TestSkidFrictionStat;
+        [NMS(Index = 214)]
+        /* 0xCA0 */ public float TravelSpeedReportReducer;
+        [NMS(Index = 175)]
+        /* 0xCA4 */ public float UnderwaterBuoyancyRangeMax;
+        [NMS(Index = 174)]
+        /* 0xCA8 */ public float UnderwaterBuoyancyRangeMin;
+        [NMS(Index = 186)]
+        /* 0xCAC */ public float UnderwaterDiveForce;
+        [NMS(Index = 179)]
+        /* 0xCB0 */ public float UnderwaterFlattenMinDepth;
+        [NMS(Index = 180)]
+        /* 0xCB4 */ public float UnderwaterFlattenRange;
+        [NMS(Index = 185)]
+        /* 0xCB8 */ public float UnderwaterJumpForce;
+        [NMS(Index = 1)]
+        /* 0xCBC */ public float UnderwaterScannerIconRangeBoost;
+        [NMS(Index = 177)]
+        /* 0xCC0 */ public float UnderwaterSummonSurfaceOffset;
+        [NMS(Index = 181)]
+        /* 0xCC4 */ public float UnderwaterSurfaceForceFlatteningAngleMin;
+        [NMS(Index = 182)]
+        /* 0xCC8 */ public float UnderwaterSurfaceForceFlatteningAngleRange;
+        [NMS(Index = 178)]
+        /* 0xCCC */ public float UnderwaterSurfaceOffset;
+        [NMS(Index = 183)]
+        /* 0xCD0 */ public float UnderwaterSurfaceSplashdownForce;
+        [NMS(Index = 184)]
+        /* 0xCD4 */ public float UnderwaterSurfaceSplashdownMinSpeed;
+        [NMS(Index = 191)]
+        /* 0xCD8 */ public float VehicleAltControlStickSmoothInTime;
+        [NMS(Index = 192)]
+        /* 0xCDC */ public float VehicleAltControlStickSmoothOutTime;
+        [NMS(Index = 273)]
+        /* 0xCE0 */ public float VehicleBoostFuelRate;
+        [NMS(Index = 274)]
+        /* 0xCE4 */ public float VehicleBoostFuelRateSurvival;
+        [NMS(Index = 193)]
+        /* 0xCE8 */ public float VehicleBoostSpeedMultiplierPercent;
+        [NMS(Index = 0)]
+        /* 0xCEC */ public float VehicleCollisionScaleFactor;
+        [NMS(Index = 272)]
+        /* 0xCF0 */ public float VehicleDeactivateRange;
+        [NMS(Index = 268)]
+        /* 0xCF4 */ public float VehicleFadeTime;
+        [NMS(Index = 275)]
+        /* 0xCF8 */ public float VehicleFuelRate;
+        [NMS(Index = 276)]
+        /* 0xCFC */ public float VehicleFuelRateTruckMultiplier;
+        [NMS(Index = 195)]
+        /* 0xD00 */ public float VehicleGarageHologramFadeRange;
+        [NMS(Index = 194)]
+        /* 0xD04 */ public float VehicleGarageHologramMinFadeRange;
+        [NMS(Index = 279)]
+        /* 0xD08 */ public float VehicleJumpCooldown;
+        [NMS(Index = 278)]
+        /* 0xD0C */ public float VehicleJumpTimeMax;
+        [NMS(Index = 277)]
+        /* 0xD10 */ public float VehicleJumpTimeMin;
+        [NMS(Index = 270)]
+        /* 0xD14 */ public float VehicleMaxSummonDistance;
+        [NMS(Index = 271)]
+        /* 0xD18 */ public float VehicleMaxSummonDistanceUnderwater;
+        [NMS(Index = 269)]
+        /* 0xD1C */ public float VehicleMinSummonDistance;
+        [NMS(Index = 280)]
+        /* 0xD20 */ public float VehicleMotionDeadZone;
+        [NMS(Index = 2)]
+        /* 0xD24 */ public float VehicleSolarRegenFactor;
+        [NMS(Index = 265)]
+        /* 0xD28 */ public float VehicleSuspensionAudioDelay;
+        [NMS(Index = 266)]
+        /* 0xD2C */ public float VehicleSuspensionAudioScale;
+        [NMS(Index = 264)]
+        /* 0xD30 */ public float VehicleSuspensionAudioSpacing;
+        [NMS(Index = 267)]
+        /* 0xD34 */ public float VehicleSuspensionAudioTrigger;
+        [NMS(Index = 261)]
+        /* 0xD38 */ public float VehicleTextSize;
+        [NMS(Index = 252)]
+        /* 0xD3C */ public float VehicleWheelNoise;
+        [NMS(Index = 253)]
+        /* 0xD40 */ public float VehicleWheelNoiseScale;
+        [NMS(Index = 32)]
+        /* 0xD44 */ public float VignetteAmountAcceleration;
+        [NMS(Index = 33)]
+        /* 0xD48 */ public float VignetteAmountTurning;
+        [NMS(Index = 30)]
+        /* 0xD4C */ public float VisualRollUnderwaterSpring;
+        [NMS(Index = 31)]
+        /* 0xD50 */ public float VisualTurnSpring;
+        [NMS(Index = 29)]
+        /* 0xD54 */ public float VisualTurnUnderwaterSpring;
+        [NMS(Index = 159)]
+        /* 0xD58 */ public float WeaponInterpSpeed;
+        [NMS(Index = 35)]
+        /* 0xD5C */ public float WheelDustColourLightFactor;
+        [NMS(Index = 281)]
+        /* 0xD60 */ public float WheelForceHalflife;
+        [NMS(Index = 254)]
+        /* 0xD64 */ public float WheelSideVerticalFactor;
+        [NMS(Index = 156, Size = 0x5, EnumType = typeof(GcMechWeaponLocation.MechWeaponLocationEnum))]
+        /* 0xD68 */ public NMSString0x20[] MechWeaponLocatorNames;
+        [NMS(Index = 46)]
+        /* 0xE08 */ public bool MechAltJumpMode;
+        [NMS(Index = 81)]
+        /* 0xE09 */ public TkCurveType MechArmSwingCurveFastWalk;
+        [NMS(Index = 78)]
+        /* 0xE0A */ public TkCurveType MechArmSwingCurveWalk;
+        [NMS(Index = 40)]
+        /* 0xE0B */ public bool MechCanUpdateMeshWhileMaintenanceUIActive;
+        [NMS(Index = 111)]
+        /* 0xE0C */ public bool MechFirstPersonTurretTweaksEnabled;
+        [NMS(Index = 45)]
+        /* 0xE0D */ public bool MechStrafeEnabled;
+        [NMS(Index = 132)]
+        /* 0xE0E */ public bool MechTitanFallTerrainEditEnabled;
+        [NMS(Index = 228)]
+        /* 0xE0F */ public bool RaceFinishAtStart;
+        [NMS(Index = 14)]
+        /* 0xE10 */ public bool ShowAllCheckpoints;
+        [NMS(Index = 257)]
+        /* 0xE11 */ public bool ShowTempVehicleMesh;
+        [NMS(Index = 258)]
+        /* 0xE12 */ public bool ShowVehicleDebugging;
         [NMS(Index = 262)]
-        /* 0xE18 */ public bool VehicleDrawAudioDebug;
+        /* 0xE13 */ public bool ShowVehicleParticleDebug;
+        [NMS(Index = 260)]
+        /* 0xE14 */ public bool ShowVehicleText;
+        [NMS(Index = 259)]
+        /* 0xE15 */ public bool ShowVehicleWheelGuards;
+        [NMS(Index = 21)]
+        /* 0xE16 */ public TkCurveType SteeringWheelOutputCurve;
+        [NMS(Index = 25)]
+        /* 0xE17 */ public bool TestAnims;
+        [NMS(Index = 282)]
+        /* 0xE18 */ public bool ThrottleButtonCamRelative;
+        [NMS(Index = 176)]
+        /* 0xE19 */ public TkCurveType UnderwaterBuoyancyDepthCurve;
+        [NMS(Index = 12)]
+        /* 0xE1A */ public bool UseFirstPersonCamera;
+        [NMS(Index = 190)]
+        /* 0xE1B */ public bool VehicleAltControlScheme;
+        [NMS(Index = 263)]
+        /* 0xE1C */ public bool VehicleDrawAudioDebug;
     }
 }

--- a/libMBIN/Source/NMS/Toolkit/TkAnim2dBlendNode.cs
+++ b/libMBIN/Source/NMS/Toolkit/TkAnim2dBlendNode.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace libMBIN.NMS.Toolkit
 {
-    [NMS(GUID = 0x866FFBC9318E6C6F, NameHash = 0xA7619C09)]
+    [NMS(GUID = 0xA7C01CB35B294521, NameHash = 0xA7619C09)]
     public class TkAnim2dBlendNode : NMSTemplate
     {
         [NMS(Index = 0)]
@@ -22,21 +22,27 @@ namespace libMBIN.NMS.Toolkit
         /* 0x5D */ public bool SelectBlend;
         [NMS(Index = 7)]
         /* 0x60 */ public float SelectBlendSpring;
+        [NMS(Index = 8)]
+        /* 0x64 */ public bool PolarInputInterpolation;
+        [NMS(Index = 9)]
+        /* 0x68 */ public float PolarInputLimitCentre;
+        [NMS(Index = 10)]
+        /* 0x6C */ public float PolarInputLimitExtent;
         // size: 0x2
         public enum CoordinatesEnum : uint {
             Polar,
             Cartesian,
         }
-        [NMS(Index = 8)]
-        /* 0x64 */ public CoordinatesEnum Coordinates;
+        [NMS(Index = 11)]
+        /* 0x70 */ public CoordinatesEnum Coordinates;
         // size: 0x2
         public enum BlendOpEnum : uint {
             Blend,
             Add,
         }
-        [NMS(Index = 9)]
-        /* 0x68 */ public BlendOpEnum BlendOp;
-        [NMS(Index = 10)]
-        /* 0x70 */ public List<TkAnim2dBlendNodeData> BlendChildren;
+        [NMS(Index = 12)]
+        /* 0x74 */ public BlendOpEnum BlendOp;
+        [NMS(Index = 13)]
+        /* 0x78 */ public List<TkAnim2dBlendNodeData> BlendChildren;
     }
 }

--- a/libMBIN/Source/NMS/Toolkit/TkGeometryData.cs
+++ b/libMBIN/Source/NMS/Toolkit/TkGeometryData.cs
@@ -6,7 +6,7 @@ using System.Reflection;
 
 namespace libMBIN.NMS.Toolkit
 {
-    [NMS(GUID = 0xED9C2FCDA6D4B22F, NameHash = 0x819C3220)]
+    [NMS(GUID = 0xE2C133EF90E9F7A3, NameHash = 0x819C3220)]
     public class TkGeometryData : NMSTemplate
     {
         [NMS(Index = 20)]

--- a/libMBIN/Source/NMS/Toolkit/TkNGuiEditorStyleData.cs
+++ b/libMBIN/Source/NMS/Toolkit/TkNGuiEditorStyleData.cs
@@ -3,24 +3,24 @@ using System.Collections.Generic;
 
 namespace libMBIN.NMS.Toolkit
 {
-    [NMS(GUID = 0x309B0C1094EFDDC3, NameHash = 0xE9E49954)]
+    [NMS(GUID = 0x212A1F0AF74BB604, NameHash = 0xE9E49954)]
     public class TkNGuiEditorStyleData : NMSTemplate
     {
-        [NMS(Index = 4, Size = 0x5F, EnumType = typeof(TkNGuiEditorGraphicType.NGuiEditorGraphicEnum))]
-        /* 0x0000 */ public TkNGuiGraphicStyle[] GraphicStyles;
-        [NMS(Index = 5, Size = 0xF, EnumType = typeof(TKNGuiEditorTextType.NGuiEditorTextEnum))]
-        /* 0xD5C0 */ public TkNGuiTextStyle[] TextStyles;
         [NMS(Index = 1, Size = 0x8, MxmlName = "Skin Colours")]
-        /* 0xE6A0 */ public TkNGuiEditorStyleColour[] SkinColours;
+        /* 0x0000 */ public TkNGuiEditorStyleColour[] SkinColours;
         [NMS(Index = 3)]
-        /* 0xEB20 */ public VariableSizeString Font;
+        /* 0x0480 */ public VariableSizeString Font;
         [NMS(Index = 7)]
-        /* 0xEB30 */ public List<TkNGuiLayoutShortcut> LayoutShortcuts;
+        /* 0x0490 */ public List<TkNGuiLayoutShortcut> LayoutShortcuts;
         [NMS(Index = 6)]
-        /* 0xEB40 */ public List<float> SnapSettings;
+        /* 0x04A0 */ public List<float> SnapSettings;
+        [NMS(Index = 4, Size = 0x5F, EnumType = typeof(TkNGuiEditorGraphicType.NGuiEditorGraphicEnum))]
+        /* 0x04B0 */ public TkNGuiGraphicStyle[] GraphicStyles;
+        [NMS(Index = 5, Size = 0xF, EnumType = typeof(TKNGuiEditorTextType.NGuiEditorTextEnum))]
+        /* 0x9330 */ public TkNGuiTextStyle[] TextStyles;
         [NMS(Index = 0, Size = 0x41, EnumType = typeof(TKNGuiEditorComponentSize.NGuiEditorComponentSizeEnum))]
-        /* 0xEB50 */ public float[] Sizes;
+        /* 0x9C54 */ public float[] Sizes;
         [NMS(Index = 2, MxmlName = "Skin Font Height")]
-        /* 0xEC54 */ public float SkinFontHeight;
+        /* 0x9D58 */ public float SkinFontHeight;
     }
 }

--- a/libMBIN/Source/NMS/Toolkit/TkNGuiGraphicStyle.cs
+++ b/libMBIN/Source/NMS/Toolkit/TkNGuiGraphicStyle.cs
@@ -2,19 +2,19 @@ using libMBIN.NMS.Toolkit;
 
 namespace libMBIN.NMS.Toolkit
 {
-    [NMS(GUID = 0x79AA9AF064027FF8, NameHash = 0x80EBCD8A)]
+    [NMS(GUID = 0x1B5D669E28609266, NameHash = 0x80EBCD8A)]
     public class TkNGuiGraphicStyle : NMSTemplate
     {
         [NMS(Index = 2)]
         /* 0x000 */ public TkNGuiGraphicStyleData Active;
         [NMS(Index = 0)]
-        /* 0x0B0 */ public TkNGuiGraphicStyleData Default;
+        /* 0x070 */ public TkNGuiGraphicStyleData Default;
         [NMS(Index = 1)]
-        /* 0x160 */ public TkNGuiGraphicStyleData Highlight;
+        /* 0x0E0 */ public TkNGuiGraphicStyleData Highlight;
         [NMS(Index = 15)]
-        /* 0x210 */ public Vector2f CustomMaxStart;
+        /* 0x150 */ public Vector2f CustomMaxStart;
         [NMS(Index = 14)]
-        /* 0x218 */ public Vector2f CustomMinStart;
+        /* 0x158 */ public Vector2f CustomMinStart;
         // size: 0x6
         public enum AnimateEnum : uint {
             None,
@@ -25,26 +25,26 @@ namespace libMBIN.NMS.Toolkit
             CustomWipeAlpha,
         }
         [NMS(Index = 9)]
-        /* 0x220 */ public AnimateEnum Animate;
+        /* 0x160 */ public AnimateEnum Animate;
         [NMS(Index = 11)]
-        /* 0x224 */ public float AnimSplit;
+        /* 0x164 */ public float AnimSplit;
         [NMS(Index = 10)]
-        /* 0x228 */ public float AnimTime;
+        /* 0x168 */ public float AnimTime;
         [NMS(Index = 8)]
-        /* 0x22C */ public float GlobalFade;
+        /* 0x16C */ public float GlobalFade;
         [NMS(Index = 7)]
-        /* 0x230 */ public float HighlightScale;
+        /* 0x170 */ public float HighlightScale;
         [NMS(Index = 6)]
-        /* 0x234 */ public float HighlightTime;
+        /* 0x174 */ public float HighlightTime;
         [NMS(Index = 12)]
-        /* 0x238 */ public TkCurveType AnimCurve1;
+        /* 0x178 */ public TkCurveType AnimCurve1;
         [NMS(Index = 13)]
-        /* 0x239 */ public TkCurveType AnimCurve2;
+        /* 0x179 */ public TkCurveType AnimCurve2;
         [NMS(Index = 5)]
-        /* 0x23A */ public bool DistributeChildrenHeight;
+        /* 0x17A */ public bool DistributeChildrenHeight;
         [NMS(Index = 4)]
-        /* 0x23B */ public bool DistributeChildrenWidth;
+        /* 0x17B */ public bool DistributeChildrenWidth;
         [NMS(Index = 3)]
-        /* 0x23C */ public bool InheritStyleFromParentLayer;
+        /* 0x17C */ public bool InheritStyleFromParentLayer;
     }
 }

--- a/libMBIN/Source/NMS/Toolkit/TkNGuiGraphicStyleData.cs
+++ b/libMBIN/Source/NMS/Toolkit/TkNGuiGraphicStyleData.cs
@@ -2,47 +2,47 @@ using libMBIN.NMS.Toolkit;
 
 namespace libMBIN.NMS.Toolkit
 {
-    [NMS(GUID = 0x8F024C7F5B7460BD, NameHash = 0x93482A51)]
+    [NMS(GUID = 0x62442BDF65EFB91D, NameHash = 0x93482A51)]
     public class TkNGuiGraphicStyleData : NMSTemplate
     {
-        [NMS(Index = 0)]
-        /* 0x00 */ public Colour Colour;
-        [NMS(Index = 3, MxmlName = "Gradient Colour")]
-        /* 0x10 */ public Colour GradientColour;
-        [NMS(Index = 1, MxmlName = "Icon Colour")]
-        /* 0x20 */ public Colour IconColour;
-        [NMS(Index = 2, MxmlName = "Stroke Colour")]
-        /* 0x30 */ public Colour StrokeColour;
-        [NMS(Index = 4, MxmlName = "Stroke Gradient Colour")]
-        /* 0x40 */ public Colour StrokeGradientColour;
         [NMS(Index = 26)]
-        /* 0x50 */ public TkNGuiGraphicAnimatedImageData Animated;
+        /* 0x00 */ public TkNGuiGraphicAnimatedImageData Animated;
         [NMS(Index = 11, MxmlName = "Corner Radius")]
-        /* 0x70 */ public float CornerRadius;
+        /* 0x20 */ public float CornerRadius;
         [NMS(Index = 15)]
-        /* 0x74 */ public float Desaturation;
+        /* 0x24 */ public float Desaturation;
         [NMS(Index = 14)]
-        /* 0x78 */ public TkNGuiEditorIcons EditorIcon;
+        /* 0x28 */ public TkNGuiEditorIcons EditorIcon;
         [NMS(Index = 10, MxmlName = "Gradient End Offset")]
-        /* 0x7C */ public float GradientEndOffset;
+        /* 0x2C */ public float GradientEndOffset;
         [NMS(Index = 9, MxmlName = "Gradient Start Offset")]
-        /* 0x80 */ public float GradientStartOffset;
+        /* 0x30 */ public float GradientStartOffset;
         [NMS(Index = 13)]
-        /* 0x84 */ public int Image;
+        /* 0x34 */ public int Image;
         [NMS(Index = 7)]
-        /* 0x88 */ public float MarginX;
+        /* 0x38 */ public float MarginX;
         [NMS(Index = 8)]
-        /* 0x8C */ public float MarginY;
+        /* 0x3C */ public float MarginY;
         [NMS(Index = 5)]
-        /* 0x90 */ public float PaddingX;
+        /* 0x40 */ public float PaddingX;
         [NMS(Index = 6)]
-        /* 0x94 */ public float PaddingY;
+        /* 0x44 */ public float PaddingY;
         [NMS(Index = 17, MxmlName = "Stroke Gradient Feather")]
-        /* 0x98 */ public float StrokeGradientFeather;
+        /* 0x48 */ public float StrokeGradientFeather;
         [NMS(Index = 16, MxmlName = "Stroke Gradient Offset")]
-        /* 0x9C */ public float StrokeGradientOffset;
+        /* 0x4C */ public float StrokeGradientOffset;
         [NMS(Index = 12, MxmlName = "Stroke Size")]
-        /* 0xA0 */ public float StrokeSize;
+        /* 0x50 */ public float StrokeSize;
+        [NMS(Index = 0)]
+        /* 0x54 */ public Colour32 Colour;
+        [NMS(Index = 3, MxmlName = "Gradient Colour")]
+        /* 0x58 */ public Colour32 GradientColour;
+        [NMS(Index = 1, MxmlName = "Icon Colour")]
+        /* 0x5C */ public Colour32 IconColour;
+        [NMS(Index = 2, MxmlName = "Stroke Colour")]
+        /* 0x60 */ public Colour32 StrokeColour;
+        [NMS(Index = 4, MxmlName = "Stroke Gradient Colour")]
+        /* 0x64 */ public Colour32 StrokeGradientColour;
         // size: 0x6
         public enum GradientEnum : byte {
             None,
@@ -53,15 +53,15 @@ namespace libMBIN.NMS.Toolkit
             Box,
         }
         [NMS(Index = 19)]
-        /* 0xA4 */ public GradientEnum Gradient;
+        /* 0x68 */ public GradientEnum Gradient;
         [NMS(Index = 24, MxmlName = "Gradient Offset Percent")]
-        /* 0xA5 */ public bool GradientOffsetPercent;
+        /* 0x69 */ public bool GradientOffsetPercent;
         [NMS(Index = 21, MxmlName = "Has Drop Shadow")]
-        /* 0xA6 */ public bool HasDropShadow;
+        /* 0x6A */ public bool HasDropShadow;
         [NMS(Index = 23, MxmlName = "Has Inner Gradient")]
-        /* 0xA7 */ public bool HasInnerGradient;
+        /* 0x6B */ public bool HasInnerGradient;
         [NMS(Index = 22, MxmlName = "Has Outer Gradient")]
-        /* 0xA8 */ public bool HasOuterGradient;
+        /* 0x6C */ public bool HasOuterGradient;
         // size: 0x8
         public enum ShapeEnum : byte {
             Rectangle,
@@ -74,10 +74,10 @@ namespace libMBIN.NMS.Toolkit
             BezierWideInverted,
         }
         [NMS(Index = 18)]
-        /* 0xA9 */ public ShapeEnum Shape;
+        /* 0x6D */ public ShapeEnum Shape;
         [NMS(Index = 20, MxmlName = "Solid Colour")]
-        /* 0xAA */ public bool SolidColour;
+        /* 0x6E */ public bool SolidColour;
         [NMS(Index = 25, MxmlName = "Stroke Gradient")]
-        /* 0xAB */ public bool StrokeGradient;
+        /* 0x6F */ public bool StrokeGradient;
     }
 }

--- a/libMBIN/Source/NMS/Toolkit/TkNGuiTextStyle.cs
+++ b/libMBIN/Source/NMS/Toolkit/TkNGuiTextStyle.cs
@@ -2,14 +2,14 @@ using libMBIN.NMS.Toolkit;
 
 namespace libMBIN.NMS.Toolkit
 {
-    [NMS(GUID = 0x884AFFCD55C5B919, NameHash = 0x6D1FFAE5)]
+    [NMS(GUID = 0x65DD5ECD4CE3B7B0, NameHash = 0x6D1FFAE5)]
     public class TkNGuiTextStyle : NMSTemplate
     {
         [NMS(Index = 2)]
         /* 0x00 */ public TkNGuiTextStyleData Active;
         [NMS(Index = 0)]
-        /* 0x60 */ public TkNGuiTextStyleData Default;
+        /* 0x34 */ public TkNGuiTextStyleData Default;
         [NMS(Index = 1)]
-        /* 0xC0 */ public TkNGuiTextStyleData Highlight;
+        /* 0x68 */ public TkNGuiTextStyleData Highlight;
     }
 }

--- a/libMBIN/Source/NMS/Toolkit/TkNGuiTextStyleData.cs
+++ b/libMBIN/Source/NMS/Toolkit/TkNGuiTextStyleData.cs
@@ -2,52 +2,52 @@ using libMBIN.NMS.Toolkit;
 
 namespace libMBIN.NMS.Toolkit
 {
-    [NMS(GUID = 0x73126CE46AE90B56, NameHash = 0x903BF7DD)]
+    [NMS(GUID = 0x3D9E72845056C24D, NameHash = 0x903BF7DD)]
     public class TkNGuiTextStyleData : NMSTemplate
     {
-        [NMS(Index = 0)]
-        /* 0x00 */ public Colour Colour;
-        [NMS(Index = 2, MxmlName = "Outline Colour")]
-        /* 0x10 */ public Colour OutlineColour;
-        [NMS(Index = 1, MxmlName = "Shadow Colour")]
-        /* 0x20 */ public Colour ShadowColour;
         [NMS(Index = 5, MxmlName = "Drop Shadow Angle")]
-        /* 0x30 */ public float DropShadowAngle;
+        /* 0x00 */ public float DropShadowAngle;
         [NMS(Index = 6, MxmlName = "Drop Shadow Offset")]
-        /* 0x34 */ public float DropShadowOffset;
+        /* 0x04 */ public float DropShadowOffset;
         [NMS(Index = 3, MxmlName = "Font Height")]
-        /* 0x38 */ public float FontHeight;
+        /* 0x08 */ public float FontHeight;
         [NMS(Index = 8, MxmlName = "Font Index")]
-        /* 0x3C */ public int FontIndex;
+        /* 0x0C */ public int FontIndex;
         [NMS(Index = 4, MxmlName = "Font Spacing")]
-        /* 0x40 */ public float FontSpacing;
+        /* 0x10 */ public float FontSpacing;
         [NMS(Index = 7, MxmlName = "Outline Size")]
-        /* 0x44 */ public float OutlineSize;
+        /* 0x14 */ public float OutlineSize;
+        [NMS(Index = 0)]
+        /* 0x18 */ public Colour32 Colour;
+        [NMS(Index = 2, MxmlName = "Outline Colour")]
+        /* 0x1C */ public Colour32 OutlineColour;
+        [NMS(Index = 1, MxmlName = "Shadow Colour")]
+        /* 0x20 */ public Colour32 ShadowColour;
         [NMS(Index = 9)]
-        /* 0x48 */ public TkNGuiAlignment Align;
+        /* 0x24 */ public TkNGuiAlignment Align;
         [NMS(Index = 14, MxmlName = "Allow Scroll")]
-        /* 0x4A */ public bool AllowScroll;
+        /* 0x26 */ public bool AllowScroll;
         [NMS(Index = 17, MxmlName = "Auto Adjust Font Height")]
-        /* 0x4B */ public bool AutoAdjustFontHeight;
+        /* 0x27 */ public bool AutoAdjustFontHeight;
         [NMS(Index = 16, MxmlName = "Auto Adjust Height")]
-        /* 0x4C */ public bool AutoAdjustHeight;
+        /* 0x28 */ public bool AutoAdjustHeight;
         [NMS(Index = 18, MxmlName = "Block Audio")]
-        /* 0x4D */ public bool BlockAudio;
+        /* 0x29 */ public bool BlockAudio;
         [NMS(Index = 19, MxmlName = "Bypass Style Colours")]
-        /* 0x4E */ public bool BypassStyleColours;
+        /* 0x2A */ public bool BypassStyleColours;
         [NMS(Index = 20, MxmlName = "Bypass Style Font")]
-        /* 0x4F */ public bool BypassStyleFont;
+        /* 0x2B */ public bool BypassStyleFont;
         [NMS(Index = 21, MxmlName = "Bypass Style Font Height")]
-        /* 0x50 */ public bool BypassStyleFontHeight;
+        /* 0x2C */ public bool BypassStyleFontHeight;
         [NMS(Index = 15, MxmlName = "Force Upper Case")]
-        /* 0x51 */ public bool ForceUpperCase;
+        /* 0x2D */ public bool ForceUpperCase;
         [NMS(Index = 11, MxmlName = "Has Drop Shadow")]
-        /* 0x52 */ public bool HasDropShadow;
+        /* 0x2E */ public bool HasDropShadow;
         [NMS(Index = 12, MxmlName = "Has Outline")]
-        /* 0x53 */ public bool HasOutline;
+        /* 0x2F */ public bool HasOutline;
         [NMS(Index = 10, MxmlName = "Is Indented")]
-        /* 0x54 */ public bool IsIndented;
+        /* 0x30 */ public bool IsIndented;
         [NMS(Index = 13, MxmlName = "Is Paragraph")]
-        /* 0x55 */ public bool IsParagraph;
+        /* 0x31 */ public bool IsParagraph;
     }
 }

--- a/libMBIN/Source/NMS/Toolkit/TkTestMetadata.cs
+++ b/libMBIN/Source/NMS/Toolkit/TkTestMetadata.cs
@@ -5,56 +5,56 @@ using System;
 
 namespace libMBIN.NMS.Toolkit
 {
-    [NMS(GUID = 0xDCD9AF07B412ED7E, NameHash = 0x69A0FDE1)]
+    [NMS(GUID = 0x547A3B81BB412A15, NameHash = 0x69A0FDE1)]
     public class TkTestMetadata : NMSTemplate
     {
-        [NMS(Index = 45)]
+        [NMS(Index = 46)]
         /* 0x0000 */ public Vector3f DocOptionalVector;
         [NMS(Index = 5)]
         /* 0x0010 */ public Colour TestColour;
-        [NMS(Index = 41)]
-        /* 0x0020 */ public Vector3f TestVector;
         [NMS(Index = 42)]
+        /* 0x0020 */ public Vector3f TestVector;
+        [NMS(Index = 43)]
         /* 0x0030 */ public Vector4f TestVector4;
         [NMS(Index = 2)]
         /* 0x0040 */ public TkTrophyEntry TestClass;
-        [NMS(Index = 51)]
+        [NMS(Index = 52)]
         /* 0x00B8 */ public HashMap<TkLocalisationEntry> TestHashMap;
-        [NMS(Index = 47)]
+        [NMS(Index = 48)]
         /* 0x00E8 */ public NMSString0x20A DocOptionalRenamed;
-        [NMS(Index = 19)]
-        /* 0x0108 */ public NMSString0x20A TestID256;
         [NMS(Index = 20)]
+        /* 0x0108 */ public NMSString0x20A TestID256;
+        [NMS(Index = 21)]
         /* 0x0128 */ public NMSString0x20A TestLocID;
-        [NMS(Index = 8)]
+        [NMS(Index = 9)]
         /* 0x0148 */ public HashedString TestHashedString;
         [NMS(Index = 3)]
         /* 0x0160 */ public NMSTemplate TestClassPointer;
-        [NMS(Index = 6)]
-        /* 0x0170 */ public List<float> TestDynamicArray;
         [NMS(Index = 7)]
+        /* 0x0170 */ public List<float> TestDynamicArray;
+        [NMS(Index = 8)]
         /* 0x0180 */ public VariableSizeString TestDynamicString;
-        [NMS(Index = 18)]
+        [NMS(Index = 19)]
         /* 0x0190 */ public NMSString0x10 TestID;
-        [NMS(Index = 43)]
+        [NMS(Index = 44)]
         /* 0x01A0 */ public NMSString0x10 TestIDLookup;
         [NMS(Index = 4)]
         /* 0x01B0 */ public List<LinkableNMSTemplate> TestLinkableClassPointerArray;
-        [NMS(Index = 14)]
-        /* 0x01C0 */ public VariableSizeString TestModelFilename;
-        [NMS(Index = 27)]
-        /* 0x01D0 */ public GcSeed TestSeed;
         [NMS(Index = 15)]
+        /* 0x01C0 */ public VariableSizeString TestModelFilename;
+        [NMS(Index = 28)]
+        /* 0x01D0 */ public GcSeed TestSeed;
+        [NMS(Index = 16)]
         /* 0x01E0 */ public VariableSizeString TestTextureFilename;
-        [NMS(Index = 24)]
+        [NMS(Index = 25)]
         /* 0x01F0 */ public long TestInt64;
-        [NMS(Index = 38)]
-        /* 0x01F8 */ public ulong TestUInt64;
         [NMS(Index = 39)]
+        /* 0x01F8 */ public ulong TestUInt64;
+        [NMS(Index = 40)]
         /* 0x0200 */ public ulong TestUniqueId;
-        [NMS(Index = 28, Size = 0xA)]
+        [NMS(Index = 29, Size = 0xA)]
         /* 0x0208 */ public float[] TestStaticArray;
-        [NMS(Index = 50, Size = 0x5, EnumType = typeof(TkEqualityEnum.EqualityEnumEnum))]
+        [NMS(Index = 51, Size = 0x5, EnumType = typeof(TkEqualityEnum.EqualityEnumEnum))]
         /* 0x0230 */ public float[] TestExternalEnumArray;
         // size: 0x4
         public enum TestEnumArrayEnum {
@@ -63,9 +63,9 @@ namespace libMBIN.NMS.Toolkit
             Option2,
             Option3,
         }
-        [NMS(Index = 49, Size = 0x4, EnumType = typeof(TestEnumArrayEnum))]
+        [NMS(Index = 50, Size = 0x4, EnumType = typeof(TestEnumArrayEnum))]
         /* 0x0244 */ public float[] TestEnumArray;
-        [NMS(Index = 40)]
+        [NMS(Index = 41)]
         /* 0x0254 */ public Vector2f TestVector2;
         // size: 0x4
         public enum DocOptionalEnumEnum : uint {
@@ -74,9 +74,9 @@ namespace libMBIN.NMS.Toolkit
             SomeValue3,
             SomeValue4,
         }
-        [NMS(Index = 48)]
+        [NMS(Index = 49)]
         /* 0x025C */ public DocOptionalEnumEnum DocOptionalEnum;
-        [NMS(Index = 44)]
+        [NMS(Index = 45)]
         /* 0x0260 */ public GcAudioWwiseEvents TestAudioEvent;
         // size: 0x4
         public enum TestEnumEnum : uint {
@@ -85,7 +85,7 @@ namespace libMBIN.NMS.Toolkit
             Option2,
             Option3,
         }
-        [NMS(Index = 9)]
+        [NMS(Index = 10)]
         /* 0x0264 */ public TestEnumEnum TestEnum;
         // size: 0x4
         public enum TestEnumUInt32BitFieldEnum : uint {
@@ -94,9 +94,9 @@ namespace libMBIN.NMS.Toolkit
             Enum3 = 0x4,
             None = 0x0,
         }
-        [NMS(Index = 11)]
+        [NMS(Index = 12)]
         /* 0x0268 */ public TestEnumUInt32BitFieldEnum TestEnumUInt32BitField;
-        [NMS(Index = 13)]
+        [NMS(Index = 14)]
         /* 0x026C */ public TkLanguages TestExternalEnum;
         // size: 0x4
         [Flags]
@@ -106,9 +106,9 @@ namespace libMBIN.NMS.Toolkit
             Flag2 = 0x2,
             Flag3 = 0x4,
         }
-        [NMS(Index = 16)]
-        /* 0x0270 */ public TestFlagsEnum TestFlags;
         [NMS(Index = 17)]
+        /* 0x0270 */ public TestFlagsEnum TestFlags;
+        [NMS(Index = 18)]
         /* 0x0274 */ public float TestFloat;
         // size: 0x3
         public enum TestInlineEnumEnum : uint {
@@ -116,49 +116,51 @@ namespace libMBIN.NMS.Toolkit
             NotDefault,
             Other,
         }
-        [NMS(Index = 12)]
+        [NMS(Index = 13)]
         /* 0x0278 */ public TestInlineEnumEnum TestInlineEnum;
-        [NMS(Index = 23)]
+        [NMS(Index = 24)]
         /* 0x027C */ public int TestInt;
-        [NMS(Index = 25)]
-        /* 0x0280 */ public GcNodeID TestNodeHandle;
         [NMS(Index = 26)]
+        /* 0x0280 */ public GcNodeID TestNodeHandle;
+        [NMS(Index = 27)]
         /* 0x0284 */ public GcResource TestResource;
-        [NMS(Index = 37)]
+        [NMS(Index = 38)]
         /* 0x0288 */ public uint TestUInt32;
-        [NMS(Index = 22)]
+        [NMS(Index = 23)]
         /* 0x028C */ public short TestInt16;
-        [NMS(Index = 36)]
+        [NMS(Index = 37)]
         /* 0x028E */ public ushort TestUInt16;
-        [NMS(Index = 35)]
+        [NMS(Index = 36)]
         /* 0x0290 */ public NMSString0x800 TestString2048;
-        [NMS(Index = 34)]
+        [NMS(Index = 35)]
         /* 0x0A90 */ public NMSString0x400 TestString1024;
-        [NMS(Index = 33)]
+        [NMS(Index = 34)]
         /* 0x0E90 */ public NMSString0x200 TestString512;
-        [NMS(Index = 32)]
+        [NMS(Index = 33)]
         /* 0x1090 */ public NMSString0x100 TestString256;
-        [NMS(Index = 31)]
+        [NMS(Index = 32)]
         /* 0x1190 */ public NMSString0x80 TestString128;
-        [NMS(Index = 46)]
+        [NMS(Index = 47)]
         /* 0x1210 */ public NMSString0x40 DocRenamedString64;
-        [NMS(Index = 30)]
+        [NMS(Index = 31)]
         /* 0x1250 */ public NMSString0x40 TestString64;
-        [NMS(Index = 29)]
+        [NMS(Index = 30)]
         /* 0x1290 */ public NMSString0x20 TestString;
+        [NMS(Index = 6)]
+        /* 0x12B0 */ public Colour32 TestColour32;
         [NMS(Index = 0)]
-        /* 0x12B0 */ public bool TestBool;
+        /* 0x12B4 */ public bool TestBool;
         [NMS(Index = 1)]
-        /* 0x12B1 */ public byte TestByte;
+        /* 0x12B5 */ public byte TestByte;
         // size: 0x3
         public enum TestEnumUInt8Enum : byte {
             Enum1,
             Enum2,
             Enum3,
         }
-        [NMS(Index = 10)]
-        /* 0x12B2 */ public TestEnumUInt8Enum TestEnumUInt8;
-        [NMS(Index = 21)]
-        /* 0x12B3 */ public sbyte TestInt8;
+        [NMS(Index = 11)]
+        /* 0x12B6 */ public TestEnumUInt8Enum TestEnumUInt8;
+        [NMS(Index = 22)]
+        /* 0x12B7 */ public sbyte TestInt8;
     }
 }

--- a/libMBIN/Source/NMS/Toolkit/TkVertexElement.cs
+++ b/libMBIN/Source/NMS/Toolkit/TkVertexElement.cs
@@ -1,26 +1,24 @@
 namespace libMBIN.NMS.Toolkit
 {
-    [NMS(GUID = 0x97808CB98AF5876A, NameHash = 0xC4D67634)]
+    [NMS(GUID = 0x7B45114B1556765A, NameHash = 0xC4D67634)]
     public class TkVertexElement : NMSTemplate
     {
-        [NMS(Index = 6)]
-        /* 0x00 */ public long PlatformData;
         // size: 0x2
         public enum InstancingEnum : uint {
             PerVertex,
             PerModel,
         }
         [NMS(Index = 5)]
-        /* 0x08 */ public InstancingEnum Instancing;
-        [NMS(Index = 4)]
-        /* 0x0C */ public int Normalise;
-        [NMS(Index = 3)]
-        /* 0x10 */ public int Offset;
+        /* 0x0 */ public InstancingEnum Instancing;
         [NMS(Index = 0)]
-        /* 0x14 */ public int SemanticID;
-        [NMS(Index = 1)]
-        /* 0x18 */ public int Size;
+        /* 0x4 */ public int Type;
         [NMS(Index = 2)]
-        /* 0x1C */ public int Type;
+        /* 0x8 */ public byte Normalise;
+        [NMS(Index = 4)]
+        /* 0x9 */ public byte Offset;
+        [NMS(Index = 1)]
+        /* 0xA */ public byte SemanticID;
+        [NMS(Index = 3)]
+        /* 0xB */ public byte Size;
     }
 }

--- a/libMBIN/Source/NMS/Toolkit/TkVertexLayout.cs
+++ b/libMBIN/Source/NMS/Toolkit/TkVertexLayout.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace libMBIN.NMS.Toolkit
 {
-    [NMS(GUID = 0x41692BF0F10B2A3, NameHash = 0x33314386)]
+    [NMS(GUID = 0x8EA91FEDF878654F, NameHash = 0x33314386)]
     public class TkVertexLayout : NMSTemplate
     {
         [NMS(Index = 3)]

--- a/libMBIN/Source/Template/NMSTemplate.cs
+++ b/libMBIN/Source/Template/NMSTemplate.cs
@@ -1045,6 +1045,9 @@ namespace libMBIN
             // write the list header into the template
             if ( list.Count > 0 ) {
                 writer.Write( listPosition - listHeaderPosition );
+            } else if ( list.Count == 0 && writingHashMap) {
+                // For some reason an empty HashMap still has a size of 50...
+                writer.Write( 0x50 );
             } else {
                 writer.Write( (long) 0 ); // lists with 0 entries have offset set to 0
             }

--- a/libMBIN/Source/Template/NMSTemplate.cs
+++ b/libMBIN/Source/Template/NMSTemplate.cs
@@ -30,7 +30,7 @@ namespace libMBIN
 {
     public class NMSTemplate
     {
-        internal static readonly string[] FakeTypes = { "Colour", "Vector2f", "Vector3f", "Vector4f" };
+        internal static readonly string[] FakeTypes = { "Colour", "Vector2f", "Vector3f", "Vector4f", "Colour32" };
         internal static readonly Dictionary<string, Type> NMSTemplateMap = Assembly.GetExecutingAssembly()
                 .GetTypes()
                 .Where(t => t.BaseType == typeof(NMSTemplate))
@@ -448,6 +448,14 @@ namespace libMBIN
                         }
                     }
                     return null;
+                case "Colour32":
+                    uint col = reader.ReadUInt32();
+                    byte A = (byte)((col >> 24) & 0xFF);
+                    byte B = (byte)((col >> 16) & 0xFF);
+                    byte G = (byte)((col >> 8) & 0xFF);
+                    byte R = (byte)(col & 0xFF);
+                    Colour32 colour = new Colour32(R, G, B, A);
+                    return colour;
                 case "HashMap`1":
                     reader.Align(8);
                     Type subType = field.GetGenericArguments()[0];
@@ -743,6 +751,11 @@ namespace libMBIN
                     } else {
                         writer.Write( (UInt64) fieldData );
                     }
+                    break;
+                case "Colour32":
+                    Colour32 colour = (Colour32)fieldData;
+                    uint col = ((uint)(colour.A * 255f) << 24) + ((uint)(colour.B * 255f) << 16) + ((uint)(colour.G * 255f) << 8) + (uint)(colour.R * 255f);
+                    writer.Write(col);
                     break;
                 case "List`1":
                     writer.Align( 8, field?.Name ?? fieldType.Name, paddingByte );
@@ -1304,14 +1317,15 @@ namespace libMBIN
 
                         Array array = (Array) value;
                         string[] names = GetEnumNames( field.Name, array.Length, settings );
-
                         i = 0;
                         foreach ( var template in array ) {
-                            MXmlBase data = SerializeMXmlValue( arrayType, field, settings, template, false );
+                            MXmlProperty data = (MXmlProperty)SerializeMXmlValue( arrayType, field, settings, template, false );
                             // Only change the name if we have an associated enum.
                             string overwriteName = names[i++];
                             if (overwriteName != null && overwriteName != "") {
                                 data.Name = overwriteName;
+                            } else {
+                                data.Index = i.ToString();
                             }
 
                             arrayProperty.Elements.Add( data );

--- a/libMBIN/Source/Template/NMSTemplate.cs
+++ b/libMBIN/Source/Template/NMSTemplate.cs
@@ -126,6 +126,18 @@ namespace libMBIN
             return null; // Template type doesn't exist
         }
 
+        public static string TypeHasID(Type templateType) {
+            IEnumerable<string> fieldNames = templateType.GetFields().Select(
+                field => field.Name
+            ).Where(
+                fieldName => fieldName.ToLower() == "id"
+            );
+            if (fieldNames.Count() == 1) {
+                return fieldNames.First();
+            }
+            return null;
+        }
+
         public static bool ValueSerializable(Type fieldType) {
             if (typeof(INMSString).IsAssignableFrom(fieldType)) {
                 // If the data is a string, we read as a property since it won't have the type.
@@ -1251,14 +1263,35 @@ namespace libMBIN
                                 MXmlProperty data = new MXmlProperty {
                                     Name = fieldName,
                                     Value = ((INMSString)template).StringValue(),
+                                    Index = i.ToString()
                                 };
                                 listProperty.Elements.Add( data );
+                                i++;
                             }
                         } else {
+                            Dictionary<string, uint> IdCounter = new Dictionary<string, uint>{};
                             foreach ( var template in templates ) {
-                                MXmlBase data = SerializeMXmlValue( listType, field, settings, template, false );
+                                MXmlProperty data = (MXmlProperty)SerializeMXmlValue( listType, field, settings, template, false );
                                 data.Name = fieldName;
+                                string typeIdField = TypeHasID(listType);
+                                if (typeIdField != null) {
+                                    MXmlProperty IdData = (MXmlProperty)data.Elements.Where(
+                                        element => element.Name == typeIdField
+                                    ).First();
+                                    if (IdData != null) {
+                                        data.ID = IdData.Value;
+                                        if (!IdCounter.ContainsKey(IdData.Value)) {
+                                            IdCounter.Add(IdData.Value, 1);
+                                        } else {
+                                            data.Index = IdCounter[IdData.Value].ToString();
+                                            IdCounter[IdData.Value] = IdCounter[IdData.Value] + 1;
+                                        }
+                                    }
+                                } else {
+                                    data.Index = i.ToString();
+                                }
                                 listProperty.Elements.Add( data );
+                                i++;
                             }
                         }
                     }
@@ -1321,7 +1354,7 @@ namespace libMBIN
                         foreach ( var template in array ) {
                             MXmlProperty data = (MXmlProperty)SerializeMXmlValue( arrayType, field, settings, template, false );
                             // Only change the name if we have an associated enum.
-                            string overwriteName = names[i++];
+                            string overwriteName = names[i];
                             if (overwriteName != null && overwriteName != "") {
                                 data.Name = overwriteName;
                             } else {
@@ -1329,6 +1362,7 @@ namespace libMBIN
                             }
 
                             arrayProperty.Elements.Add( data );
+                            i++;
                         }
 
                         return arrayProperty;

--- a/libMBIN/Source/Version.cs
+++ b/libMBIN/Source/Version.cs
@@ -25,7 +25,7 @@
         //      the Prerelease version should be reset to 1
         // When the Release version is incremented:
         //      the Prerelease version should be reset to 0
-        internal const string VERSION_STRING = "5.57.0.1";
+        internal const string VERSION_STRING = "5.58.0.1";
 
         /// <summary>Shorthand for AssemblyVersion.Major</summary>
         public static int Major      => AssemblyVersion.Major;

--- a/libMBIN/libMBIN-Shared.projitems
+++ b/libMBIN/libMBIN-Shared.projitems
@@ -28,6 +28,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Source\MBIN\MBINFile.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Source\MBIN\MBINHeader.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Source\NMS\BaseTypes\Colour.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Source\NMS\BaseTypes\Colour32.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Source\NMS\BaseTypes\OptionalVariableSizeString.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Source\NMS\BaseTypes\HashMap.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Source\NMS\BaseTypes\halfVector3.cs" />


### PR DESCRIPTION
New `Colour32` field type. It's like the normal colour except it's packed into just 32 bits - 1 byte per channel.
I have added just the `_index` attribute to non-enum arrays. I know that lists need them in some cases, and there is also the `_id` attribute, but I'll get to that soon..