### PR TITLE
Disable DEBUG defines by default

### DIFF
--- a/libMBIN/Source/Template/NMSTemplate.cs
+++ b/libMBIN/Source/Template/NMSTemplate.cs
@@ -2,16 +2,16 @@
 // They will always be disabled/ignored in Release builds.
 
 // Uncomment to enable debug logging of the template de/serialization.
-#define DEBUG_TEMPLATE
+// #define DEBUG_TEMPLATE
 
 // Uncomment to enable debug logging of XML comments
 // #define DEBUG_COMMENTS
 
 // Uncomment to enable debug logging of MBIN field names
-#define DEBUG_FIELD_NAMES
+// #define DEBUG_FIELD_NAMES
 
 // Uncomment to enable debug logging of XML property names
-#define DEBUG_PROPERTY_NAMES
+// #define DEBUG_PROPERTY_NAMES
 
 
 using System;


### PR DESCRIPTION
Currently working on a project (which will be open source when it is ready), and I have a submodule of MBINCompiler in my project specifically referencing the source files for libMBIN, to form my own in-project libMBIN. I did this to avoid DLL loading headaches; effectively "statically linking" libMBIN instead of dynamically.

This works wonderfully, except it's painfully slow due to the debug logs and I can't seem to be able to remove them without direct source modifications, or some MSBuild shenanigans I'm frankly terrified by.

For now I just excluded the specific file:

```diff
        <Compile Include="..\..\3rdparty\MBINCompiler\libMBIN\Source\**\*.cs" LinkBase="DoNotModify-3rdparty"/>
+       <!-- Has unremovable debug defines, so we copy this file into our source manually with those removed. -->
+       <Compile Remove="..\..\3rdparty\MBINCompiler\libMBIN\Source\Template\NMSTemplate.cs"/>
```

and included the file unmodified in my own libMBIN project directory, with the defines removed entirely. This fixes the issue.

Alternatively this PR fixes the issue, for me in the future and anyone who uses this source code without expecting those defines to be there, such as myself.

Thanks for the work on this project!