### PR TITLE
Fix linux tests running on CI

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -25,6 +25,12 @@ jobs:
         dotnet: [{framework: 'net6.0', version: '6.0.0'}, {framework: 'net7.0', version: '7.0.0'}]
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v5
+        with:
+          # Install both sdk versions.
+          dotnet-version: |
+            6.0.100
+            7.0.100
       - name: Build ${{ matrix.os.name }}-dotnet ${{ matrix.dotnet }} binaries
         run: |
           sed -i '\|<TargetFrameworks>net6.0;net7.0</TargetFrameworks>|a\    <RuntimeFrameworkVersion>${{ matrix.dotnet.version }}</RuntimeFrameworkVersion>' ./MBINCompiler/MBINCompiler.csproj

--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ MBINCompiler has a number of arguments that can be called from the command line 
 
 There are also a number of other options that can be passed to the executable in most modes. To see all the details call `MBINCompiler.exe help` to see the help details.
 
+### Running on linux
+
+MBINCompiler provides pre-built binaries for linux. These do not require mono to be run but will require the dotnet framework to be installed on your system.
+
+To run the binary simply call it directly (eg. `MBINCompiler ./path/to/file.MBIN`) and this will convert the provided file.
+See above for any extra command line arguments.
+
 ## SUBMITTING BUG REPORTS
 
 If you run into errors, in most cases the errors are because:
@@ -112,7 +119,7 @@ For anyone helping to develop MBINCompiler, if you are contributing new structs 
 
 ### Requirements
 
-To run the tests you will need python installed and on the path. It is recommended you get a recent version (3.7 or above).
+To run the tests you will need python installed and on the path. It is recommended you get a recent version (3.9 or above).
 The required dependencies are `pytest` and `requests`. These can be installed by entering `python -m pip install -U pytest requests` in your favorite command line program.
 Before running the tests, you need to have built a `Release` version of MBINCompiler locally.
 

--- a/conftest.py
+++ b/conftest.py
@@ -93,13 +93,7 @@ def convert_files():
     if not op.exists(mbincompiler_path):
         pytest.fail(f"MBINCompiler can't be found at the following path: {mbincompiler_path}", False)
 
-    if platform == 'linux-x64':
-        # need to run with mono on linux
-        # Build path also includes platform on the CI
-        cmd = ['sudo', 'mono', mbincompiler_path, '-q', '-y']
-    else:
-        cmd = [mbincompiler_path, '-q', '-y']
-    cmd.append('--force')
+    cmd = [mbincompiler_path, '-q', '-y', '--force']
 
     datapath = os.environ.get('datapath', DATA_PATH)
 


### PR DESCRIPTION
closes #621 

Linux tests now run as expected on the CI.

Documentation in readme expanded to have a section on running on a linux platform