### PR TITLE
Update dotnet version from 7 to 8

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -7,11 +7,6 @@ on:
       - '*.md'
     branches-ignore:
       - 'gh-pages'
-  pull_request:
-    paths-ignore:
-      - '*.md'
-    branches-ignore:
-      - 'gh-pages'
   create:
 
 jobs:
@@ -22,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [{name: 'Ubuntu', runtime: 'linux-x64'}, {name: 'Windows', runtime: 'win-x64'}]
-        dotnet: [{framework: 'net6.0', version: '6.0.0'}, {framework: 'net7.0', version: '7.0.0'}]
+        dotnet: [{framework: 'net6.0', version: '6.0.0'}, {framework: 'net8.0', version: '8.0.0'}]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v5
@@ -30,11 +25,11 @@ jobs:
           # Install both sdk versions.
           dotnet-version: |
             6.0.100
-            7.0.100
+            8.0.100
       - name: Build ${{ matrix.os.name }}-dotnet ${{ matrix.dotnet }} binaries
         run: |
-          sed -i '\|<TargetFrameworks>net6.0;net7.0</TargetFrameworks>|a\    <RuntimeFrameworkVersion>${{ matrix.dotnet.version }}</RuntimeFrameworkVersion>' ./MBINCompiler/MBINCompiler.csproj
-          sed -i '\|<TargetFrameworks>net6.0;net7.0</TargetFrameworks>|a\    <RuntimeFrameworkVersion>${{ matrix.dotnet.version }}</RuntimeFrameworkVersion>' ./libMBIN-DLL/libMBIN-DLL.csproj
+          sed -i '\|<TargetFrameworks>net6.0;net8.0</TargetFrameworks>|a\    <RuntimeFrameworkVersion>${{ matrix.dotnet.version }}</RuntimeFrameworkVersion>' ./MBINCompiler/MBINCompiler.csproj
+          sed -i '\|<TargetFrameworks>net6.0;net8.0</TargetFrameworks>|a\    <RuntimeFrameworkVersion>${{ matrix.dotnet.version }}</RuntimeFrameworkVersion>' ./libMBIN-DLL/libMBIN-DLL.csproj
           dotnet publish libMBIN-DLL --no-self-contained -c Release -f ${{ matrix.dotnet.framework }} -r ${{ matrix.os.runtime }} /nowarn:cs0618 /nowarn:cs0169 /nowarn:cs0414
           dotnet publish MBINCompiler --no-self-contained -c Release -f ${{ matrix.dotnet.framework }} -r ${{ matrix.os.runtime }} /nowarn:cs0618 /nowarn:cs0169 /nowarn:cs0414
       - name: Move the exe so the tests can find it easier
@@ -86,9 +81,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build SaveFileMapping binary
-        run: dotnet publish SaveFileMapping -c Release -f net6.0 -r win-x64 -o Build/Release/net6/ /nowarn:cs0618 /nowarn:cs0169 /nowarn:cs0414
+        run: dotnet publish SaveFileMapping -c Release -f net8.0 -r win-x64 -o Build/Release/net8/ /nowarn:cs0618 /nowarn:cs0169 /nowarn:cs0414
       - name: Generate save data mapping
-        run : Build/Release/net6/SaveFileMapping.exe
+        run : Build/Release/net8/SaveFileMapping.exe
         shell: bash
       - name: Upload report
         uses: actions/upload-artifact@v4
@@ -106,14 +101,14 @@ jobs:
         uses: actions/download-artifact@v4
       - name: Rename files for release
         run: |
-          mv MBINCompiler-Windows-net6.0/MBINCompiler.exe MBINCompiler.exe
-          mv MBINCompiler-Windows-net6.0/libMBIN.dll libMBIN.dll
-          mv MBINCompiler-Windows-net7.0/MBINCompiler.exe MBINCompiler-dotnet7.exe
-          mv MBINCompiler-Windows-net7.0/libMBIN.dll libMBIN-dotnet7.dll
-          mv MBINCompiler-Ubuntu-net6.0/MBINCompiler.exe MBINCompiler-linux
-          mv MBINCompiler-Ubuntu-net6.0/libMBIN.dll libMBIN-linux.dll
-          mv MBINCompiler-Ubuntu-net7.0/MBINCompiler.exe MBINCompiler-linux-dotnet7
-          mv MBINCompiler-Ubuntu-net7.0/libMBIN.dll libMBIN-linux-dotnet7.dll
+          mv MBINCompiler-Windows-net6.0/MBINCompiler.exe MBINCompiler-dotnet6.exe
+          mv MBINCompiler-Windows-net6.0/libMBIN.dll libMBIN-dotnet6.dll
+          mv MBINCompiler-Windows-net8.0/MBINCompiler.exe MBINCompiler.exe
+          mv MBINCompiler-Windows-net8.0/libMBIN.dll libMBIN.dll
+          mv MBINCompiler-Ubuntu-net6.0/MBINCompiler.exe MBINCompiler-linux-dotnet6
+          mv MBINCompiler-Ubuntu-net6.0/libMBIN.dll libMBIN-linux-dotnet6.so
+          mv MBINCompiler-Ubuntu-net8.0/MBINCompiler.exe MBINCompiler-linux
+          mv MBINCompiler-Ubuntu-net8.0/libMBIN.dll libMBIN-linux.so
           mv savedata-mapping/mapping.json mapping.json
           mv MBINCompiler-report/report.json report.json
       - name: Get MBINCompiler tag version
@@ -131,12 +126,12 @@ jobs:
           files: |
             MBINCompiler.exe
             libMBIN.dll
-            MBINCompiler-dotnet7.exe
-            libMBIN-dotnet7.dll
+            MBINCompiler-dotnet6.exe
+            libMBIN-dotnet6.dll
             MBINCompiler-linux
-            libMBIN-linux.dll
-            MBINCompiler-linux-dotnet7
-            libMBIN-linux-dotnet7.dll
+            libMBIN-linux.so
+            MBINCompiler-linux-dotnet6
+            libMBIN-linux-dotnet6.so
             report.json
             mapping.json
         env:

--- a/MBINCompiler/MBINCompiler.csproj
+++ b/MBINCompiler/MBINCompiler.csproj
@@ -8,7 +8,7 @@
   </ItemGroup>
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>

--- a/MBINCompilerDocs/MBINCompilerDocs.csproj
+++ b/MBINCompilerDocs/MBINCompilerDocs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ _**For Developers:** You can download a precompiled DLL or get the libMBIN sourc
 
 [DOWNLOAD LATEST RELEASE](../../releases)  
 
-**PLEASE NOTE:** MBINCompiler requires .NET 6 to run. If you do not have this you can download is [here](https://dotnet.microsoft.com/download/dotnet/6.0/runtime)
+**PLEASE NOTE:** MBINCompiler requires .NET 8 to run. If you do not have this you can download is [here](https://dotnet.microsoft.com/download/dotnet/8.0/runtime)
 Select an appropriate download under the the "Run desktop apps" set of downloads
 
 **ALSO NOTE:** As of the Worlds part 2 update, MBINCompiler will no longer generate or handle EXML files, and will instead handle MXML files. This is to (finally) get MBINCompiler producing files in the same format as NMS expects. For modding puposes the MXML are not the actual files you need to place in a mod directory. To do this, you can rename the MXML file to EXML.
@@ -107,10 +107,10 @@ While this library targets multiple frameworks, building MBINCompiler and libMBI
 The full command to build all the libraries under the .NET  framework looks like:
 
 ```sh
-dotnet publish -c Release -f net6.0-windows -r win-x64 -o Build/Release/net6/ /nowarn:cs0618 /nowarn:cs0169 /nowarn:cs0414
+dotnet publish -c Release -f net8.0 -r win-x64 /nowarn:cs0618 /nowarn:cs0169 /nowarn:cs0414
 ```
 
-For convenience we have included two batch scripts which build either the entire project for the .NET 6 framework (`build-net6.bat`) or the .NET 7 framework (`build-net7.bat`)
+For convenience we have included two batch scripts which build either the entire project for the .NET 6 framework (`build-net6.bat`) or the .NET 8 framework (`build-net8.bat`)
 
 ## Installing python dependencies
 
@@ -125,12 +125,12 @@ For anyone helping to develop MBINCompiler, if you are contributing new structs 
 ### Requirements
 
 Before running the tests, you need to have built a `Release` version of MBINCompiler locally.
-You can do this by running `dotnet publish --no-self-contained -c Release -f net6.0 -r win-x64 /nowarn:cs0618 /nowarn:cs0169 /nowarn:cs0414` (change dotnet and framework version as required).
+You can do this by running `dotnet publish --no-self-contained -c Release -f net8.0 -r win-x64 /nowarn:cs0618 /nowarn:cs0169 /nowarn:cs0414` (change dotnet and framework version as required).
 See section above about building for more details.
 
 ### Running the tests
 
-Open a command line window in the root MBINCompiler directory and enter `uv run python -m pytest`.
+Open a command line window in the root MBINCompiler directory and enter `uv run pytest`.
 This will pull the latest test data into the directory `./tests/data`.
 
 #### Command line arguments:

--- a/SaveFileMapping/SaveFileMapping.csproj
+++ b/SaveFileMapping/SaveFileMapping.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>

--- a/build-net7.bat
+++ b/build-net7.bat
@@ -1,2 +1,0 @@
-dotnet publish --no-self-contained -c Release -f net7.0 -r win-x64 /nowarn:cs0618 /nowarn:cs0169 /nowarn:cs0414
-pause

--- a/build-net7.sh
+++ b/build-net7.sh
@@ -1,1 +1,0 @@
-dotnet publish --no-self-contained -c Release -f net7.0 -r linux-x64 /nowarn:cs0618 /nowarn:cs0169 /nowarn:cs0414

--- a/build-net8.bat
+++ b/build-net8.bat
@@ -1,0 +1,2 @@
+dotnet publish --no-self-contained -c Release -f net8.0 -r win-x64 /nowarn:cs0618 /nowarn:cs0169 /nowarn:cs0414
+pause

--- a/build-net8.sh
+++ b/build-net8.sh
@@ -1,0 +1,1 @@
+dotnet publish --no-self-contained -c Release -f net8.0 -r linux-x64 /nowarn:cs0618 /nowarn:cs0169 /nowarn:cs0414

--- a/conftest.py
+++ b/conftest.py
@@ -10,7 +10,7 @@ from tests.utils import download_data, format_err_results, generate_report
 
 TEST_ROOT_PATH = op.join(op.dirname(__file__), 'tests')
 DATA_PATH = op.join(TEST_ROOT_PATH, 'data')
-BASE_PATH = op.join("Build", "Release", "net6.0", "win-x64", "publish")
+BASE_PATH = op.join("Build", "Release", "net8.0", "win-x64", "publish")
 FAILED_FNAME = '_failed.txt'
 REPORT_FNAME = op.join(op.dirname(__file__), 'results.txt')
 JSON_REPORT_FNAME = op.join(op.dirname(__file__), 'report.json')

--- a/libMBIN-DLL/libMBIN-DLL.csproj
+++ b/libMBIN-DLL/libMBIN-DLL.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>libMBIN</RootNamespace>
     <AssemblyName>libMBIN</AssemblyName>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
     <Configurations>Release;Debug;Release-XML</Configurations>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>


### PR DESCRIPTION
This changes the default MBINCompiler .NET version from 6 to 8, and the secondary version from 7 to 6