### PR TITLE
fix issue with converting a folder on linux

### DIFF
--- a/MBINCompiler/Source/CommandLineOptions.cs
+++ b/MBINCompiler/Source/CommandLineOptions.cs
@@ -142,7 +142,7 @@ namespace MBINCompiler
                                         "The * and ? wildcard characters can be used.\n" +
                                         "Multiple glob patterns are separated by a semicolon.\n" +
                                         "The default is --include=\"*.MBIN;*.MBIN.PC;*.MXML\" (all).\n" +
-                                        "The --include filter is applied before --exclude." },
+                                        "Any pattern in the --include filter will not be applied if it matches --exclude also." },
 
             new Option { longName = "exclude", param = "<Glob Pattern>[;<Glob Pattern>...]",
                             description = "\nFilter all files to exclude any that match the " +
@@ -150,7 +150,7 @@ namespace MBINCompiler
                                         "The * and ? wildcard characters can be used.\n" +
                                         "Multiple glob patterns are separated by a semicolon.\n" +
                                         "The default is --exclude=\"\" (nothing).\n" +
-                                        "The --exclude filter is applied after --include." },
+                                        "The --exclude filter overrides any value in --include." },
 
             new Option { shortName = 'V', longName = "format-version", param = "[0|1|2]", isHidden = true,
                             description = "\nOutput using the specified MBIN format version.\n" +

--- a/MBINCompiler/Source/Commands/ConvertMode.cs
+++ b/MBINCompiler/Source/Commands/ConvertMode.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
 using System.Collections.Generic;
 
 using libMBIN;
@@ -7,6 +9,23 @@ using libMBIN;
 namespace MBINCompiler.Commands {
 
     using static CommandLineOptions;
+
+    public static class StringExtensions {
+        /// <summary>
+        /// Compares the string against a given pattern.
+        /// Code credit: https://stackoverflow.com/a/4146349
+        /// </summary>
+        /// <param name="str">The string.</param>
+        /// <param name="pattern">The pattern to match, where "*" means any sequence of characters, and "?" means any single character.</param>
+        /// <returns><c>true</c> if the string matches the given pattern; otherwise <c>false</c>.</returns>
+        public static bool Like(this string str, string pattern)
+        {
+            return new Regex(
+                "^" + Regex.Escape(pattern).Replace(@"\*", ".*").Replace(@"\?", ".") + "$",
+                RegexOptions.IgnoreCase | RegexOptions.Singleline
+            ).IsMatch(str);
+        }
+    }
 
     internal class ConvertCommand : Command<ConvertCommand> {
 
@@ -60,12 +79,8 @@ namespace MBINCompiler.Commands {
 
             var defaultExclude = @"";
 
-            //#if DEBUG
-            //defaultExclude = "";
-            //#endif
-
-            IncludeFilters = new List<string>((optIncludes?.value ?? defaultInclude).Split(';'));
-            ExcludeFilters = new List<string>((optExcludes?.value ?? defaultExclude).Split(';'));
+            IncludeFilters = new List<string>((optIncludes?.value.ToUpper() ?? defaultInclude).Split(';'));
+            ExcludeFilters = new List<string>((optExcludes?.value.ToUpper() ?? defaultExclude).Split(';'));
 
             // if not auto-detecting then OutputFormat can be excluded
             if ( !autoFormat ) ExcludeFilters.Add( $"*.{OutputFormat}" );
@@ -150,28 +165,20 @@ namespace MBINCompiler.Commands {
         private static List<string> GetFilteredFiles( string path ) {
             var files = new List<string>();
 
-            var includeFiles = new List<string>();
-            var excludeFiles = new List<string>();
-            foreach ( var filter in IncludeFilters ) {
-                includeFiles.AddRange( GetDirectoryFiles( path, filter ) );
-            }
-            foreach ( var filter in ExcludeFilters ) {
-                excludeFiles.AddRange( GetDirectoryFiles( path, filter ) );
-            }
-
-            // add the filtered files to fileList
-            foreach ( var file in includeFiles ) {
-                if ( !excludeFiles.Contains( file ) ) files.Add( file );
+            var allFiles = Directory.EnumerateFiles(path, "", SearchOption.AllDirectories);
+            foreach (string fname in allFiles) {
+                string upperFname = fname.ToUpper();
+                if (ExcludeFilters.Count > 0) {
+                    if (ExcludeFilters.Any(ext => upperFname.Like(ext))) {
+                        continue;
+                    }
+                }
+                if (IncludeFilters.Any(ext => upperFname.Like(ext))) {
+                    files.Add(fname);
+                }
             }
 
             return files;
-        }
-
-        private static string[] GetDirectoryFiles( string path, string filter ) {
-            try {
-                return Directory.GetFiles( path, filter, SearchOption.AllDirectories );
-            } catch ( DirectoryNotFoundException ) { }
-            return new string[] { };
         }
 
         private static string DetectFormat( string file, ref bool foundMBIN, ref bool foundMXML ) {


### PR DESCRIPTION
On linux since paths are case-sensitive, the code to automatically determine the files in a folder recursively fails.
I have fixed this by iterating over the folder and then applying custom logic to get the files.

This however brought around a change because the original functions to filter the files did not work in a case-sensitive way, so I changed the code to simply loop over all the files once and then pattern match them. Despite now using regex, this should still be the same if not faster than before since we now only need to loop over all the file sin the directory once.